### PR TITLE
[local-kafka] Add external listener

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: ct --config ct.yaml lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Install CRDs

--- a/charts/local-kafka/Chart.yaml
+++ b/charts/local-kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: local-kafka
 description: Local Development spinup of Strimzi-managed Kafka
 type: application
-version: 0.0.1
+version: 0.1.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/local-kafka/README.md
+++ b/charts/local-kafka/README.md
@@ -41,6 +41,7 @@ project's development namespace.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clusterName | string | `"default"` | Set the name of the Kafka Cluster that is created for local development |
+| listeners | list | `[{"configuration":{"brokers":[{"advertisedHost":"127.0.0.1","broker":0,"nodePort":32000}]},"name":"external","port":9094,"tls":false,"type":"nodeport"}]` | Additional configurable listeners for connecting to brokers. |
 | namespaceOverride | string | `nil` | Optionally force the namespace that the resources in this stack are launched in. Without this, the default namespace that the Helm chart is being put into is used. It is recommended to keep this empty. |
 | strimzi-kafka-operator.enabled | bool | `true` | Set to `false` to intentionally disable installation of the Operator. This is useful if you are running this stack in a local dev environment where you might have multiple Kafka environments, and are already running the Strimzi operator. |
 | strimzi-kafka-operator.livenessProbe.initialDelaySeconds | int | `300` |  |

--- a/charts/local-kafka/README.md
+++ b/charts/local-kafka/README.md
@@ -2,7 +2,7 @@
 
 Local Development spinup of Strimzi-managed Kafka
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [strimzi_op]: https://github.com/strimzi/strimzi-kafka-operator
 

--- a/charts/local-kafka/templates/kafka.yaml
+++ b/charts/local-kafka/templates/kafka.yaml
@@ -17,6 +17,8 @@ spec:
       failureThreshold: 30  # 30 * 10s
     authorization:
       type: simple
+      superUsers:
+        - ANONYMOUS
     jvmOptions:
       '-Xmx': '384M'
       '-Xms': '128M'
@@ -31,6 +33,15 @@ spec:
         port: 9093
         type: internal
         tls: false
+      - name: external
+        port: 9094
+        type: nodeport
+        tls: false
+        configuration:
+          brokers:
+            - broker: 0
+              nodePort: 32000
+              advertisedHost: 127.0.0.1
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1

--- a/charts/local-kafka/templates/kafka.yaml
+++ b/charts/local-kafka/templates/kafka.yaml
@@ -33,15 +33,7 @@ spec:
         port: 9093
         type: internal
         tls: false
-      - name: external
-        port: 9094
-        type: nodeport
-        tls: false
-        configuration:
-          brokers:
-            - broker: 0
-              nodePort: 32000
-              advertisedHost: 127.0.0.1
+      {{- toYaml .Values.listeners | nindent 6 }}
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1

--- a/charts/local-kafka/values.yaml
+++ b/charts/local-kafka/values.yaml
@@ -9,6 +9,18 @@ clusterName: default
 # put into is used. It is recommended to keep this empty.
 namespaceOverride:
 
+# -- Additional configurable listeners for connecting to brokers.
+listeners:
+  - name: external
+    port: 9094
+    type: nodeport
+    tls: false
+    configuration:
+      brokers:
+        - broker: 0
+          nodePort: 32000
+          advertisedHost: 127.0.0.1
+
 # These settings directly get passed into the Strimzi Kafka Operator helm chart.
 strimzi-kafka-operator:
   # -- Set to `false` to intentionally disable installation of the Operator.


### PR DESCRIPTION
I wanted to be able to access `local-kafka` from services running directly on my local machine, and was able to get something working by adding an external listener (https://strimzi.io/blog/2019/04/23/accessing-kafka-part-2) that advertises `127.0.0.1:32000` for the single broker, and then exposing that address in the kind config. 

Output from `make template`:
```
# Source: local-kafka/templates/kafka.yaml
# https://github.com/strimzi/strimzi-kafka-operator/blob/master/examples/kafka/kafka-ephemeral.yaml
apiVersion: kafka.strimzi.io/v1beta2
kind: Kafka
metadata:
  name: default
spec:
  kafka:
    replicas: 1
    livenessProbe:
      initialDelaySeconds: 60
      failureThreshold: 30  # 30 * 10s
    readinessProbe:
      initialDelaySeconds: 60
      failureThreshold: 30  # 30 * 10s
    authorization:
      type: simple
      superUsers:
        - ANONYMOUS
    jvmOptions:
      '-Xmx': '384M'
      '-Xms': '128M'
    listeners:
      - name: tls
        port: 9092
        type: internal
        tls: true
        authentication:
          type: tls
      - name: plain
        port: 9093
        type: internal
        tls: false
      - configuration:
          brokers:
          - advertisedHost: 127.0.0.1
            broker: 0
            nodePort: 32000
        name: external
        port: 9094
        tls: false
        type: nodeport
    config:
      offsets.topic.replication.factor: 1
      transaction.state.log.replication.factor: 1
      transaction.state.log.min.isr: 1
      log.message.format.version: "2.8"
      inter.broker.protocol.version: "2.8"
    storage:
      type: jbod
      volumes:
      - id: 0
        type: persistent-claim
        size: 500Mi
        deleteClaim: false
  zookeeper:
    replicas: 1
    storage:
      type: persistent-claim
      size: 500Mi
      deleteClaim: false
  entityOperator:
    topicOperator: {}
    userOperator: {}
```