### PR TITLE
[simple/daemon/stateful-apps] Support overriding the image Tag manually

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -78,6 +78,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | envFrom | list | `[]` | Pull all of the environment variables listed in a ConfigMap into the Pod. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables for more details. |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | string | `nil` |  |
+| image.forceTag | String | `nil` | Forcefully overrides the `image.tag` setting - this is useful if you have an outside too that automatically updates the `image.tag` value, but you want your application operators to be able to squash that override themselves. |
 | image.pullPolicy | string | `"IfNotPresent"` | (String) Always, Never or IfNotPresent |
 | image.repository | string | `"nginx"` | (String) The Docker image name and repository for your application |
 | image.tag | String | `nil` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/daemonset-app/templates/_helpers.tpl
+++ b/charts/daemonset-app/templates/_helpers.tpl
@@ -45,7 +45,7 @@ label.
 https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes
 */}}
 {{- define "daemonset-app.labels" -}}
-{{- $_tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- $_tag := include "daemonset-app.imageTag" . }}
 {{- $tag  := $_tag | replace ":" "_" | trunc 63 | quote -}}
 {{- if not (hasKey .Values.podLabels "app") }}
 app: {{ .Release.Name }}
@@ -93,10 +93,19 @@ Create the name of the service account to use
 Proxy and Main App Image Names
 */}}
 {{- define "daemonset-app.imageFqdn" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- $tag := include "daemonset-app.imageTag" . }}
 {{- if hasPrefix "sha256:" $tag }}
 {{- .Values.image.repository }}@{{ $tag }}
 {{- else }}
 {{- .Values.image.repository }}:{{ $tag }}
 {{- end }}
+{{- end }}
+
+{{/*
+Gathers the application image tag. This allows overriding the tag with a master
+`forceTag` setting, as well as the more common mechanism of setting the `tag`
+setting.
+*/}}
+{{- define "daemonset-app.imageTag" -}}
+{{- default .Chart.AppVersion (default .Values.image.tag .Values.image.forceTag) }}
 {{- end }}

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -26,6 +26,12 @@ image:
   # -- (String) Overrides the image tag whose default is the chart appVersion.
   tag: null
 
+  # -- (String) Forcefully overrides the `image.tag` setting - this is useful
+  # if you have an outside too that automatically updates the `image.tag`
+  # value, but you want your application operators to be able to squash that
+  # override themselves.
+  forceTag: null
+
 # -- The command run by the container. This overrides `ENTRYPOINT`. If not
 # specified, the container's default entrypoint is used. The exact rules of how
 # commadn and args are interpreted can be # found at:

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.15.0
+version: 0.15.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -87,6 +87,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
 | envFrom | list | `[]` | Pull all of the environment variables listed in a ConfigMap into the Pod. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables for more details. |
 | fullnameOverride | string | `""` |  |
+| image.forceTag | String | `nil` | Forcefully overrides the `image.tag` setting - this is useful if you have an outside too that automatically updates the `image.tag` value, but you want your application operators to be able to squash that override themselves. |
 | image.pullPolicy | string | `"IfNotPresent"` | (String) Always, Never or IfNotPresent |
 | image.repository | string | `"nginx"` | (String) The Docker image name and repository for your application |
 | image.tag | String | `nil` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -45,7 +45,7 @@ label.
 https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes
 */}}
 {{- define "simple-app.labels" -}}
-{{- $_tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- $_tag := include "simple-app.imageTag" . }}
 {{- $tag  := $_tag | replace ":" "_" | trunc 63 | quote -}}
 {{- if not (hasKey .Values.podLabels "app") }}
 app: {{ .Release.Name }}
@@ -93,7 +93,7 @@ Create the name of the service account to use
 Proxy and Main App Image Names
 */}}
 {{- define "simple-app.imageFqdn" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- $tag := include "simple-app.imageTag" . }}
 {{- if hasPrefix "sha256:" $tag }}
 {{- .Values.image.repository }}@{{ $tag }}
 {{- else }}
@@ -101,8 +101,17 @@ Proxy and Main App Image Names
 {{- end }}
 {{- end }}
 
+{{/*
+Gathers the application image tag. This allows overriding the tag with a master
+`forceTag` setting, as well as the more common mechanism of setting the `tag`
+setting.
+*/}}
+{{- define "simple-app.imageTag" -}}
+{{- default .Chart.AppVersion (default .Values.image.tag .Values.image.forceTag) }}
+{{- end }}
+
 {{- define "simple-app.proxyImageFqdn" -}}
-{{- $tag := .Values.proxySidecar.image.tag }}
+{{- $tag := include "simple-app.imageTag" . }}
 {{- if hasPrefix "sha256:" $tag }}
 {{- .Values.proxySidecar.image.repository }}@{{ $tag }}
 {{- else }}

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -24,6 +24,12 @@ image:
   # -- (String) Overrides the image tag whose default is the chart appVersion.
   tag: null
 
+  # -- (String) Forcefully overrides the `image.tag` setting - this is useful
+  # if you have an outside too that automatically updates the `image.tag`
+  # value, but you want your application operators to be able to squash that
+  # override themselves.
+  forceTag: null
+
 # -- The command run by the container. This overrides `ENTRYPOINT`. If not
 # specified, the container's default entrypoint is used. The exact rules of how
 # commadn and args are interpreted can be # found at:

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -83,6 +83,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
 | envFrom | list | `[]` | Pull all of the environment variables listed in a ConfigMap into the Pod. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables for more details. |
 | fullnameOverride | string | `""` |  |
+| image.forceTag | String | `nil` | Forcefully overrides the `image.tag` setting - this is useful if you have an outside too that automatically updates the `image.tag` value, but you want your application operators to be able to squash that override themselves. |
 | image.pullPolicy | string | `"IfNotPresent"` | (String) Always, Never or IfNotPresent |
 | image.repository | string | `"nginx"` | (String) The Docker image name and repository for your application |
 | image.tag | String | `nil` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/stateful-app/templates/_helpers.tpl
+++ b/charts/stateful-app/templates/_helpers.tpl
@@ -45,7 +45,7 @@ label.
 https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes
 */}}
 {{- define "stateful-app.labels" -}}
-{{- $_tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- $_tag := include "stateful-app.imageTag" . }}
 {{- $tag  := $_tag | replace ":" "_" | trunc 63 | quote -}}
 {{- if not (hasKey .Values.podLabels "app") }}
 app: {{ .Release.Name }}
@@ -93,12 +93,21 @@ Create the name of the service account to use
 Proxy and Main App Image Names
 */}}
 {{- define "stateful-app.imageFqdn" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- $tag := include "stateful-app.imageTag" . }}
 {{- if hasPrefix "sha256:" $tag }}
 {{- .Values.image.repository }}@{{ $tag }}
 {{- else }}
 {{- .Values.image.repository }}:{{ $tag }}
 {{- end }}
+{{- end }}
+
+{{/*
+Gathers the application image tag. This allows overriding the tag with a master
+`forceTag` setting, as well as the more common mechanism of setting the `tag`
+setting.
+*/}}
+{{- define "stateful-app.imageTag" -}}
+{{- default .Chart.AppVersion (default .Values.image.tag .Values.image.forceTag) }}
 {{- end }}
 
 {{- define "stateful-app.proxyImageFqdn" -}}

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -51,6 +51,12 @@ image:
   # -- (String) Overrides the image tag whose default is the chart appVersion.
   tag: null
 
+  # -- (String) Forcefully overrides the `image.tag` setting - this is useful
+  # if you have an outside too that automatically updates the `image.tag`
+  # value, but you want your application operators to be able to squash that
+  # override themselves.
+  forceTag: null
+
 # -- The command run by the container. This overrides `ENTRYPOINT`. If not
 # specified, the container's default entrypoint is used. The exact rules of how
 # commadn and args are interpreted can be # found at:


### PR DESCRIPTION
When using ArgoCD and the ArgoCD Image Updater, we want to allow the
image updater to do its job (setting `.image.tag`), but also allow for
humans to override the updater. Creating a new `image.forceTag` setting
lets a human with access to the `Application`. The argocd-image-updater
will not have any idea that it's change is being overridden, and this
new setting makes it more clear to application owners that a
human-introduced change has been applied.