### PR TITLE
 [simple/daemon/stateful-apps] Use string for Datadog check_names annotation

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -101,7 +101,7 @@ spec:
         */}}
         {{- if and .Values.datadog.enabled .Values.monitor.enabled .Values.datadog.scrapeMetrics }}
         {{- if .Values.istio.enabled }}
-        ad.datadoghq.com/istio-proxy.check_names: ['prometheus']
+        ad.datadoghq.com/istio-proxy.check_names: '["prometheus"]'
         ad.datadoghq.com/istio-proxy.init_configs: '[{}]'
         ad.datadoghq.com/istio-proxy.instances: |-
           [
@@ -111,7 +111,7 @@ spec:
             }
           ]
         {{- else }}
-        ad.datadoghq.com/{{ .Chart.Name }}.check_names: ['prometheus']
+        ad.datadoghq.com/{{ .Chart.Name }}.check_names: '["prometheus"]'
         ad.datadoghq.com/{{ .Chart.Name }}.init_configs: '[{}]'
         ad.datadoghq.com/{{ .Chart.Name }}.instances: |-
           [

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.15.1
+version: 0.15.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
         */}}
         {{- if and .Values.datadog.enabled .Values.monitor.enabled .Values.datadog.scrapeMetrics }}
         {{- if .Values.istio.enabled }}
-        ad.datadoghq.com/istio-proxy.check_names: ['prometheus']
+        ad.datadoghq.com/istio-proxy.check_names: '["prometheus"]'
         ad.datadoghq.com/istio-proxy.init_configs: '[{}]'
         ad.datadoghq.com/istio-proxy.instances: |-
           [
@@ -117,7 +117,7 @@ spec:
             }
           ]
         {{- else }}
-        ad.datadoghq.com/{{ .Chart.Name }}.check_names: ['prometheus']
+        ad.datadoghq.com/{{ .Chart.Name }}.check_names: '["prometheus"]'
         ad.datadoghq.com/{{ .Chart.Name }}.init_configs: '[{}]'
         ad.datadoghq.com/{{ .Chart.Name }}.instances: |-
           [

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
         */}}
         {{- if and .Values.datadog.enabled .Values.monitor.enabled .Values.datadog.scrapeMetrics }}
         {{- if .Values.istio.enabled }}
-        ad.datadoghq.com/istio-proxy.check_names: ['prometheus']
+        ad.datadoghq.com/istio-proxy.check_names: '["prometheus"]'
         ad.datadoghq.com/istio-proxy.init_configs: '[{}]'
         ad.datadoghq.com/istio-proxy.instances: |-
           [
@@ -119,7 +119,7 @@ spec:
             }
           ]
         {{- else }}
-        ad.datadoghq.com/{{ .Chart.Name }}.check_names: ['prometheus']
+        ad.datadoghq.com/{{ .Chart.Name }}.check_names: '["prometheus"]'
         ad.datadoghq.com/{{ .Chart.Name }}.init_configs: '[{}]'
         ad.datadoghq.com/{{ .Chart.Name }}.instances: |-
           [


### PR DESCRIPTION
Got this error after enabling `datadog.scrapeMetrics`:
```
error validating data: ValidationError(Deployment.spec.template.metadata.annotations.ad.datadoghq.com/istio-proxy.check_names): invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.annotations: got "array", expected "string"
```
https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes