### PR TITLE
[simple-app] Make the chart "connection" test configurable

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -16,17 +16,17 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `100` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| autoscaling.enabled | bool | `false` | Controls whether or not an HorizontalPodAutoscaler resource is created. |
+| autoscaling.maxReplicas | int | `100` | Sets the maximum number of Pods to run |
+| autoscaling.minReplicas | int | `1` | Sets the minimum number of Pods to run |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Configures the HPA to target a particular CPU utilization percentage |
 | env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | (String) Always, Never or IfNotPresent |
 | image.repository | string | `"nginx"` | (String) The Docker image name and repository for your application |
 | image.tag | String | `nil` | Overrides the image tag whose default is the chart appVersion. |
-| imagePullSecrets | list | `[]` | If |
-| ingress.annotations."alb.ingress.kubernetes.io/actions.ssl-redirect" | string | `"{\"Type\": \"redirect\", \"RedirectConfig\": { \"Protocol\": \"HTTPS\", \"Port\": \"443\", \"StatusCode\": \"HTTP_301\" }}"` |  |
+| imagePullSecrets | list | `[]` | Supply a reference to a Secret that can be used by Kubernetes to pull down the Docker image. This is only used in local development, in combination with our `kube_create_ecr_creds` function from dotfiles. |
+| ingress.annotations."alb.ingress.kubernetes.io/actions.ssl-redirect" | string | `"{\n  \"Type\": \"redirect\",\n  \"RedirectConfig\": {\n    \"Protocol\": \"HTTPS\",\n    \"Port\": \"443\",\n    \"StatusCode\": \"HTTP_301\"\n  }\n}"` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].path | string | `""` |  |
@@ -63,6 +63,10 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| tests.connection.args | list | `["{{ include \"simple-app.fullname\" . }}:{{ .Values.service.port }}"]` | A list of arguments passed into the command. These are run through the tpl function. |
+| tests.connection.command | list | `["curl"]` | The command used to trigger the test. |
+| tests.connection.image.repository | string | `nil` | Sets the image-name that will be used in the "connection" integration test. If this is left empty, then the .image.repository value will be used instead (and the .image.tag will also be used). |
+| tests.connection.image.tag | string | `nil` | Sets the tag that will be used in the "connection" integration test. If this is left empty, the default is "latest" |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/simple-app/templates/tests/test-connection.yaml
+++ b/charts/simple-app/templates/tests/test-connection.yaml
@@ -7,9 +7,19 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "simple-app.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+  containers:
+    - name: test
+      image: >-
+        {{- if .Values.tests.connection.image.repository }}
+        {{ .Values.tests.connection.image.repository }}:{{ .Values.tests.connection.image.tag | default "latest" }}
+        {{- else }}
+        {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        {{- end }}
+      command:
+        {{ toYaml .Values.tests.connection.command }}
+      args:
+        {{- $global := . }}
+        {{- range $arg := index .Values.tests.connection.args }}
+        - {{ tpl $arg $global }}
+        {{- end }}

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -21,7 +21,8 @@ image:
 # Secrets that can be bound into the sidecar container for a more complete
 # solution.
 proxySidecar:
-  # -- (Boolean) Enables injecting a pre-defined reverse proxy sidecar container into the Pod containers list.
+  # -- (Boolean) Enables injecting a pre-defined reverse proxy sidecar
+  # container into the Pod containers list.
   enabled: false
 
   # -- (String) The name of the proxy sidecar container
@@ -73,7 +74,9 @@ ports:
     containerPort: 443
     protocol: TCP
 
-# -- If
+# -- Supply a reference to a Secret that can be used by Kubernetes to pull down
+# the Docker image. This is only used in local development, in combination with
+# our `kube_create_ecr_creds` function from dotfiles.
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -125,7 +128,15 @@ service:
 ingress:
   enabled: false
   annotations:
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301" }}'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: >-
+      {
+        "Type": "redirect",
+        "RedirectConfig": {
+          "Protocol": "HTTPS",
+          "Port": "443",
+          "StatusCode": "HTTP_301"
+        }
+      }
   hosts:
     - host: chart-example.local
       path: ''
@@ -174,11 +185,18 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Enabling Horizontal Pod Autoscaling (HPA) ensures that your application
+# scales up to meet demand.
 autoscaling:
+  # -- Controls whether or not an HorizontalPodAutoscaler resource is created.
   enabled: false
+  # -- Sets the minimum number of Pods to run
   minReplicas: 1
+  # -- Sets the maximum number of Pods to run
   maxReplicas: 100
+  # -- Configures the HPA to target a particular CPU utilization percentage
   targetCPUUtilizationPercentage: 80
+  # -- If supplied, configures the HPA to target a particular Memory utilization percentage
   # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
@@ -186,3 +204,23 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+tests:
+  connection:
+    # -- The command used to trigger the test.
+    command: ['curl']
+    # -- A list of arguments passed into the command. These are run through the tpl function.
+    args:
+      - '{{ include "simple-app.fullname" . }}:{{ .Values.service.port }}'
+    # By default, we actually use the source-image for the main application as
+    # the image for testing, This allows the image to contain its own "client"
+    # (curl, in this example) for testing the application. Alternatively, you
+    # can configure your own testing image.
+    image:
+      # -- Sets the image-name that will be used in the "connection"
+      # integration test. If this is left empty, then the .image.repository
+      # value will be used instead (and the .image.tag will also be used).
+      repository:
+      # -- Sets the tag that will be used in the "connection" integration test.
+      # If this is left empty, the default is "latest"
+      tag:

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,5 +4,3 @@ chart-dirs:
   - charts
 helm-extra-args: --timeout 600s
 target-branch: main
-excluded-charts:
-  - iam-manager


### PR DESCRIPTION
**What did I want?**

The existing test-case was hard coded to a plain-text HTTP get with `wget` as the client. That doesn't make it easy to support alternative use-cases (gRPC for example).

**What did I do?**

Reconfigured the test suite so that all of the details are in the `values.yaml` file under the `tests.connection` key. This not only makes the test more configurable, but it also lets us start adding in other tests down the road that might be different and gives us independent control to configure them.