### PR TITLE
[prometheus-alerts] Split out the ContainerTerminated alert from an OOMKilled alert

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -1,6 +1,6 @@
 # prometheus-alerts
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
@@ -33,8 +33,7 @@ Helm Chart that provisions a series of common Prometheus Alerts
 | containerRules.KubeDaemonSetNotScheduled.severity | string | `"warning"` |  |
 | containerRules.KubeDaemonSetRolloutStuck.for | string | `"15m"` |  |
 | containerRules.KubeDaemonSetRolloutStuck.severity | string | `"warning"` |  |
-| containerRules.KubeDeploymentGenerationMismatch.for | string | `"15m"` |  |
-| containerRules.KubeDeploymentGenerationMismatch.severity | string | `"warning"` |  |
+| containerRules.KubeDeploymentGenerationMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment generation mismatch due to possible roll-back |
 | containerRules.KubeDeploymentReplicasMismatch.for | string | `"15m"` |  |
 | containerRules.KubeDeploymentReplicasMismatch.severity | string | `"warning"` |  |
 | containerRules.KubeHpaMaxedOut.for | string | `"15m"` |  |
@@ -45,22 +44,16 @@ Helm Chart that provisions a series of common Prometheus Alerts
 | containerRules.KubeJobCompletion.severity | string | `"warning"` |  |
 | containerRules.KubeJobFailed.for | string | `"15m"` |  |
 | containerRules.KubeJobFailed.severity | string | `"warning"` |  |
-| containerRules.KubePodCrashLooping.for | string | `"15m"` |  |
-| containerRules.KubePodCrashLooping.severity | string | `"warning"` |  |
-| containerRules.KubePodNotReady.for | string | `"15m"` |  |
-| containerRules.KubePodNotReady.severity | string | `"warning"` |  |
+| containerRules.KubePodCrashLooping | object | `{"for":"15m","severity":"warning"}` | Pod is crash looping |
+| containerRules.KubePodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
 | containerRules.KubeStatefulSetGenerationMismatch.for | string | `"15m"` |  |
 | containerRules.KubeStatefulSetGenerationMismatch.severity | string | `"warning"` |  |
 | containerRules.KubeStatefulSetReplicasMismatch.for | string | `"15m"` |  |
 | containerRules.KubeStatefulSetReplicasMismatch.severity | string | `"warning"` |  |
 | containerRules.KubeStatefulSetUpdateNotRolledOut.for | string | `"15m"` |  |
 | containerRules.KubeStatefulSetUpdateNotRolledOut.severity | string | `"warning"` |  |
-| containerRules.PodContainerTerminated.for | string | `"10m"` |  |
-| containerRules.PodContainerTerminated.reasons[0] | string | `"OOMKilled"` |  |
-| containerRules.PodContainerTerminated.reasons[1] | string | `"Error"` |  |
-| containerRules.PodContainerTerminated.reasons[2] | string | `"ContainerCannotRun"` |  |
-| containerRules.PodContainerTerminated.severity | string | `"warning"` |  |
-| containerRules.PodContainerTerminated.threshold | int | `0` |  |
+| containerRules.PodContainerOOMKilled | object | `{"for":"1m","over":"60m","severity":"warning","threshold":0}` | Sums up all of the OOMKilled events per pod over the $over time (60m). If that number breaches the $threshold (0) for $for (1m), then it will alert. |
+| containerRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
 | defaults.additionalRuleLabels | object | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/prometheus-alerts/runbook.md"` | The prefix URL to the runbook_urls that will be applied to each PrometheusRule |

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -19,16 +19,38 @@ spec:
         runbook_url: {{ $values.defaults.runbookUrl }}#kube-pod-container-terminated
         description: >-
           Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
-          has a container that has been terminated due to
-          {{`{{$labels.reason}}`}} in the last {{ .threshold }} at least
-          {{`{{$labels.threshold}}`}} times.
+          has a container that has been terminated ({{`{{ $value }}`}} times) due to
+          {{`{{$labels.reason}}`}} in the last {{ .for }}.
       expr: |-
         sum by (container, instance, namespace, pod, reason) (
           sum_over_time(
-            kube_pod_container_status_terminated_reason{reason=~"{{ join "|" .reasons }}", namespace="{{ $targetNamespace }}"}[{{ .for }}]
+            kube_pod_container_status_terminated_reason{reason=~"{{ join "|" .reasons }}", namespace="{{ $targetNamespace }}"}[{{ .over }}]
           )
         ) > {{ .threshold }}
-      for: 1m  # as soon as this trips, page.
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{ end -}}
+
+    {{ with .Values.containerRules.PodContainerOOMKilled -}}
+    - alert: PodContainerOOMKilled
+      annotations:
+        summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
+        runbook_url: {{ $values.defaults.runbookUrl }}#kube-pod-container-terminated
+        description: >-
+          Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
+          has a container that has been terminated ({{`{{ $value }}`}} times) due to
+          {{`{{$labels.reason}}`}} in the last {{ .for }}.
+      expr: |-
+        sum by (container, instance, namespace, pod, reason) (
+          sum_over_time(
+            kube_pod_container_status_terminated_reason{reason=~"OOMKilled", namespace="{{ $targetNamespace }}"}[{{ .over }}]
+          )
+        ) > {{ .threshold }}
+      for: {{ .for }}
       labels:
         severity: {{ .severity }}
         {{- if $values.defaults.additionalRuleLabels }}

--- a/charts/prometheus-alerts/test.yaml
+++ b/charts/prometheus-alerts/test.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: test-rules
+spec:
+  groups:
+  - name: test-prometheus-alerts.default.containerRules
+    rules:
+    - alert: PodContainerTerminated
+      annotations:
+        summary: Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status
+        runbook_url: https://github.com/Nextdoor/k8s-charts/blob/main/charts/prometheus-alerts/runbook.md#kube-pod-container-terminated
+        description: >-
+          Pod {{$labels.pod}} in namespace {{$labels.namespace}}
+          has a container that has been terminated due to
+          {{$labels.reason}} in the last 0 at least
+          {{$labels.threshold}} times.
+      expr: |-
+        sum by (container, instance, namespace, pod, reason) (
+          sum_over_time(
+            kube_pod_container_status_terminated_reason{reason=~"OOMKilled|Error|ContainerCannotRun", namespace="observability"}[30m]
+          )
+        ) > 0
+      for: 1m
+      labels:
+        severity: warning

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -80,28 +80,38 @@ containerRules:
   # -- Whether or not to enable the container rules template
   enabled: true
 
-  # Monitors Pods for Containers that are terminated for specific reasons that
-  # are unexpected - like OOM's.
+  # -- Monitors Pods for Containers that are terminated either for unexpected
+  # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
+  # for $for (1m), then it will alert.
   PodContainerTerminated:
     severity: warning
     threshold: 0
-    for: 10m
+    over: 10m
+    for: 1m
     reasons:
-      - OOMKilled
-      - Error
+      # - Error  < when a container is evicted gracefully, the "error" state is used.
       - ContainerCannotRun
+      - DeadlineExceeded
 
-  # Pod is crash looping
+  # -- Sums up all of the OOMKilled events per pod over the $over time (60m). If
+  # that number breaches the $threshold (0) for $for (1m), then it will alert.
+  PodContainerOOMKilled:
+    severity: warning
+    threshold: 0
+    over: 60m
+    for: 1m
+
+  # -- Pod is crash looping
   KubePodCrashLooping:
     severity: warning
     for: 15m
 
-  # Pod has been in a non-ready state for more than a specific threshold
+  # -- Pod has been in a non-ready state for more than a specific threshold
   KubePodNotReady:
     severity: warning
     for: 15m
 
-  # Deployment generation mismatch due to possible roll-back
+  # -- Deployment generation mismatch due to possible roll-back
   KubeDeploymentGenerationMismatch:
     severity: warning
     for: 15m


### PR DESCRIPTION
**What did I want?**

I discovered a few things..

1. The `error` reason can include a pod being evicted gracefully.
2. The templating was broken in our alert text
3. The `OOMKilled` alert should definitely be separate so that you can have different thresholds
