### PR TITLE
[simple-app] Bake in the istio preStop command, and fix our empty port handling

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.13.6
+version: 0.13.7
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.13.6](https://img.shields.io/badge/Version-0.13.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.13.7](https://img.shields.io/badge/Version-0.13.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -94,6 +94,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | ingress.portName | string | `"http"` | This is the port "name" that the `Service` will point to on the backing Pods. This value must match one of the values of `.name` in the `Values.ports` configuration. |
 | ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
 | istio.enabled | bool | `false` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `ServiceMonitor` object. |
+| istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down. eg: preStopCommand: [ /bin/sleep, "30" ] |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
 | minReadySeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds |
 | monitor.enabled | bool | `true` | (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
+{{- /*
 Common labels
 
 *app.kubernetes.io/<labels>*
@@ -62,7 +62,7 @@ tags.datadoghq.com/service: {{ default .Release.Name .Values.datadog.service | q
 tags.datadoghq.com/version: {{ $tag }}
 {{- end }}
 {{- end }}
-{{/*
+{{- /*
 https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
 (Disabled for now, here for future reference. Disabled because we can get
 the same value through the Kubernetes downward API, which doesn't introduce

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -40,6 +40,55 @@ spec:
         conditions.
         */}}
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+
+        {{- /*
+        If the service has any ports exposed at all, we're going to make the
+        Istio Sidecar wait to shut down until after the application stops
+        listening on the port. This ensures that the app is able to complete
+        whatever its shutdown process is (like flushing data out of memory to a
+        downstream source) before the network connectivity to the application
+        is cut off.
+        */}}
+        {{- if .Values.ports }}
+        {{- if .Values.istio.preStopCommand }}
+        proxy.istio.io/overrides: >-
+          {
+            "containers": [
+              {
+                "name": "istio-proxy",
+                "lifecycle": {
+                  "preStop": {
+                    "exec": {
+                      "command": {{ .Values.istio.preStopCommand | toJson }}
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        {{- else if gt (len .Values.ports) 0 }}
+        proxy.istio.io/overrides: >-
+          {
+            "containers": [
+              {
+                "name": "istio-proxy",
+                "lifecycle": {
+                  "preStop": {
+                    "exec": {
+                      "command": [
+                        "/bin/sh",
+                        "-c",
+                        "while [ $(netstat -plunt | grep tcp | egrep -v 'envoy|pilot-agent' | wc -l | xargs) -ne 0 ]; do sleep 1; done"
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        {{- end }}
+        {{- end }}
+
         {{- /*
         If monitoring is enabled, and we're in an Istio environment, then we
         default to using the Isto metrics-merging feature where the sidecar
@@ -51,6 +100,7 @@ spec:
         prometheus.io/path: {{ .Values.monitor.path }}
         {{- end }}
         {{- end }}
+
 
         {{- /*
         If the datadog agent is enabled,
@@ -158,8 +208,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.ports }}
           ports:
-            {{- toYaml .Values.ports | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -249,7 +301,11 @@ spec:
           {{- if .Values.proxySidecar.enabled }}
           {{- else }}
           ports:
+            {{- if .Values.ports }}
+            {{- if gt (len .Values.ports) 0 }}
             {{- toYaml .Values.ports | nindent 12 }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.monitor.enabled }}
             - name: {{ .Values.monitor.portName }}
               containerPort: {{ .Values.monitor.portNumber }}

--- a/charts/simple-app/templates/ingress/networkpolicy.yaml
+++ b/charts/simple-app/templates/ingress/networkpolicy.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.ingress.enabled .Values.ports }}
+{{- if gt (len .Values.ports) 0 }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -16,4 +17,5 @@ spec:
       - port: {{ $port.containerPort }}
         protocol: {{ $port.protocol }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/simple-app/templates/istio/networkpolicy.yaml
+++ b/charts/simple-app/templates/istio/networkpolicy.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.virtualService.enabled }}
+{{- if and .Values.virtualService.enabled .Values.ports }}
+{{- if gt (len .Values.ports) 0 }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -21,4 +22,5 @@ spec:
           podSelector:
             matchLabels:
               app: istio-ingressgateway
+{{- end }}
 {{- end }}

--- a/charts/simple-app/templates/service.yaml
+++ b/charts/simple-app/templates/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ports }}
+{{- if gt (len .Values.ports) 0 }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,4 +17,5 @@ spec:
     {{- end }}
   selector:
     {{- include "simple-app.selectorLabels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -9,3 +9,5 @@ ingress:
   sslRedirect: false
 
 terminationGracePeriodSeconds: 30
+istio:
+  enabled: true

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -378,6 +378,17 @@ istio:
   # from the application, rather than creating a new `ServiceMonitor` object.
   enabled: false
 
+  # -- (`list <str>`) If supplied, this is the command that will be passed into
+  # the `istio-proxy` sidecar container as a pre-stop function. This is used to
+  # delay the shutdown of the istio-proxy sidecar in some way or another. Our
+  # own default behavior is applied if this value is not set - which is that
+  # the sidecar will wait until it does not see the application container
+  # listening on any TCP ports, and then it will shut down.
+  #
+  # eg:
+  # preStopCommand: [ /bin/sleep, "30" ]
+  preStopCommand: null
+
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.
 datadog:


### PR DESCRIPTION
**What did I want?**

First, I want to make it easier and automatic for our applications to delay the shutdown of the `istio-proxy` sidecar app until after our web serving services have shut down. Second, I noticed that we do not handle the situation where no listener ports (`.Values.ports`) are supplied very well - this is a reasonable thing to handle as it is how any non-web-service is likely to operate.

**What did I do?**

* _Fixed `.Values.ports` handling_: If the `.Values.ports` is supplied as an empty list, or a `nil` value, then we no longer try to create NetworkPolicies.
* _Automatic preStop command_: If Istio is enabled, and the `.Values.ports` list is greater than 0, then we default to using the automatic prestop command that scans for listening ports before shutting down.
* _Override available at `.Values.istio.preStopCommand`_: The operator can also replace the prestop command with their own explicit one if they are operating in a different mode.