### PR TITLE
[prometheus-alerts] Bump chart version to unblock release

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -1,6 +1,6 @@
 # prometheus-alerts
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Helm Chart that provisions a series of common Prometheus Alerts
 


### PR DESCRIPTION
https://github.com/Nextdoor/k8s-charts/runs/3353281960 is detecting [changes to the runbook](https://github.com/Nextdoor/k8s-charts/commit/87f51e566fba62abc62d584ad597b7802f82fdad), and tries to re-release the chart, but `prometheus-alerts-0.1.4` already exists. 

I wonder if the `local-kafka` chart version needs to be incremented also, since https://github.com/Nextdoor/k8s-charts/releases/tag/local-kafka-0.1.0 got created? 