### PR TITLE
[simple-app] Properly support when the image.tag is set to a sha256:value

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.9.4
+version: 0.9.5
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.9.5](https://img.shields.io/badge/Version-0.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -34,10 +34,11 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "simple-app.labels" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
 helm.sh/chart: {{ include "simple-app.chart" . }}
-{{ include "simple-app.selectorLabels" . }}
-app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.image.tag | trunc 63 | replace ":" "_" | quote }}
+app.kubernetes.io/version: {{ $tag | replace ":" "_" | trunc 63 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "simple-app.selectorLabels" . }}
 {{- end }}
 
 {{/*
@@ -56,5 +57,26 @@ Create the name of the service account to use
 {{- default (include "simple-app.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Proxy and Main App Image Names
+*/}}
+{{- define "simple-app.imageFqdn" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- if hasPrefix "sha256:" $tag }}
+{{- .Values.image.repository }}@{{ $tag }}
+{{- else }}
+{{- .Values.image.repository }}:{{ $tag }}
+{{- end }}
+{{- end }}
+
+{{- define "simple-app.proxyImageFqdn" -}}
+{{- $tag := .Values.proxySidecar.image.tag }}
+{{- if hasPrefix "sha256:" $tag }}
+{{- .Values.proxySidecar.image.repository }}@{{ $tag }}
+{{- else }}
+{{- .Values.proxySidecar.image.repository }}:{{ $tag }}
 {{- end }}
 {{- end }}

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         {{- if .Values.proxySidecar.enabled }}
         - name: {{ .Values.proxySidecar.name }}
-          image: "{{ .Values.proxySidecar.image.repository }}:{{ .Values.proxySidecar.image.tag }}"
+          image: {{ include "simple-app.proxyImageFqdn" . }}
           imagePullPolicy: {{ .Values.proxySidecar.image.pullPolicy }}
           {{- with .Values.proxySidecar.envFrom }}
           envFrom:
@@ -84,7 +84,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: {{ include "simple-app.imageFqdn" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.envFrom }}
           envFrom:

--- a/charts/simple-app/templates/tests/test-connection.yaml
+++ b/charts/simple-app/templates/tests/test-connection.yaml
@@ -14,7 +14,7 @@ spec:
         {{- if .Values.tests.connection.image.repository }}
         {{ .Values.tests.connection.image.repository }}:{{ default "latest" .Values.tests.connection.image.tag }}
         {{- else }}
-        {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        {{ include "simple-app.imageFqdn" . }}
         {{- end }}
       command:
         {{- toYaml .Values.tests.connection.command | nindent 8 }}

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -7,4 +7,3 @@ ingress:
   # -- Disable the SSL-Redirect explicitly because it only applies to
   # ALB-ingress controllers.
   sslRedirect: false
-


### PR DESCRIPTION
When you pass in a `sha256:...` image hash to a Pod spec, you need to use a `@` rather than a `:` separator.