### PR TITLE
Revert "Use a recent version of the spotify CRD. (#72)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml \
                         -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml \
                         -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml \
-                        -f https://raw.githubusercontent.com/spotify/flink-on-k8s-operator/v0.1.15/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml \
+                        -f https://raw.githubusercontent.com/spotify/flink-on-k8s-operator/v1beta1/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml \
                         -f https://raw.githubusercontent.com/istio/istio/1.10.0/manifests/charts/base/crds/crd-all.gen.yaml
         if: steps.list-changed.outputs.changed == 'true'
 


### PR DESCRIPTION
This reverts commit 458ed5485b2910b6898a649b611d9092aaab5aec.

@sabw8217 For some reason this causes the CRD install to break. The build failure at https://github.com/Nextdoor/k8s-charts/runs/3839257790?check_suite_focus=true looks like this:

```
The CustomResourceDefinition "flinkclusters.flinkoperator.k8s.io" is invalid: metadata.annotations[api-approved.kubernetes.io]: Required value: protected groups must have approval annotation "api-approved.kubernetes.io", see https://github.com/kubernetes/enhancements/pull/1111
```

For now I am reverting this. We can try to troubleshoot this and submit a PR upstream to the Spotify team.