### PR TITLE
[simple-app] Allow VirtualService resources to explicitly allow-list certain paths

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.13.8
+version: 0.14.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.13.8](https://img.shields.io/badge/Version-0.13.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -149,6 +149,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | virtualService.hosts | list | `["{{ include \"simple-app.fullname\" . }}"]` | A list of destination hostnames that this VirtualService will accept traffic for. Multiple names can be listed here. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService for more details. |
 | virtualService.namespace | string | `"istio-system"` | The namespace where the Istio services are operating. Do not change this. |
 | virtualService.path | string | `"/"` | The default path prefix that the `VirtualService` will match requests against to pass to the default `Service` object in this deployment. |
+| virtualService.paths | list | `[]` | (`string[]`) List of optional path prefixes that the `VirtualService` will use to match requests against and will pass to the `Service` object in this deployment. This list replaces the `path` prefix above - use one or the other, do not use both. |
 | virtualService.port | int | `80` | This is the backing Pod port _number_ to route traffic to. This must match a `containerPort` in the `Values.ports` list. |
 | virtualService.tls | string | `""` |  |
 | volumeMounts | list | `[]` | List of VolumeMounts that are applied to the application container - these must refer to volumes set in the `Values.volumes` parameter. |

--- a/charts/simple-app/templates/istio/virtualservice.yaml
+++ b/charts/simple-app/templates/istio/virtualservice.yaml
@@ -26,8 +26,15 @@ spec:
   http:
     - match:
       {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest */}}
+      {{- if .Values.virtualService.paths }}
+      {{- range $path := .Values.virtualService.paths }}
+      - uri:
+          prefix: {{ $path }}
+      {{- end }}
+      {{- else }}
       - uri:
           prefix: {{ .Values.virtualService.path }}
+      {{- end }}
       {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRouteDestination */}}
       route:
         - destination:

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -286,6 +286,12 @@ virtualService:
   # against to pass to the default `Service` object in this deployment.
   path: '/'
 
+  # -- (`string[]`) List of optional path prefixes that the `VirtualService`
+  # will use to match requests against and will pass to the `Service` object in
+  # this deployment. This list replaces the `path` prefix above - use one or
+  # the other, do not use both.
+  paths: []
+
   # -- This is the backing Pod port _number_ to route traffic to. This must
   # match a `containerPort` in the `Values.ports` list.
   port: 80


### PR DESCRIPTION
**What did I want?**

It's reasonable that some services would want to explicitly allow-list paths, rather than just passing in an entire path prefix. This allows requests to be blocked at the IngressGateway level before it ever gets to the `istio-proxy` sidecar container.

**What did I do?**

While trying to keep this simple, I wanted to allow multiple paths to be set... at a certain point, it makes more sense for a developer to just manage their own `VirtualService` object. I think though that this is a reasonable and common option.

**Diff**

Given the following config change to `values.local.yaml`:
```diff
diff --git a/charts/simple-app/values.local.yaml b/charts/simple-app/values.local.yaml
index 41f229e..e592e84 100644
--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -11,3 +11,11 @@ ingress:
 terminationGracePeriodSeconds: 30
 istio:
   enabled: true
+
+virtualService:
+  enabled: true
+  paths:
+    - /app/path1
+    - /app/path2
+    - /path3
+    - /healthz
ip-192-168-208-27:simple-app diranged$ 

```

```diff
--- orig	2021-09-20 10:21:19.000000000 -0700
+++ new	2021-09-20 10:28:42.000000000 -0700
@@ -513,7 +513,13 @@
   http:
     - match:
       - uri:
-          prefix: /
+          prefix: /app/path1
+      - uri:
+          prefix: /app/path2
+      - uri:
+          prefix: /path3
+      - uri:
+          prefix: /healthz
       route:
         - destination:
             host: simple-app
```
