### PR TITLE
[statefulset/simpleapp/daemonset] Set the proper datadog "metrics" scrape config

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -71,6 +71,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | datadog.enabled | bool | `true` | (`bool`) Whether or not the various datadog labels and options should be included or not. |
 | datadog.env | string | `"dev"` | (`string`) The "env" tag to configure for the application - this maps to the Datadog environment concept for isolating traces/apm data. |
 | datadog.metricsNamespace | string | `"eks"` | (`string`) The prefix to append to all metrics that are scraped by Datadog. We set this to one common value so that common metrics (like `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier dashboard creation as well as comparision between applications. |
+| datadog.metricsToScrape | list | `["\"*\""]` | (`strings[]`) A list of strings that match the metric names that Datadog should scrape from the endpoint. This defaults to `"*"` to tell it to scrape ALL metrics - however, if your app exposes too many metrics (> 2000), Datadog will drop them all on the ground. |
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the Pod (or the `istio-proxy` sidecar). |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -107,7 +107,8 @@ spec:
           [
             {
               "prometheus_url": "http://%%host%%:15020/stats/prometheus",
-              "namespace": "{{ .Values.datadog.metricsNamespace }}"
+              "namespace": "{{ .Values.datadog.metricsNamespace }}",
+              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
         {{- else }}
@@ -117,7 +118,8 @@ spec:
           [
             {
               "prometheus_url": "http://%%host%%:{{ .Values.monitor.portNumber }}{{ .Values.monitor.path }}",
-              "namespace": "{{ .Values.datadog.metricsNamespace }}"
+              "namespace": "{{ .Values.datadog.metricsNamespace }}",
+              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
 

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -108,7 +108,7 @@ spec:
             {
               "prometheus_url": "http://%%host%%:15020/stats/prometheus",
               "namespace": "{{ .Values.datadog.metricsNamespace }}",
-              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
+              "metrics": [ {{ join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
         {{- else }}
@@ -119,7 +119,7 @@ spec:
             {
               "prometheus_url": "http://%%host%%:{{ .Values.monitor.portNumber }}{{ .Values.monitor.path }}",
               "namespace": "{{ .Values.datadog.metricsNamespace }}",
-              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
+              "metrics": [ {{ join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
 

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -319,6 +319,13 @@ datadog:
   # dashboard creation as well as comparision between applications.
   metricsNamespace: eks
 
+  # -- (`strings[]`) A list of strings that match the metric names that Datadog
+  # should scrape from the endpoint. This defaults to `"*"` to tell it to
+  # scrape ALL metrics - however, if your app exposes too many metrics (>
+  # 2000), Datadog will drop them all on the ground.
+  metricsToScrape:
+    - '"*"'
+
 tests:
   connection:
     # -- The command used to trigger the test.

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: istio-alerts
-    version: 0.1.0
+    version: 0.1.1
     repository: "file://../istio-alerts/"
     condition: istio-alerts.enabled

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -65,7 +65,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../istio-alerts/ | istio-alerts | 0.1.0 |
+| file://../istio-alerts/ | istio-alerts | 0.1.1 |
 
 ## Values
 
@@ -81,6 +81,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | datadog.enabled | bool | `true` | (`bool`) Whether or not the various datadog labels and options should be included or not. |
 | datadog.env | string | `"dev"` | (`string`) The "env" tag to configure for the application - this maps to the Datadog environment concept for isolating traces/apm data. |
 | datadog.metricsNamespace | string | `"eks"` | (`string`) The prefix to append to all metrics that are scraped by Datadog. We set this to one common value so that common metrics (like `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier dashboard creation as well as comparision between applications. |
+| datadog.metricsToScrape | list | `["\"*\""]` | (`strings[]`) A list of strings that match the metric names that Datadog should scrape from the endpoint. This defaults to `"*"` to tell it to scrape ALL metrics - however, if your app exposes too many metrics (> 2000), Datadog will drop them all on the ground. |
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the Pod (or the `istio-proxy` sidecar). |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -113,7 +113,8 @@ spec:
           [
             {
               "prometheus_url": "http://%%host%%:15020/stats/prometheus",
-              "namespace": "{{ .Values.datadog.metricsNamespace }}"
+              "namespace": "{{ .Values.datadog.metricsNamespace }}",
+              "metrics": [{{- join ", " .Values.datadog.metricsToScrape -}}]
             }
           ]
         {{- else }}
@@ -123,7 +124,8 @@ spec:
           [
             {
               "prometheus_url": "http://%%host%%:{{ .Values.monitor.portNumber }}{{ .Values.monitor.path }}",
-              "namespace": "{{ .Values.datadog.metricsNamespace }}"
+              "namespace": "{{ .Values.datadog.metricsNamespace }}",
+              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
 

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -114,7 +114,7 @@ spec:
             {
               "prometheus_url": "http://%%host%%:15020/stats/prometheus",
               "namespace": "{{ .Values.datadog.metricsNamespace }}",
-              "metrics": [{{- join ", " .Values.datadog.metricsToScrape -}}]
+              "metrics": [{{ join ", " .Values.datadog.metricsToScrape }}]
             }
           ]
         {{- else }}
@@ -125,7 +125,7 @@ spec:
             {
               "prometheus_url": "http://%%host%%:{{ .Values.monitor.portNumber }}{{ .Values.monitor.path }}",
               "namespace": "{{ .Values.datadog.metricsNamespace }}",
-              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
+              "metrics": [ {{ join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
 

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -1,5 +1,11 @@
 # For local development, we turn on the Ingress controller and set up a simple
 # local ingress.
+datadog:
+  enabled: true
+monitor:
+  enabled: true
+datadog:
+  scrapeMetrics: true
 ingress:
   # -- Enable local ingress for local development.
   enabled: true

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -1,11 +1,5 @@
 # For local development, we turn on the Ingress controller and set up a simple
 # local ingress.
-datadog:
-  enabled: true
-monitor:
-  enabled: true
-datadog:
-  scrapeMetrics: true
 ingress:
   # -- Enable local ingress for local development.
   enabled: true

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -444,6 +444,13 @@ datadog:
   # dashboard creation as well as comparision between applications.
   metricsNamespace: eks
 
+  # -- (`strings[]`) A list of strings that match the metric names that Datadog
+  # should scrape from the endpoint. This defaults to `"*"` to tell it to
+  # scrape ALL metrics - however, if your app exposes too many metrics (>
+  # 2000), Datadog will drop them all on the ground.
+  metricsToScrape:
+    - '"*"'
+
 tests:
   connection:
     # -- The command used to trigger the test.

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -77,6 +77,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | datadog.enabled | bool | `true` | (`bool`) Whether or not the various datadog labels and options should be included or not. |
 | datadog.env | string | `"dev"` | (`string`) The "env" tag to configure for the application - this maps to the Datadog environment concept for isolating traces/apm data. |
 | datadog.metricsNamespace | string | `"eks"` | (`string`) The prefix to append to all metrics that are scraped by Datadog. We set this to one common value so that common metrics (like `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier dashboard creation as well as comparision between applications. |
+| datadog.metricsToScrape | list | `["\"*\""]` | (`strings[]`) A list of strings that match the metric names that Datadog should scrape from the endpoint. This defaults to `"*"` to tell it to scrape ALL metrics - however, if your app exposes too many metrics (> 2000), Datadog will drop them all on the ground. |
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the Pod (or the `istio-proxy` sidecar). |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             {
               "prometheus_url": "http://%%host%%:15020/stats/prometheus",
               "namespace": "{{ .Values.datadog.metricsNamespace }}",
-              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
+              "metrics": [ {{ join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
         {{- else }}
@@ -127,7 +127,7 @@ spec:
             {
               "prometheus_url": "http://%%host%%:{{ .Values.monitor.portNumber }}{{ .Values.monitor.path }}",
               "namespace": "{{ .Values.datadog.metricsNamespace }}",
-              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
+              "metrics": [ {{ join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
 

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -115,7 +115,8 @@ spec:
           [
             {
               "prometheus_url": "http://%%host%%:15020/stats/prometheus",
-              "namespace": "{{ .Values.datadog.metricsNamespace }}"
+              "namespace": "{{ .Values.datadog.metricsNamespace }}",
+              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
         {{- else }}
@@ -125,7 +126,8 @@ spec:
           [
             {
               "prometheus_url": "http://%%host%%:{{ .Values.monitor.portNumber }}{{ .Values.monitor.path }}",
-              "namespace": "{{ .Values.datadog.metricsNamespace }}"
+              "namespace": "{{ .Values.datadog.metricsNamespace }}",
+              "metrics": [ {{- join ", " .Values.datadog.metricsToScrape }} ]
             }
           ]
 

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -451,6 +451,13 @@ datadog:
   # dashboard creation as well as comparision between applications.
   metricsNamespace: eks
 
+  # -- (`strings[]`) A list of strings that match the metric names that Datadog
+  # should scrape from the endpoint. This defaults to `"*"` to tell it to
+  # scrape ALL metrics - however, if your app exposes too many metrics (>
+  # 2000), Datadog will drop them all on the ground.
+  metricsToScrape:
+    - '"*"'
+
 tests:
   connection:
     # -- The command used to trigger the test.


### PR DESCRIPTION
We were missing the `"metrics"` key - which meant that if you tried to have Datadog scrape your metrics endpoints nicely through our chart config, it would fail with this error: 

```
datadog_checks.base.errors.CheckException: You have to collect at least one metric from the endpoint: http://100.64.42.155:15020/stats/prometheus
```