### PR TITLE
[local-kafka] Upgrade the Strimzi Operator to 0.25.0

### DIFF
--- a/charts/local-kafka/Chart.yaml
+++ b/charts/local-kafka/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: local-kafka
 description: Local Development spinup of Strimzi-managed Kafka
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.23.0
+    version: 0.25.0
     repository: https://strimzi.io/charts
     condition: strimzi-kafka-operator.enabled

--- a/charts/local-kafka/README.md
+++ b/charts/local-kafka/README.md
@@ -2,7 +2,7 @@
 
 Local Development spinup of Strimzi-managed Kafka
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [strimzi_op]: https://github.com/strimzi/strimzi-kafka-operator
 
@@ -34,7 +34,7 @@ project's development namespace.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://strimzi.io/charts | strimzi-kafka-operator | 0.23.0 |
+| https://strimzi.io/charts | strimzi-kafka-operator | 0.25.0 |
 
 ## Values
 


### PR DESCRIPTION
This newer operator is built so it can operate on an ARM64 M1 mac in
emulation mode, while the older operator does not.