### PR TITLE
[flink-job] Expose job mode and JM replicas

### DIFF
--- a/charts/flink-job/Chart.yaml
+++ b/charts/flink-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Flink job cluster on k8s
 name: flink-job
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: Zedive
     email: albert@nextdoor.com

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -2,7 +2,7 @@
 
 Flink job cluster on k8s
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 This chart deploys a flink job cluster and runs a simple word counting flink app as an example.
 This chart includes some production ready set-ups such as
@@ -38,6 +38,7 @@ See metrics reporter in the flink properties for more details.
 | job.fromSavepoint | String | `nil` | Savepoint where to restore the job from. Unspecify if to restore from the latest savepoint |
 | job.initContainers | object | `{"enabled":false}` | Init containers of the Job pod. It can be used to download a remote job jar to your job pod. It is only needed if you have no other way to download your job files into the Flink job cluster. |
 | job.jarFile | string | `"./examples/streaming/WordCount.jar"` | (String) JAR file of the job |
+| job.mode | string | `"Detached"` | (String) JobMode of the job submitter, either Detached or Blocking |
 | job.parallelism | int | `1` | (`int`) Parallelism of the job |
 | job.restartPolicy | string | `"FromSavepointOnFailure"` | (String) Restart policy when the job fails, enum("Never", "FromSavepointOnFailure") |
 | job.savepointGeneration | `int` | `nil` | Update this field to jobStatus.savepointGeneration + 1 for a running job cluster to trigger a new savepoint to savepointsDir on demand. |
@@ -50,6 +51,7 @@ See metrics reporter in the flink properties for more details.
 | jobManager.ports.query | int | `6125` | (`int`) Query ports that JobManager listening on |
 | jobManager.ports.rpc | int | `6123` | (`int`) RPC port that JobManager listening on |
 | jobManager.ports.ui | int | `8081` | (`int`) UI port that JobManager listening on |
+| jobManager.replicas | int | `1` | (`int`) The number of JobManager replicas |
 | jobManager.resources | object | `{"limits":{"memory":"1400Mi"},"requests":{"cpu":"100m","memory":"1000Mi"}}` | Compute resources required by JobManager container |
 | logConfig | object | `{"log4j-console.properties":"rootLogger.level = INFO\nrootLogger.appenderRef.file.ref = LogFile\nrootLogger.appenderRef.console.ref = LogConsole\nappender.file.name = LogFile\nappender.file.type = File\nappender.file.append = false\nappender.file.fileName = ${sys:log.file}\nappender.file.layout.type = PatternLayout\nappender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n\nappender.console.name = LogConsole\nappender.console.type = CONSOLE\nappender.console.layout.type = PatternLayout\nappender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n\nlogger.akka.name = akka\nlogger.akka.level = INFO\nlogger.kafka.name= org.apache.kafka\nlogger.kafka.level = INFO\nlogger.hadoop.name = org.apache.hadoop\nlogger.hadoop.level = INFO\nlogger.zookeeper.name = org.apache.zookeeper\nlogger.zookeeper.level = INFO\nlogger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline\nlogger.netty.level = OFF\n","logback-console.xml":"<configuration>\n  <appender name=\"console\" class=\"ch.qos.logback.core.ConsoleAppender\">\n    <encoder>\n      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{60} %X{sourceThread} - %msg%n</pattern>\n    </encoder>\n  </appender>\n  <appender name=\"file\" class=\"ch.qos.logback.core.FileAppender\">\n    <file>${log.file}</file>\n    <append>false</append>\n    <encoder>\n      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{60} %X{sourceThread} - %msg%n</pattern>\n    </encoder>\n  </appender>\n  <root level=\"INFO\">\n    <appender-ref ref=\"console\"/>\n    <appender-ref ref=\"file\"/>\n  </root>\n  <logger name=\"akka\" level=\"INFO\" />\n  <logger name=\"org.apache.kafka\" level=\"INFO\" />\n  <logger name=\"org.apache.hadoop\" level=\"INFO\" />\n  <logger name=\"org.apache.zookeeper\" level=\"INFO\" />\n  <logger name=\"org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline\" level=\"ERROR\" />\n</configuration>\n"}` | The logging configuration, a string-to-string map that becomes the ConfigMap mounted at /opt/flink/conf |
 | operatorGroups | list | `["system:masters"]` | (List) A list of groups to grant the operator-role to in the namespace the chart is installed in. |

--- a/charts/flink-job/templates/flinkjobcluster.yaml
+++ b/charts/flink-job/templates/flinkjobcluster.yaml
@@ -17,6 +17,7 @@ spec:
   serviceAccountName: {{ template "flink-job-cluster.fullname" . }}
   recreateOnUpdate: {{ .Values.recreateOnUpdate }}
   jobManager:
+    replicas: {{ .Values.jobManager.replicas }}
     accessScope: {{ .Values.jobManager.accessScope }}
     ports:
       ui: {{ .Values.jobManager.ports.ui }}
@@ -112,6 +113,7 @@ spec:
       {{- toYaml .Values.taskManager.securityContext | nindent 6 }}
     memoryProcessRatio: {{ .Values.taskManager.memoryProcessRatio }}
   job:
+    mode: {{ .Values.job.mode }}
     jarFile: {{ .Values.job.jarFile }}
     className: {{ .Values.job.className }}
     args: {{ .Values.job.args }}

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -76,6 +76,8 @@ logConfig:
     </configuration>
 
 jobManager:
+  # -- (`int`) The number of JobManager replicas
+  replicas: 1
   # -- (String) Access scope of the JobManager service. enum("Cluster", "VPC", "External", "NodePort", "Headless")
   accessScope: Cluster
   ports:
@@ -145,6 +147,8 @@ taskManager:
   memoryProcessRatio: 80
 
 job:
+  # -- (String) JobMode of the job submitter, either Detached or Blocking
+  mode: Detached
   # -- (String) JAR file of the job
   jarFile: ./examples/streaming/WordCount.jar
   # -- (String) Java class name of the job


### PR DESCRIPTION
Flink operator uses mutating webhook to set default values for some fields in CRDs, https://github.com/spotify/flink-on-k8s-operator/blob/5f2c73a16f9040cb06cd9665e6a59b77d2280709/api/v1beta1/flinkcluster_default.go. As we try to scope down the operator to namespace level with webhook disabled, we need to expose these fields with default values set. 