### PR TITLE
simple-app: Prefer latest curl image by default

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.17.1
+version: 0.17.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.17.2](https://img.shields.io/badge/Version-0.17.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -177,7 +177,7 @@ This feature is turned on by default if you set `Values.istio.enabled=true` and
 | terminationGracePeriodSeconds | string | `nil` | https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution |
 | tests.connection.args | list | `["{{ include \"simple-app.fullname\" . }}"]` | A list of arguments passed into the command. These are run through the tpl function. |
 | tests.connection.command | list | `["curl","--retry-connrefused","--retry","5"]` | The command used to trigger the test. |
-| tests.connection.image.repository | string | `nil` | Sets the image-name that will be used in the "connection" integration test. If this is left empty, then the .image.repository value will be used instead (and the .image.tag will also be used). |
+| tests.connection.image.repository | string | `"curlimages/curl"` | Sets the image-name that will be used in the "connection" integration test. If this is left empty, then the .image.repository value will be used instead (and the .image.tag will also be used). By default, prefer the latest official version to handle cases where the app image provides either no curl binary or an outdated one. |
 | tests.connection.image.tag | string | `nil` | Sets the tag that will be used in the "connection" integration test. If this is left empty, the default is "latest" |
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` |  |

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -472,7 +472,9 @@ tests:
       # -- Sets the image-name that will be used in the "connection"
       # integration test. If this is left empty, then the .image.repository
       # value will be used instead (and the .image.tag will also be used).
-      repository:
+      # By default, prefer the latest official version to handle cases where the
+      # app image provides either no curl binary or an outdated one.
+      repository: curlimages/curl
       # -- Sets the tag that will be used in the "connection" integration test.
       # If this is left empty, the default is "latest"
       tag:


### PR DESCRIPTION
The intent here is to fix this [build error](https://github.com/Nextdoor/hello-world-k8s.template/pull/11/checks?check_run_id=5069569863) by defaulting to a curl version that should support `--retry-connrefused`.