### PR TITLE
[istio-endpoints] Bugfix on the Sidecar object

### DIFF
--- a/charts/istio-endpoints/Chart.yaml
+++ b/charts/istio-endpoints/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-endpoints
 description: Per-Namespace Istio Configuration Chart
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/istio-endpoints/README.md
+++ b/charts/istio-endpoints/README.md
@@ -2,7 +2,7 @@
 
 Per-Namespace Istio Configuration Chart
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [elasticache]: https://aws.amazon.com/elasticache/
 [serviceentry]: https://istio.io/latest/docs/reference/config/networking/service-entry/
@@ -53,7 +53,7 @@ spec:
 + dependencies:
 +   - name: istio-endpoints
 +     repository: https://k8s-charts.nextdoor.com
-+     version: 0.1.1
++     version: 0.1.2
   maintainers:
     - name: diranged
       email: matt@nextdoor.com

--- a/charts/istio-endpoints/templates/sidecar.yaml
+++ b/charts/istio-endpoints/templates/sidecar.yaml
@@ -41,7 +41,7 @@ spec:
       the Service Entry.
       */}} 
       hosts:
-        - {{ $name }}.{{ include "istio-endpoints.domainName" $global }}
+        - ./{{ $name }}.{{ include "istio-endpoints.domainName" $global }}
 
       {{- /*
       Setting captureMode to NONE is how you tell Istio that it's not doing any


### PR DESCRIPTION
```
admission webhook "validation.istio.io" denied the request: configuration is invalid: host must be of form namespace/dnsName
```

The namespace needs to be included (or `.`).