### PR TITLE
[prometheus-alerts] Fix the OOMKilled alert so that it sum's properly

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -1,6 +1,6 @@
 # prometheus-alerts
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Helm Chart that provisions a series of common Prometheus Alerts
 

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -18,10 +18,17 @@ spec:
         summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
         runbook_url: {{ $values.defaults.runbookUrl }}#kube-pod-container-terminated
         description: >-
-          {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} has a
-          container terminated for more than 10 minutes`}}
-      expr: kube_pod_container_status_terminated_reason{reason=~"{{ join "|" .reasons }}", namespace="{{ $targetNamespace }}"} > {{ .threshold }}
-      for: {{ .for }}
+          Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
+          has a container that has been terminated due to
+          {{`{{$labels.reason}}`}} in the last {{ .threshold }} at least
+          {{`{{$labels.threshold}}`}} times.
+      expr: |-
+        sum by (container, instance, namespace, pod, reason) (
+          sum_over_time(
+            kube_pod_container_status_terminated_reason{reason=~"{{ join "|" .reasons }}", namespace="{{ $targetNamespace }}"}[{{ .for }}]
+          )
+        ) > {{ .threshold }}
+      for: 1m  # as soon as this trips, page.
       labels:
         severity: {{ .severity }}
         {{- if $values.defaults.additionalRuleLabels }}


### PR DESCRIPTION
**What did I want?**

I discovered that we had pods being OOMed and we were not being alerted. It turns out that the original `PodContainerTerminated` alert was looking for a container that was permanently in the OOMKilled/Error/ContainerCannotRun state.. but since containers get restarted within a Pod, we need to
monitor for the _count_ of that metric, not the _current state_ of it.

Here is the example of the "view" that the original alert had on a pod that was OOMing every few mins:
![image](https://user-images.githubusercontent.com/768067/129816039-c9fce8fc-20b7-4ba4-86a2-3b2259b4543d.png)

Obviously this was not going to trip the alarm.

**What did I do?**

I replaced the query with one that sum's over time. The `for` value is now used as the "sum over this period" value, and the alarm trips as soon as it trips. Here is the graph view of this new alarm:

![image](https://user-images.githubusercontent.com/768067/129816093-75a489d3-6175-495b-88df-cedbe71c4c07.png)

While I was here, I limit the number of labels returned so that the alarm is more clear.