### PR TITLE
[simple-app] Bugfix, undo alias'ing of the dependency chart

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -10,7 +10,6 @@ maintainers:
 dependencies:
 
   - name: istio-alerts
-    alias: istioRules
     version: 0.1.2
     repository: https://k8s-charts.nextdoor.com
-    condition: istioRules.enabled
+    condition: istio-alerts.enabled

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -65,7 +65,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://k8s-charts.nextdoor.com | istioRules(istio-alerts) | 0.1.2 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.1.2 |
 
 ## Values
 
@@ -101,9 +101,9 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | ingress.port | string | `nil` | If set, this will override the `service.portName` parameter, and the `Service` object will point specifically to this port number on the backing Pods. |
 | ingress.portName | string | `"http"` | This is the port "name" that the `Service` will point to on the backing Pods. This value must match one of the values of `.name` in the `Values.ports` configuration. |
 | ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
+| istio-alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
 | istio.enabled | bool | `false` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `ServiceMonitor` object. |
 | istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down. eg: preStopCommand: [ /bin/sleep, "30" ] |
-| istioRules.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
 | minReadySeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds |
 | monitor.enabled | bool | `true` | (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -479,7 +479,7 @@ runbookUrl: https://github.com/Nextdoor/k8s-charts/blob/main/charts/simple-app/R
 # to reproduce similar behavior to services launched on ECS with dedicated ALBs. For more
 # complex scenarios, you may want to disable this, and have your application chart directly
 # depend on istio-alerts.
-istioRules:
+istio-alerts:
   # -- (`bool`) Whether or not to enable the istio-alerts chart.
   enabled: true
 


### PR DESCRIPTION
**Update: Helm Bug**

I've discovered a bug that took me the better part of all of yesterday to figure out. I couldn't understand why I was unable to disable the `istio-alerts` chart [(alias'ed to `istioRules` in simple-app)](https://github.com/Nextdoor/k8s-charts/pull/97/files#diff-01d4bc68d5049882db28ae0896ab77392652b798a14592fdd04f330c321984c5R13). Every time I ran the template, the `app1` chart would properly bypass creating the service-rules template... but the `app2` chart would create it. Weirder yet, the name of the `app2` chart's template clearly indicated it was using the `istio-alerts` name instead of the `istioRules` alias. I thought I was losing my mind... or having a caching bug.

**The bug**

To test this, I learned a little trick... create a `templates/test.yaml` file with the contents: `{{ toYaml . }}`. That will print out the entire global variable context at that chart level. I created a stupid simple test-chart:

```
# test/Chart.yaml
apiVersion: v2
name: test-app
description: test-app
type: application
version: 0.0.1
appVersion: latest
maintainers:
  - name: diranged
    email: matt@nextdoor.com
dependencies:

  - name: simple-app
    alias: app1
    version: 0.16.1
    repository: "file://../simple-app/"

  - name: simple-app
    alias: app2
    version: 0.16.1
    repository: "file://../simple-app/"
```

and then I patched the my `simple-app` and `istio-alerts` charts to add in these test files:

```
MacBook-Air:charts diranged$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   simple-app/Chart.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	istio-alerts/templates/test.yaml
	simple-app/templates/test.yaml
```

When I ran the `make template` on the `test` chart, I got some pretty valuable output. I'll copy only the parts that I think are relevant here.

First, we can see that the `app1` subchart is alias'ed to `app1` and it has a subchart that is aliased to `istioRules`. Just like we expect:
```yaml
---
# Source: test-app/charts/app1/templates/test.yaml
Capabilities:
  APIVersions:
  - v1
...
Chart:
  IsRoot: false
  apiVersion: v2
  appVersion: latest
  dependencies:
  - alias: istioRules
    condition: istioRules.enabled
    enabled: true
    name: istioRules   <<<< this is right
    repository: file://../istio-alerts/
    version: 0.1.2
  description: Default Microservice Helm Chart
  maintainers:
  - email: matt@nextdoor.com
    name: diranged
  name: app1   <<<<<< this is right
  type: application
  version: 0.16.1
...
Release:
  IsInstall: true
  IsUpgrade: false
  Name: test
  Namespace: test-app
  Revision: 1
  Service: Helm
...
Subcharts:
  istioRules:
...
    Chart:
      IsRoot: false
      apiVersion: v2
      appVersion: 0.0.1
      description: A Helm chart that provisions a series of alerts for istio VirtualServices
      maintainers:
      - email: aaron@nextdoor.com
        name: sabw8217
      name: istioRules   <<<< this is right
      type: application
      version: 0.1.2
```

When the `app2` chart runs the same template, notice how suddenly it has a different behavior? The main chart name is correct, but the subchart is not able to use the `istioRules` alias and seems to revert to the `istio-alerts` chart name!

```yaml
---
# Source: test-app/charts/app2/templates/test.yaml
Capabilities:
  APIVersions:
...
Chart:
  IsRoot: false
  apiVersion: v2
  appVersion: latest
  dependencies:
  - alias: istioRules
    condition: istioRules.enabled
    enabled: true
    name: istioRules   <<< this looks right
    repository: file://../istio-alerts/
    version: 0.1.2
  description: Default Microservice Helm Chart
  maintainers:
  - email: matt@nextdoor.com
    name: diranged
  name: app2   <<<< this is right
  type: application
  version: 0.16.1
...
Subcharts:
  istio-alerts:
    Capabilities:
      APIVersions:
...
    Chart:
      IsRoot: false
      apiVersion: v2
      appVersion: 0.0.1
      description: A Helm chart that provisions a series of alerts for istio VirtualServices
      maintainers:
      - email: aaron@nextdoor.com
        name: sabw8217
      name: istio-alerts <<<<< WHOA WHATS THIS??
      type: application
      version: 0.1.2
```

If we step one layer down into the nested `istio-alerts` chart for `app1`:

```yaml
# Source: test-app/charts/app1/charts/istioRules/templates/test.yaml
Capabilities:
  APIVersions:
  - v1
Chart:
  IsRoot: false
  apiVersion: v2
  appVersion: 0.0.1
  description: A Helm chart that provisions a series of alerts for istio VirtualServices
  maintainers:
  - email: aaron@nextdoor.com
    name: sabw8217
  name: istioRules <<<<< THIS IS RIGHT
  type: application
  version: 0.1.2
```

But again when we get to the `app2` nested `istio-alerts` chart, things go south:

```yaml
# Source: test-app/charts/app2/charts/istio-alerts/templates/test.yaml
Capabilities:
  APIVersions:
...
Chart:
  IsRoot: false
  apiVersion: v2
  appVersion: 0.0.1
  description: A Helm chart that provisions a series of alerts for istio VirtualServices
  maintainers:
  - email: aaron@nextdoor.com
    name: sabw8217
  name: istio-alerts    <<<< YUP THATS WRONG
  type: application
  version: 0.1.2
```

**What do we do?**

The first thing to do is remove the `istioRules` alias. When I remove that alias, then setting `app1.istio-alerts.enabled: false`  works properly in my tests. This isn't the right long term fix, but it will let us move forward for the time being. I think that the second fix is to turn the `istio-alerts` chart into a `library` chart. That will involve refactoring it a bit and changing the way the other charts use it though.