### PR TITLE
[simple-app] Make sure to always quote the values in the env key

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "latest"
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             {{- range $env := index . }}
             - name: {{ tpl $env.name $global }}
               {{- if $env.value }}
-              value: {{ tpl $env.value $global }}
+              value: {{ tpl $env.value $global | quote }}
               {{- else if $env.valueFrom }}
               valueFrom: {{ tpl (toYaml $env.valueFrom) $global | nindent 16 }}
               {{- end }}
@@ -63,7 +63,7 @@ spec:
             {{- range $env := index . }}
             - name: {{ tpl $env.name $global }}
               {{- if $env.value }}
-              value: {{ tpl $env.value $global }}
+              value: {{ tpl $env.value $global | quote }}
               {{- else if $env.valueFrom }}
               valueFrom: {{ tpl (toYaml $env.valueFrom) $global | nindent 16 }}
               {{- end }}


### PR DESCRIPTION
This fixes a bug introduced in 0.2.0 where the `tpl` function could interpret a
stringified int as a number and return it as a number rather than its original
from of a string. All environment `value` keys must be a string, so force that
with the quote function.
