### PR TITLE
[simple-app] Add support for Prometheus ServiceMonitors and Istio Metrics Merging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
       - name: Install CRDs
         run: |
           kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml \
+                        -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml \
                         -f https://raw.githubusercontent.com/istio/istio/1.10.0/manifests/charts/base/crds/crd-all.gen.yaml
         if: steps.list-changed.outputs.changed == 'true'
 

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.9.5
+version: 0.10.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.9.5](https://img.shields.io/badge/Version-0.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -60,6 +60,18 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If enabled, ServiceMonitor resources for Prometheus Operator are created |
+| serviceMonitor.interval | string | `nil` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
+| serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
+| serviceMonitor.path | string | `"/metrics"` | Path to scrape metrics from |
+| serviceMonitor.portName | string | `"metrics"` | Name of the port to scrape for metrics |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
+| serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | tests.connection.args | list | `["{{ include \"simple-app.fullname\" . }}"]` | A list of arguments passed into the command. These are run through the tpl function. |
 | tests.connection.command | list | `["curl","--retry-connrefused","--retry","5"]` | The command used to trigger the test. |
 | tests.connection.image.repository | string | `nil` | Sets the image-name that will be used in the "connection" integration test. If this is left empty, then the .image.repository value will be used instead (and the .image.tag will also be used). |

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -11,6 +11,48 @@ This chart provides a default deployment for a simple application that operates
 in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
+## Monitoring
+
+This chart makes the assumption that you _do_ have a Prometheus-style
+monitoring endpoint configured. See the `Values.monitor.portName`,
+`Values.monitor.portNumber` and `Values.monitor.path` settings for informing
+the chart of where your metrics are exposed.
+
+If you are operating in an Istio Service Mesh, see the
+[Istio](#istio-networking-support) section below for details on how monitoring
+works. Otherwise, see the `Values.serviceMonitor` settings to configure a
+Prometheus ServiceMonitor resource to monitor your application.
+
+## Istio Networking Support
+
+### Monitoring through the Sidecar Proxy
+
+[metrics_merging]: https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging
+
+When running your Pod within an Istio Mesh, access to the `metrics` endpoint
+for your Pod can be obscured by the mesh itself which sits in front of the
+metrics port and may require that all clients are coming in through the
+mesh natively. The simplest way around this is to use [Istio Metrics
+Merging][metrics_merging] - where the Sidecar container is responsible for
+scraping your application's `metrics` port, merging the metrics with its own,
+and then Prometheus is configured to pull all of the metrics from the Sidecar.
+
+There are several advantages to this model.
+
+* It's much simpler - developers do not need to create `ServiceMonitor` or
+  `PodMonitor` resources because the Prometheus system is already configured to
+  discover all `istio-proxy` sidecar containers and collect their metrics.
+
+* Your application is not exposed outside of the service mesh to anybody - the
+  `istio-proxy` sidecar handles that for you.
+
+* There are fewer individual configurations for Prometheus, letting it's
+  configuration be simpler and lighter weight. It runs fewer "scrape" jobs,
+  improving its overall performance.
+
+This feature is turned on by default if you set `Values.istio.enabled=true` and
+`Values.monitor.enabled=true`.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -35,7 +77,12 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | ingress.port | string | `nil` | If set, this will override the `service.portName` parameter, and the `Service` object will point specifically to this port number on the backing Pods. |
 | ingress.portName | string | `"http"` | This is the port "name" that the `Service` will point to on the backing Pods. This value must match one of the values of `.name` in the `Values.ports` configuration. |
 | ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
+| istio.enabled | bool | `false` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `ServiceMonitor` object. |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
+| monitor.enabled | bool | `true` | (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
+| monitor.path | string | `"/metrics"` | (`string`) Path to scrape metrics from within your Pod. |
+| monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
+| monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | (`Map`) List of Annotations to be added to the PodSpec |
@@ -60,14 +107,10 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
-| serviceMonitor.enabled | bool | `false` | If enabled, ServiceMonitor resources for Prometheus Operator are created |
+| serviceMonitor.annotations | object | `{}` | (`map`) ServiceMonitor annotations. |
 | serviceMonitor.interval | string | `nil` | ServiceMonitor scrape interval |
-| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
-| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
-| serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
-| serviceMonitor.path | string | `"/metrics"` | Path to scrape metrics from |
-| serviceMonitor.portName | string | `"metrics"` | Name of the port to scrape for metrics |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels. |
+| serviceMonitor.namespace | `string` | `nil` | Alternative namespace for ServiceMonitor resources. |
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -10,6 +10,48 @@ This chart provides a default deployment for a simple application that operates
 in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
+## Monitoring
+
+This chart makes the assumption that you _do_ have a Prometheus-style
+monitoring endpoint configured. See the `Values.monitor.portName`,
+`Values.monitor.portNumber` and `Values.monitor.path` settings for informing
+the chart of where your metrics are exposed.
+
+If you are operating in an Istio Service Mesh, see the
+[Istio](#istio-networking-support) section below for details on how monitoring
+works. Otherwise, see the `Values.serviceMonitor` settings to configure a
+Prometheus ServiceMonitor resource to monitor your application.
+
+## Istio Networking Support
+
+### Monitoring through the Sidecar Proxy
+
+[metrics_merging]: https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging
+
+When running your Pod within an Istio Mesh, access to the `metrics` endpoint
+for your Pod can be obscured by the mesh itself which sits in front of the
+metrics port and may require that all clients are coming in through the
+mesh natively. The simplest way around this is to use [Istio Metrics
+Merging][metrics_merging] - where the Sidecar container is responsible for
+scraping your application's `metrics` port, merging the metrics with its own,
+and then Prometheus is configured to pull all of the metrics from the Sidecar.
+
+There are several advantages to this model.
+
+* It's much simpler - developers do not need to create `ServiceMonitor` or
+  `PodMonitor` resources because the Prometheus system is already configured to
+  discover all `istio-proxy` sidecar containers and collect their metrics.
+
+* Your application is not exposed outside of the service mesh to anybody - the
+  `istio-proxy` sidecar handles that for you.
+
+* There are fewer individual configurations for Prometheus, letting it's
+  configuration be simpler and lighter weight. It runs fewer "scrape" jobs,
+  improving its overall performance.
+
+This feature is turned on by default if you set `Values.istio.enabled=true` and
+`Values.monitor.enabled=true`.
+
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -13,12 +13,33 @@ spec:
       {{- include "simple-app.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- range $annotation, $value := index . }}
         {{ $annotation }}: {{ tpl $value $ | quote }}
         {{- end }}
-      {{- end }}
+        {{- end }}
+
+        {{- if .Values.istio.enabled }}
+        {{- /*
+        Ensures that the application does not start up until after the Istio
+        proxy container is ready to pass traffic. This prevents race
+        conditions.
+        */}}
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+
+        {{- /*
+        If monitoring is enabled, and we're in an Istio environment, then we
+        default to using the Isto metrics-merging feature where the sidecar
+        scrapes the metrics.
+        */}}
+        {{- if .Values.monitor.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.monitor.portName | quote }}
+        prometheus.io/path: {{ .Values.monitor.path }}
+        {{- end }}
+
+        {{- end }}
       labels:
         {{- include "simple-app.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
@@ -119,6 +140,11 @@ spec:
           {{- else }}
           ports:
             {{- toYaml .Values.ports | nindent 12 }}
+            {{- if .Values.monitor.enabled }}
+            - name: {{ .Values.monitor.portName }}
+              containerPort: {{ .Values.monitor.portNumber }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ $global := . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,13 +16,13 @@ spec:
       {{- with .Values.podAnnotations }}
       annotations:
         {{- range $annotation, $value := index . }}
-        {{ $annotation }}: {{ tpl $value $global | quote }}
+        {{ $annotation }}: {{ tpl $value $ | quote }}
         {{- end }}
       {{- end }}
       labels:
         {{- include "simple-app.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{- tpl (toYaml .) $global | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -36,7 +35,7 @@ spec:
       {{- if or .Values.volumes .Values.volumesString }}
       volumes:
         {{- with .Values.volumes }}{{ toYaml . | nindent 8 }}{{ end }}
-        {{- with .Values.volumesString }}{{ tpl . $global | nindent 8 }}{{ end }}
+        {{- with .Values.volumesString }}{{ tpl . $ | nindent 8 }}{{ end }}
       {{- end }}
       containers:
         {{- if .Values.proxySidecar.enabled }}
@@ -48,11 +47,11 @@ spec:
             {{- range $env := index .}}
             {{- with $env.configMapRef }}
             - configMapRef:
-                name: {{ tpl (required ".name key must be set in configMapRef" .name) $global }}
+                name: {{ tpl (required ".name key must be set in configMapRef" .name) $ }}
             {{- end }}
             {{- with $env.secretRef }}
             - secretRef:
-                name: {{ tpl (required ".name key must be set on secretRef" .name) $global }}
+                name: {{ tpl (required ".name key must be set on secretRef" .name) $ }}
             {{- end }}
             {{- end }}
             {{- toYaml . | nindent 12 }}
@@ -60,11 +59,11 @@ spec:
           {{- with .Values.proxySidecar.env }}
           env:
             {{- range $env := index . }}
-            - name: {{ tpl $env.name $global }}
+            - name: {{ tpl $env.name $ }}
               {{- if $env.value }}
-              value: {{ tpl $env.value $global | quote }}
+              value: {{ tpl $env.value $ | quote }}
               {{- else if $env.valueFrom }}
-              valueFrom: {{ tpl (toYaml $env.valueFrom) $global | nindent 16 }}
+              valueFrom: {{ tpl (toYaml $env.valueFrom) $ | nindent 16 }}
               {{- end }}
             {{- end }}
           {{- end }}
@@ -91,22 +90,22 @@ spec:
             {{- range $env := index .}}
             {{- with $env.configMapRef }}
             - configMapRef:
-                name: {{ tpl (required ".name key must be set in configMapRef" .name) $global }}
+                name: {{ tpl (required ".name key must be set in configMapRef" .name) $ }}
             {{- end }}
             {{- with $env.secretRef }}
             - secretRef:
-                name: {{ tpl (required ".name key must be set on secretRef" .name) $global }}
+                name: {{ tpl (required ".name key must be set on secretRef" .name) $ }}
             {{- end }}
             {{- end }}
           {{- end }}
           {{- with .Values.env }}
           env:
             {{- range $env := index . }}
-            - name: {{ tpl $env.name $global }}
+            - name: {{ tpl $env.name $ }}
               {{- if $env.value }}
-              value: {{ tpl $env.value $global | quote }}
+              value: {{ tpl $env.value $ | quote }}
               {{- else if $env.valueFrom }}
-              valueFrom: {{ tpl (toYaml $env.valueFrom) $global | nindent 16 }}
+              valueFrom: {{ tpl (toYaml $env.valueFrom) $ | nindent 16 }}
               {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/simple-app/templates/servicemonitor.yaml
+++ b/charts/simple-app/templates/servicemonitor.yaml
@@ -1,0 +1,46 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "simple-app.fullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "simple-app.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "simple-app.selectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: {{ .portName }}
+      path: {{ .path }}
+      scheme: {{ .scheme }}
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/simple-app/templates/servicemonitor.yaml
+++ b/charts/simple-app/templates/servicemonitor.yaml
@@ -1,46 +1,40 @@
-{{- with .Values.serviceMonitor }}
-{{- if .enabled }}
+{{- if and .Values.monitor.enabled (not .Values.istio.enabled) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "simple-app.fullname" $ }}
-  {{- with .namespace }}
+  name: {{ include "simple-app.fullname" . }}
+  {{- with .Values.serviceMonitor.namespace }}
   namespace: {{ . }}
   {{- end }}
-  {{- with .annotations }}
+  {{- with .Values.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "simple-app.labels" $ | nindent 4 }}
-    {{- with .labels }}
+    {{- include "simple-app.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .namespaceSelector }}
-  namespaceSelector:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
   selector:
     matchLabels:
-      {{- include "simple-app.selectorLabels" $ | nindent 6 }}
+      {{- include "simple-app.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: {{ .portName }}
-      path: {{ .path }}
-      scheme: {{ .scheme }}
-      {{- with .interval }}
+    - port: {{ .Values.monitor.portName }}
+      path: {{ .Values.monitor.path }}
+      scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .scrapeTimeout }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
-      {{- with .relabelings }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .tlsConfig }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -7,7 +7,3 @@ ingress:
   # -- Disable the SSL-Redirect explicitly because it only applies to
   # ALB-ingress controllers.
   sslRedirect: false
-
-serviceMonitor:
-  enabled: true
-

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -7,3 +7,7 @@ ingress:
   # -- Disable the SSL-Redirect explicitly because it only applies to
   # ALB-ingress controllers.
   sslRedirect: false
+
+serviceMonitor:
+  enabled: true
+

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -276,33 +276,61 @@ tolerations: []
 
 affinity: {}
 
-# ServiceMonitor configuration
-serviceMonitor:
-  # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
-  enabled: false
-  # -- Alternative namespace for ServiceMonitor resources
-  namespace: null
-  # -- Namespace selector for ServiceMonitor resources
-  namespaceSelector: {}
-  # -- ServiceMonitor annotations
-  annotations: {}
-  # -- Name of the port to scrape for metrics
+# Monitoring configuration for metric scraping against the Prometheus-style
+# metrics endpoint.
+monitor:
+  # -- (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator
+  # are created or if `Values.istio.enabled` is `True`, then the appropriate
+  # Pod Annotations will be added for the istio-proxy sidecar container to
+  # scrape the metrics.
+  enabled: true
+
+  # -- (`string`) Name of the port to scrape for metrics - this is the name of
+  # the port that will be exposed in your `PodSpec` for scraping purposes.
   portName: metrics
-  # -- Path to scrape metrics from
+
+  # -- (`int`) Number of the port to scrape for metrics - this port will be
+  # exposed in your `PodSpec` to ensure it can be scraped.
+  portNumber: 9090
+
+  # -- (`string`) Path to scrape metrics from within your Pod.
   path: /metrics
-  # -- Additional ServiceMonitor labels
+
+serviceMonitor:
+  # -- (`string`) Alternative namespace for ServiceMonitor resources.
+  namespace: null
+
+  # -- (`map`) ServiceMonitor annotations.
+  annotations: {}
+
+  # -- Additional ServiceMonitor labels.
   labels: {}
+
   # -- ServiceMonitor scrape interval
   interval: null
+
   # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
+
   # -- ServiceMonitor relabel configs to apply to samples before scraping
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
+
   # -- ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
+
   # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
   tlsConfig: null
+
+# Configuration that lets the chart know that it's operating inside of an Istio
+# service mesh or not. If it is, certain defaults are applied to various Pod
+# and other resource configurations.
+istio:
+  # -- (`bool`) Whether or not the service should be part of an Istio Service
+  # Mesh. If this is turned on and `Values.monitor.enabled=true`, then the
+  # Istio Sidecar containers will be configured to pull and merge the metrics
+  # from the application, rather than creating a new `ServiceMonitor` object.
+  enabled: false
 
 tests:
   connection:

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -276,6 +276,34 @@ tolerations: []
 
 affinity: {}
 
+# ServiceMonitor configuration
+serviceMonitor:
+  # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
+  enabled: false
+  # -- Alternative namespace for ServiceMonitor resources
+  namespace: null
+  # -- Namespace selector for ServiceMonitor resources
+  namespaceSelector: {}
+  # -- ServiceMonitor annotations
+  annotations: {}
+  # -- Name of the port to scrape for metrics
+  portName: metrics
+  # -- Path to scrape metrics from
+  path: /metrics
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- ServiceMonitor scrape interval
+  interval: null
+  # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
+  scrapeTimeout: null
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
+  # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  relabelings: []
+  # -- ServiceMonitor will use http by default, but you can pick https as well
+  scheme: http
+  # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
+  tlsConfig: null
+
 tests:
   connection:
     # -- The command used to trigger the test.


### PR DESCRIPTION
This PR adds support for configuring metrics-collection in two ways - through a Prometheus `ServiceMonitor` resource, or through the Istio Sidecar using ["Metrics Merging"](https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging).

## Scenario 1: `istio.enabled=false`, `monitor.enabled=true`

```diff
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /Users/diranged/git/nextdoor/k8s-charts/charts/simple-app

--- orig	2021-06-21 16:40:29.000000000 -0700
+++ new	2021-06-22 07:00:39.000000000 -0700
@@ -8,7 +8,7 @@
 metadata:
   name: simple-app-ingress-access
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -32,7 +32,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -44,7 +44,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -70,7 +70,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -83,8 +83,9 @@
       app.kubernetes.io/instance: simple-app
   template:
     metadata:
+      annotations:
       labels:
-        helm.sh/chart: simple-app-0.9.5
+        helm.sh/chart: simple-app-0.10.0
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: simple-app
@@ -108,6 +109,9 @@
             - containerPort: 443
               name: https
               protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /
@@ -123,7 +127,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -327,6 +331,27 @@
       name: redis
       protocol: REDIS
 ---
+# Source: simple-app/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: simple-app
+  labels:
+    helm.sh/chart: simple-app-0.10.0
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: simple-app
+    app.kubernetes.io/instance: simple-app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: simple-app
+      app.kubernetes.io/instance: simple-app
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+---
 # Source: simple-app/charts/istio-endpoints/templates/sidecar.yaml
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
@@ -361,7 +386,7 @@
 metadata:
   name: "simple-app-test-connection"
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
```

## Scenario 2: `istio.enabled=true`, `monitor.enabled=true`
```diff
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /Users/diranged/git/nextdoor/k8s-charts/charts/simple-app

--- orig	2021-06-21 16:40:29.000000000 -0700
+++ new	2021-06-22 07:00:20.000000000 -0700
@@ -8,7 +8,7 @@
 metadata:
   name: simple-app-ingress-access
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -32,7 +32,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -44,7 +44,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -70,7 +70,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -83,8 +83,13 @@
       app.kubernetes.io/instance: simple-app
   template:
     metadata:
+      annotations:
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "metrics"
+        prometheus.io/path: /metrics
       labels:
-        helm.sh/chart: simple-app-0.9.5
+        helm.sh/chart: simple-app-0.10.0
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: simple-app
@@ -108,6 +113,9 @@
             - containerPort: 443
               name: https
               protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /
@@ -123,7 +131,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -361,7 +369,7 @@
 metadata:
   name: "simple-app-test-connection"
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
```

## Scenario 3: `istio.enabled=true`, `monitor.enabled=false`
```diff
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /Users/diranged/git/nextdoor/k8s-charts/charts/simple-app

--- orig	2021-06-21 16:40:29.000000000 -0700
+++ new	2021-06-22 07:02:07.000000000 -0700
@@ -8,7 +8,7 @@
 metadata:
   name: simple-app-ingress-access
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -32,7 +32,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -44,7 +44,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -70,7 +70,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -83,8 +83,10 @@
       app.kubernetes.io/instance: simple-app
   template:
     metadata:
+      annotations:
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
       labels:
-        helm.sh/chart: simple-app-0.9.5
+        helm.sh/chart: simple-app-0.10.0
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: simple-app
@@ -123,7 +125,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
@@ -361,7 +363,7 @@
 metadata:
   name: "simple-app-test-connection"
   labels:
-    helm.sh/chart: simple-app-0.9.5
+    helm.sh/chart: simple-app-0.10.0
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
```