### PR TITLE
[flink-job] Rebuild with new version

### DIFF
--- a/charts/flink-job/Chart.yaml
+++ b/charts/flink-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Flink job cluster on k8s
 name: flink-job
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: Zedive
     email: albert@nextdoor.com

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -2,7 +2,7 @@
 
 Flink job cluster on k8s
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 This chart deploys a flink job cluster and runs a simple word counting flink app as an example.
 This chart includes some production ready set-ups such as


### PR DESCRIPTION
No clear reason why, but the chart-releaser tool failed to release the 0.1.0 release.