### PR TITLE
[simple-app] Add the app/version labels by default to all the resources

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.13.5
+version: 0.13.6
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.13.5](https://img.shields.io/badge/Version-0.13.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.13.6](https://img.shields.io/badge/Version-0.13.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -32,10 +32,25 @@ Create chart name and version as used by the chart label.
 
 {{/*
 Common labels
+
+*app.kubernetes.io/<labels>*
+https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+
+*version*
+Istio recommends a generic "version" label, but we also think its just
+a nice generic label to add on top of the standard app.kubernetes.io/version
+label.
+
+*tags.datadoghq.com/<labels>*
+https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes
 */}}
 {{- define "simple-app.labels" -}}
 {{- $_tag := default .Chart.AppVersion .Values.image.tag -}}
 {{- $tag  := $_tag | replace ":" "_" | trunc 63 | quote -}}
+{{- if not (hasKey .Values.podLabels "app") }}
+app: {{ .Release.Name }}
+{{- end }}
+version: {{ $tag }}
 helm.sh/chart: {{ include "simple-app.chart" . }}
 app.kubernetes.io/version: {{ $tag }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -45,15 +60,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 tags.datadoghq.com/env: {{ .Values.datadog.env | quote }}
 tags.datadoghq.com/service: {{ default .Release.Name .Values.datadog.service | quote }}
 tags.datadoghq.com/version: {{ $tag }}
-#
-# https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
-# (Disabled for now, here for future reference. Disabled because we can get
-# the same value through the Kubernetes downward API, which doesn't introduce
-# a potential Pod launching failure point.)
+{{- end }}
+{{- end }}
+{{/*
+https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
+(Disabled for now, here for future reference. Disabled because we can get
+the same value through the Kubernetes downward API, which doesn't introduce
+a potential Pod launching failure point.)
 # admission.datadoghq.com/enabled: "true"
-#
-{{- end }}
-{{- end }}
+*/}}
 
 {{/*
 Selector labels


### PR DESCRIPTION
**What did I want**

I want Kiali to stop complaining that our services don't have a version label, when they already had the `app.kubernetes.io/version` label. I am adding in the `app/version` labels as well.