### PR TITLE
[simple-app] Run the env variables through the tpl parser

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "latest"
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -47,7 +47,7 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | podSecurityContext | object | `{}` |  |
 | ports | list | `[{"containerPort":80,"name":"http","protocol":"TCP"},{"containerPort":443,"name":"https","protocol":"TCP"}]` | A list of Port objects that are exposed by the service. These ports are applied to the main container, or the proxySidecar container (if enabled). The port list is also used to generate Network Policies that allow ingress into the pods. |
 | proxySidecar.enabled | bool | `false` | (Boolean) Enables injecting a pre-defined reverse proxy sidecar container into the Pod containers list. |
-| proxySidecar.env | list | `[]` | (List) Environment variables passed into the proxy container |
+| proxySidecar.env | list | `[]` |  |
 | proxySidecar.image.pullPolicy | string | `"Always"` | (String) Always, Never or IfNotPresent |
 | proxySidecar.image.repository | string | `"nginx"` | (String) The Docker image name and repository for the sidecar |
 | proxySidecar.image.tag | string | `"latest"` | (String) The Docker tag for the sidecar |

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -20,7 +20,7 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| env | list | `[]` |  |
+| env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | (String) Always, Never or IfNotPresent |
 | image.repository | string | `"nginx"` | (String) The Docker image name and repository for your application |
@@ -47,7 +47,7 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | podSecurityContext | object | `{}` |  |
 | ports | list | `[{"containerPort":80,"name":"http","protocol":"TCP"},{"containerPort":443,"name":"https","protocol":"TCP"}]` | A list of Port objects that are exposed by the service. These ports are applied to the main container, or the proxySidecar container (if enabled). The port list is also used to generate Network Policies that allow ingress into the pods. |
 | proxySidecar.enabled | bool | `false` | (Boolean) Enables injecting a pre-defined reverse proxy sidecar container into the Pod containers list. |
-| proxySidecar.env | list | `[]` |  |
+| proxySidecar.env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
 | proxySidecar.image.pullPolicy | string | `"Always"` | (String) Always, Never or IfNotPresent |
 | proxySidecar.image.repository | string | `"nginx"` | (String) The Docker image name and repository for the sidecar |
 | proxySidecar.image.tag | string | `"latest"` | (String) The Docker tag for the sidecar |

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ $global := . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,8 +33,17 @@ spec:
         - name: {{ .Values.proxySidecar.name }}
           image: "{{ .Values.proxySidecar.image.repository }}:{{ .Values.proxySidecar.image.tag }}"
           imagePullPolicy: {{ .Values.proxySidecar.image.pullPolicy }}
+          {{- with .Values.proxySidecar.env }}
           env:
-            {{- toYaml .Values.proxySidecar.env | nindent 12 }}
+            {{- range $env := index . }}
+            - name: {{ tpl $env.name $global }}
+              {{- if $env.value }}
+              value: {{ tpl $env.value $global }}
+              {{- else if $env.valueFrom }}
+              valueFrom: {{ tpl (toYaml $env.valueFrom) $global | nindent 16 }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
           ports:
             {{- toYaml .Values.ports | nindent 12 }}
           livenessProbe:
@@ -48,8 +58,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
           env:
-            {{- toYaml .Values.env | nindent 12 }}
+            {{- range $env := index . }}
+            - name: {{ tpl $env.name $global }}
+              {{- if $env.value }}
+              value: {{ tpl $env.value $global }}
+              {{- else if $env.valueFrom }}
+              valueFrom: {{ tpl (toYaml $env.valueFrom) $global | nindent 16 }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.proxySidecar.enabled }}

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -34,7 +34,7 @@ proxySidecar:
     # -- (String) Always, Never or IfNotPresent
     pullPolicy: Always
 
-  # --- Environment Variables for the primary container. These are all run
+  # -- Environment Variables for the primary container. These are all run
   # through the tpl function (the key name and value), so you can dynamically
   # name resources as you need.
   env: []
@@ -84,7 +84,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# --- Environment Variables for the primary container. These are all run
+# -- Environment Variables for the primary container. These are all run
 # through the tpl function (the key name and value), so you can dynamically
 # name resources as you need.
 env: []

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -34,7 +34,9 @@ proxySidecar:
     # -- (String) Always, Never or IfNotPresent
     pullPolicy: Always
 
-  # -- (List) Environment variables passed into the proxy container
+  # --- Environment Variables for the primary container. These are all run
+  # through the tpl function (the key name and value), so you can dynamically
+  # name resources as you need.
   env: []
 
   # -- A PodSpec "Resources" object for the proxy container
@@ -82,11 +84,20 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# --- Environment Variables for the primary container
+# --- Environment Variables for the primary container. These are all run
+# through the tpl function (the key name and value), so you can dynamically
+# name resources as you need.
 env: []
   # Example
   # - name: VAR
   #   value: MyString
+  #
+  # - name: MY-DYNAMIC-VAR-{{ .Release.Name }}
+  #   value:
+  #     secretKeyRef:
+  #       name: {{ .Release.Name }}-secret
+  #       key: foo
+  #
 
 podAnnotations: {}
 


### PR DESCRIPTION
**What I wanted?**

While passing in a list of standard-kubernetes-formatted `env` objects is what
we want the template to look like, I wanted the ability to use helm template
parsing in the Names and Values. This way you can dynamically refer to Secrets
and ConfigMaps from the main values.yaml.

**What does this do?**

Running the Env Name/Value pairs through the `tpl` function allows us to handle
this pretty gracefully without changing the interface at all.

**Example**

If I set up my `values.yaml` like this:

```yaml
env:
  - name: VAR-{{ .Release.Name }}
    value: MyValue-{{ .Release.Name }}
  - name: VARFROM
    valueFrom:
      secretKeyRef:
        name: '{{ .Release.Name }}-secret'
        key: mykey
```

The final diff in the Deployment is:

```diff
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /Users/diranged/git/nextdoor/k8s-charts/charts/simple-app

--- orig	2021-03-18 15:00:52.000000000 -0700
+++ new	2021-03-18 15:33:09.000000000 -0700
@@ -8,7 +8,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.1.1
+    helm.sh/chart: simple-app-0.2.0
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/instance: simple-app
     app.kubernetes.io/version: "latest"
@@ -20,7 +20,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.1.1
+    helm.sh/chart: simple-app-0.2.0
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/instance: simple-app
     app.kubernetes.io/version: "latest"
@@ -46,7 +46,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.1.1
+    helm.sh/chart: simple-app-0.2.0
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/instance: simple-app
     app.kubernetes.io/version: "latest"
@@ -73,7 +73,13 @@
           image: "nginx:latest"
           imagePullPolicy: IfNotPresent
           env:
-            []
+            - name: VAR-simple-app
+              value: MyValue-simple-app
+            - name: VARFROM
+              valueFrom:
+                secretKeyRef:
+                  key: mykey
+                  name: 'simple-app-secret'
           resources:
             {}
           ports:
@@ -98,7 +104,7 @@
 metadata:
   name: "simple-app-test-connection"
   labels:
-    helm.sh/chart: simple-app-0.1.1
+    helm.sh/chart: simple-app-0.2.0
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/instance: simple-app
     app.kubernetes.io/version: "latest"
```
