### PR TITLE
[simple-app] Add in a parameter for the corsPolicy

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -144,6 +144,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` |  |
 | virtualService.annotations | object | `{}` | Any annotations you wish to add to the `VirtualService` resource. See https://istio.io/latest/docs/reference/config/annotations/ for more details. |
+| virtualService.corsPolicy | `map` | `nil` | If set, this will populate the corsPolicy setting for the VirtualService. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy for more details. |
 | virtualService.enabled | bool | `false` | (Boolean) Maps the Service to an Istio IngressGateway, exposing the service outside of the Kubernetes cluster. |
 | virtualService.gateways | list | `[]` | The name of the Istio `Gateway` resource that this `VirtualService` will register with. You can get a list of the avaialable `Gateways` by running `kubectl -n istio-system get gateways`. Not specifying a Gateway means that you are creating a VirtualService routing definition only inside of the Kubernetes cluster, which is totally reasonable if you want to do that. |
 | virtualService.hosts | list | `["{{ include \"simple-app.fullname\" . }}"]` | A list of destination hostnames that this VirtualService will accept traffic for. Multiple names can be listed here. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService for more details. |

--- a/charts/simple-app/templates/istio/virtualservice.yaml
+++ b/charts/simple-app/templates/istio/virtualservice.yaml
@@ -34,6 +34,10 @@ spec:
       {{- else }}
       - uri:
           prefix: {{ .Values.virtualService.path }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy */}}
+      {{- with .Values.virtualService.corsPolicy }}
+      corsPolicy:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRouteDestination */}}
       route:

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -264,6 +264,12 @@ virtualService:
   # details.
   annotations: {}
 
+  # -- (`map`) If set, this will populate the corsPolicy setting for the
+  # VirtualService. See
+  # https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy
+  # for more details.
+  corsPolicy: null
+
   # -- A list of destination hostnames that this VirtualService will accept
   # traffic for. Multiple names can be listed here. See
   # https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService


### PR DESCRIPTION
Example diff:

```diff
$ make template > new && diff -b -u orig new
...
--- orig	2021-09-21 14:44:12.000000000 -0700
+++ new	2021-09-21 14:44:15.000000000 -0700
@@ -514,6 +514,16 @@
     - match:
       - uri:
           prefix: /
+      corsPolicy:
+        allowCredentials: false
+        allowHeaders:
+        - X-Foo-Bar
+        allowMethods:
+        - POST
+        - GET
+        allowOrigins:
+        - exact: https://example.com
+        maxAge: 24h
       route:
         - destination:
             host: simple-app
```