### PR TITLE
[istio-endpoints] Allow custom annotations on sidecar

### DIFF
--- a/charts/istio-endpoints/Chart.yaml
+++ b/charts/istio-endpoints/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-endpoints
 description: Per-Namespace Istio Configuration Chart
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/istio-endpoints/README.md
+++ b/charts/istio-endpoints/README.md
@@ -2,7 +2,7 @@
 
 Per-Namespace Istio Configuration Chart
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [elasticache]: https://aws.amazon.com/elasticache/
 [serviceentry]: https://istio.io/latest/docs/reference/config/networking/service-entry/
@@ -60,7 +60,7 @@ plugin, then you must also be running Istio 1.11+.
 + dependencies:
 +   - name: istio-endpoints
 +     repository: https://k8s-charts.nextdoor.com
-+     version: 0.2.0
++     version: 0.2.1
   maintainers:
     - name: diranged
       email: matt@nextdoor.com
@@ -97,6 +97,7 @@ istio-endpoints:
 | elasticacheEndpoints | object | `{}` | (`Map`) A key/value map with all of the elasticacheEndpoints that need to be configured for the Namespace. Each Key is a human-readable name for the endpoint, and then each value is a Map with a configuration. See the [README](#elasticache-endpoint-options) for more instructions. |
 | fullnameOverride | string | `""` | (`String`) Overrides the full prefix of all of the resources. |
 | nameOverride | string | `""` | (`String`) Overrides the main "release name" of the resources. |
+| sidecar.annotations | object | `{}` | (`Map`) Custom annotations to apply to the `Sidecar` resource, such as whether Argo should created it as a pre-sync hook or in a specific wave. |
 | sidecar.catchAllCaptureMode | string | `"IPTABLES"` | (`String`) Default `captureMode` that the final "catch all" [IstioEgressListener](https://istio.io/latest/docs/reference/config/networking/sidecar/#IstioEgressListener) will run in. Default values are here for your reference. |
 | sidecar.catchAllHosts | list | `["*/*"]` | (`Strings[]`) Default `hosts` that the final "catch all" [IstioEgressListener](https://istio.io/latest/docs/reference/config/networking/sidecar/#IstioEgressListener) will monitor for. The default value catches all resources across the cluster. |
 | sidecar.enabled | bool | `true` | (`Bool`) Controls whether or not a `Sidecar` resource is created within the Namespace to help reconfigure the local listeners and routing configuration for your Pods. This defaults to `true` because it is required in order to properly set up Listeners that work for ElastiCache. You can disable this if you are going to manage your own `Sidecar` resource. |

--- a/charts/istio-endpoints/templates/sidecar.yaml
+++ b/charts/istio-endpoints/templates/sidecar.yaml
@@ -6,6 +6,12 @@ metadata:
   name: {{ include "istio-endpoints.fullname" . }}-proxy-config
   labels:
     {{- include "istio-endpoints.labels" . | nindent 4 }}
+  {{- with .Values.sidecar.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   workloadSelector:
     labels:

--- a/charts/istio-endpoints/values.yaml
+++ b/charts/istio-endpoints/values.yaml
@@ -53,6 +53,10 @@ sidecar:
   # cluster.
   catchAllHosts: ['*/*']
 
+  # -- (`Map`) Custom annotations to apply to the `Sidecar` resource, such as whether
+  # Argo should created it as a pre-sync hook or in a specific wave.
+  annotations: {}
+
 # -- (`Map`) A key/value map with all of the elasticacheEndpoints that need to be
 # configured for the Namespace. Each Key is a human-readable name for the
 # endpoint, and then each value is a Map with a configuration. See the


### PR DESCRIPTION
I have a job that makes requests to pods in another namespace in the mesh. I want to run it as a `PreSync` hook, but that means that the custom sidecar configuration won't be applied yet at that point. I also want the sidecar to be created before the job is run, and was thinking of using [waves](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) to do that? 