### PR TITLE
[istio-alerts] Introduce .Chart.Name into Rule Names

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.1.1
-appVersion: "0.0.1"
+version: 0.1.2
+appVersion: 0.0.1
 maintainers:
   - name: sabw8217
     email: aaron@nextdoor.com

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -1,7 +1,6 @@
-{{ $values     := .Values }}
-{{ $release    := .Release }}
-
-{{ if .Values.serviceRules.enabled }}
+{{- $values     := .Values }}
+{{- $release    := .Release }}
+{{- if .Values.serviceRules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -13,14 +12,17 @@ spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.IstioServiceRules
     rules:
-    {{ with .Values.serviceRules.http5XXMonitor }}
-    {{ if .enabled }}
+    {{- with .Values.serviceRules.http5XXMonitor }}
+    {{- if .enabled }}
     - alert: 5xx-Rate-Too-High
       annotations:
-        summary: {{`High rate of 5xx errors from {{$labels.destination_service_name}} in namespace {{$labels.namespace}}`}}
+        summary: >-
+          {{`{{$labels.destination_service_name}} is throwing too many 5xx errors (namespace: {{$labels.namespace}})`}}
         runbook_url: {{ $values.defaults.runbookUrl }}#5xx-Rate-Too-High
         description: >-
-          High rate of 5xx responses from the {{`$labels.destination_service_name`}} VirtualService in namespace {{`{{$labels.namespace}}`}}.
+          High rate of 5xx responses from the {{`{{$labels.destination_service_name}}`}} VirtualService
+          in namespace {{`{{$labels.namespace}}`}}.
+
       expr: >-
         sum by (destination_service_name) (
             increase(istio_requests_total{response_code=~"5.*", destination_service_namespace="{{ $release.Namespace }}"}[60s])
@@ -42,16 +44,16 @@ spec:
     {{- end }}
 
      # Adding latency alarm to trigger when request latency is above > threshold
-    {{ with .Values.serviceRules.highRequestLatency }}
-    {{ if .enabled }}
+    {{- with .Values.serviceRules.highRequestLatency }}
+    {{- if .enabled }}
     - alert: HighRequestLatency
       annotations:
-        summary: Processes experience latency above {{ .threshold }}.
+        summary: >-
+          {{`{{$labels.destination_service_name}}`}} avg request latencies are above {{ .threshold }}s!
         runbook_url: {{ $values.defaults.runbookUrl}} #HighRequestLatency
         description: >-
-          {{`{{ $value | humanizePercentage }} latency is above
-          namespace {{ $labels.namespace }} for container {{ $labels.container
-          }} in pod {{ $labels.pod }}.`}}
+          Average request latency of {{`{{ $value | humanizePercentage }}`}} is above threshold ({{ .threshold }}s)
+          in namespace {{`{{ $labels.namespace }}`}} for pod {{`{{ $labels.pod }}`}} (container: {{`{{ $labels.container }}`}}).
       expr: |-
         sum by (destination_service_name) (
           irate(

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -1,34 +1,42 @@
-{{ $values           := .Values }}
-{{ $release          := .Release }}
-{{ if .Values.serviceRules.enabled }}
+{{ $values     := .Values }}
+{{ $release    := .Release }}
 
+{{ if .Values.serviceRules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ .Release.Name }}-service-rules
+  name: {{ .Release.Name }}-{{ lower .Chart.Name }}-service-rules
   annotations:
     nextdoor.com/chart: {{ .Values.chart_name }}
     nextdoor.com/source: {{ .Values.chart_source }}
 spec:
   groups:
-  - name: {{ .Release.Name }}.{{ .Release.Namespace }}.serviceRules
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.IstioServiceRules
     rules:
     {{ with .Values.serviceRules.http5XXMonitor }}
     {{ if .enabled }}
-    - alert: {{ $release.Name }}-5xx-Rate-Too-High
+    - alert: 5xx-Rate-Too-High
       annotations:
         summary: {{`High rate of 5xx errors from {{$labels.destination_service_name}} in namespace {{$labels.namespace}}`}}
         runbook_url: {{ $values.defaults.runbookUrl }}#5xx-Rate-Too-High
         description: >-
           High rate of 5xx responses from the {{`$labels.destination_service_name`}} VirtualService in namespace {{`{{$labels.namespace}}`}}.
       expr: >-
-        sum by (destination_service_name) (increase(istio_requests_total{response_code=~"5.*", destination_service_namespace="{{ $release.Namespace }}"}[60s]))
-         / sum by (destination_service_name) (increase(istio_requests_total{destination_service_namespace="{{ $release.Namespace }}"}[60s])) > {{ .threshold }}
+        sum by (destination_service_name) (
+            increase(istio_requests_total{response_code=~"5.*", destination_service_namespace="{{ $release.Namespace }}"}[60s])
+        )
+
+          /
+
+        sum by (destination_service_name) (
+            increase(istio_requests_total{destination_service_namespace="{{ $release.Namespace }}"}[60s])
+        )
+          > {{ .threshold }}
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with $values.defaults.additionalRuleLabels}}
+        {{ toYaml . | nindent 8}}
         {{- end }}
     {{- end }}
     {{- end }}
@@ -36,7 +44,7 @@ spec:
      # Adding latency alarm to trigger when request latency is above > threshold
     {{ with .Values.serviceRules.highRequestLatency }}
     {{ if .enabled }}
-    - alert: {{ $release.Name }}-HighRequestLatency
+    - alert: HighRequestLatency
       annotations:
         summary: Processes experience latency above {{ .threshold }}.
         runbook_url: {{ $values.defaults.runbookUrl}} #HighRequestLatency
@@ -45,13 +53,17 @@ spec:
           namespace {{ $labels.namespace }} for container {{ $labels.container
           }} in pod {{ $labels.pod }}.`}}
       expr: |-
-        sum by (destination_service_name) (irate(istio_request_duration_milliseconds_bucket{reporter=~"destination",destination_service_namespace="{{ $release.Namespace }}"}[1m]) / 1000)
-        > {{ .threshold }}
+        sum by (destination_service_name) (
+          irate(
+            istio_request_duration_milliseconds_bucket{reporter=~"destination",destination_service_namespace="{{ $release.Namespace }}"}[1m]
+          ) / 1000
+        )
+          > {{ .threshold }}
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels}}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8}}
+        {{- with $values.defaults.additionalRuleLabels}}
+        {{ toYaml . | nindent 8}}
         {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
The motivation of introducing another field into .Chart.Name here is to
make it easier to identify where the "ServiceRules" are coming from -
without this, they appear to be natively part of the parent-chart
(simple-app for example). With the .Chart.Name in there, you can more
easily see that these come from a nested chart.

![image](https://user-images.githubusercontent.com/768067/149188639-86379abf-1892-4bdf-8ae2-a307fc64af37.png)
