### PR TITLE
[nd-common] Implement a new nd-common library chart

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,8 +2,13 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.2.4
+version: 0.3.0
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
+dependencies:
+  - name: nd-common
+    version: 0.0.1
+    # Temporary while we're under active development of this dependency chart.
+    repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -13,7 +13,17 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
-### 0.1.0 -> 0.2.0
+### 0.2.x -> 0.3.x
+
+**Automatic NodeSelectors**
+
+By default the chart now sets the `kubernetes.io/os` and `kubernetes.io/arch`
+values in the `nodeSelector` field for your pods! The default values are
+targeted towards our most common deployment environments - `linux` on `amd64`
+hosts. Pay close attention to the `targetOperatingSystem` and
+`targetArchitecture` values to customize this behavior.
+
+### 0.1.x -> 0.2.x
 
 **New Feature: Vertical Pod Autoscaling**
 
@@ -98,6 +108,12 @@ secretsEngine: kms
 kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 ```
 
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../nd-common | nd-common | 0.0.1 |
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -139,7 +155,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
 | nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
+| nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | object | `{}` | (`Map`) List of Annotations to be added to the PodSpec |
 | podLabels | object | `{}` | (`Map`) List of Labels to be added to the PodSpec |
 | podMonitor.annotations | object | `{}` | (`map`) ServiceMonitor annotations. |
@@ -163,6 +179,8 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| targetArchitecture | string | `"amd64"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target host architecture. If set to null/empty-string, then this value will not be set. |
+| targetOperatingSystem | string | `"linux"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target Operating System. Must be set. |
 | terminationGracePeriodSeconds | string | `nil` | https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution |
 | tests.connection.args | list | `["$(HOST_IP)"]` | A list of arguments passed into the command. These are run through the tpl function. |
 | tests.connection.command | list | `["curl","--verbose","--retry-connrefused","--retry","5","--retry-delay","10"]` | The command used to trigger the test. |

--- a/charts/daemonset-app/README.md.gotmpl
+++ b/charts/daemonset-app/README.md.gotmpl
@@ -12,7 +12,17 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
-### 0.1.0 -> 0.2.0
+### 0.2.x -> 0.3.x
+
+**Automatic NodeSelectors**
+
+By default the chart now sets the `kubernetes.io/os` and `kubernetes.io/arch`
+values in the `nodeSelector` field for your pods! The default values are
+targeted towards our most common deployment environments - `linux` on `amd64`
+hosts. Pay close attention to the `targetOperatingSystem` and
+`targetArchitecture` values to customize this behavior.
+
+### 0.1.x -> 0.2.x
 
 **New Feature: Vertical Pod Autoscaling**
 

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -133,10 +133,8 @@ spec:
         {{- end }}
     spec:
       priorityClassName: {{ .Values.priorityClassName }}
-      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "nd-common.nodeSelector" $ | nindent 8 }}
       {{- with .Values.hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -266,6 +266,18 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target Operating
+# System. Must be set.
+targetOperatingSystem: linux
+
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target host
+# architecture. If set to null/empty-string, then this value will not be set.
+targetArchitecture: amd64
+
+# -- (`map`) A list of key/value pairs that will be added in to the
+# nodeSelector spec for the pods.
 nodeSelector: {}
 
 hostNetwork: null

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: nd-common
+description: A helper chart used by most of our other charts
+type: library
+version: 0.0.1
+appVersion: latest

--- a/charts/nd-common/Makefile
+++ b/charts/nd-common/Makefile
@@ -1,0 +1,2 @@
+include ../../contrib/Helm.mk
+include ../../contrib/Testing.mk

--- a/charts/nd-common/templates/_node_selector.tpl
+++ b/charts/nd-common/templates/_node_selector.tpl
@@ -1,0 +1,44 @@
+{{/*
+
+The "nd-common.nodeSelector" function provides a common set of nodeSelectors
+automatically, with reasonable sane defaults for our environment. The function
+can be used in a template like this:
+
+  # deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  ...
+  spec:
+    template:
+      spec:
+        nodeSelector:
+          {{- include "nd-common.nodeSelector" $ | nindent 8 }}
+
+In your Values.yaml file, the following value keys are used and/or required:
+
+** .Values.targetOperatingSystem **
+Sets the "kubernetes.io/os" nodeSelector key. Must be a string. If not set,
+defaults to "linux".
+
+** .Values.targetArchitecture **
+Sets the "kubernetes.io/arch" nodeSelector key. Must be a string. If not set,
+then no architecture nodeSelector key is set.
+
+** .Values.nodeSelector **
+Populates the remainder of the nodeSelector key with the map of key/values
+passed in. These values are each run through the 'tpl' function as well.
+
+*/}}
+{{- define "nd-common.nodeSelector" -}}
+
+kubernetes.io/os: {{ default "linux" .Values.targetOperatingSystem -}}
+
+{{- with .Values.targetArchitecture }}
+kubernetes.io/arch: {{ . }}
+{{- end }}
+
+{{- with .Values.nodeSelector }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+
+{{- end }}

--- a/charts/nd-common/values.yaml
+++ b/charts/nd-common/values.yaml
@@ -1,0 +1,1 @@
+# empty on purpose

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.18.2
+version: 0.19.0
 appVersion: latest
 maintainers:
   - name: diranged
@@ -12,3 +12,6 @@ dependencies:
     version: 0.1.2
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
+  - name: nd-common
+    version: 0.0.1
+    repository: file://../nd-common

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: istio-alerts
-    version: 0.1.2
+    version: 0.1.3
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.18.2](https://img.shields.io/badge/Version-0.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,16 @@ in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
+
+### 0.18.x -> 0.19.x
+
+**Automatic NodeSelectors**
+
+By default the chart now sets the `kubernetes.io/os` and `kubernetes.io/arch`
+values in the `nodeSelector` field for your pods! The default values are
+targeted towards our most common deployment environments - `linux` on `amd64`
+hosts. Pay close attention to the `targetOperatingSystem` and
+`targetArchitecture` values to customize this behavior.
 
 ### 0.17.x -> 0.18.x
 
@@ -107,6 +117,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
+| file://../nd-common | nd-common | 0.0.1 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.2 |
 
 ## Values
@@ -154,7 +165,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
 | nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
+| nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | object | `{}` | (`Map`) List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |
 | podLabels | object | `{}` | (`Map`) List of Labels to be added to the PodSpec |
@@ -202,6 +213,8 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
+| targetArchitecture | string | `"amd64"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target host architecture. If set to null/empty-string, then this value will not be set. |
+| targetOperatingSystem | string | `"linux"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target Operating System. Must be set. |
 | terminationGracePeriodSeconds | string | `nil` | https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution |
 | tests.connection.args | list | `["{{ include \"simple-app.fullname\" . }}"]` | A list of arguments passed into the command. These are run through the tpl function. |
 | tests.connection.command | list | `["curl","--retry-connrefused","--retry","5"]` | The command used to trigger the test. |

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -118,7 +118,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../nd-common | nd-common | 0.0.1 |
-| https://k8s-charts.nextdoor.com | istio-alerts | 0.1.2 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
 

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -12,6 +12,16 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
+### 0.18.x -> 0.19.x
+
+**Automatic NodeSelectors**
+
+By default the chart now sets the `kubernetes.io/os` and `kubernetes.io/arch`
+values in the `nodeSelector` field for your pods! The default values are
+targeted towards our most common deployment environments - `linux` on `amd64`
+hosts. Pay close attention to the `targetOperatingSystem` and
+`targetArchitecture` values to customize this behavior.
+
 ### 0.17.x -> 0.18.x
 
 **New Feature: Secrets Management**

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -138,10 +138,8 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "nd-common.nodeSelector" $ | nindent 8 }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -359,6 +359,18 @@ autoscaling:
   # -- If supplied, configures the HPA to target a particular Memory utilization percentage
   # targetMemoryUtilizationPercentage: 80
 
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target Operating
+# System. Must be set.
+targetOperatingSystem: linux
+
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target host
+# architecture. If set to null/empty-string, then this value will not be set.
+targetArchitecture: amd64
+
+# -- (`map`) A list of key/value pairs that will be added in to the
+# nodeSelector spec for the pods.
 nodeSelector: {}
 
 tolerations: []

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,13 +2,17 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: istio-alerts
-    version: 0.1.1
-    repository: "file://../istio-alerts/"
+    version: 0.1.2
+    repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
+  - name: nd-common
+    version: 0.0.1
+    # Temporary while we're under active development of this dependency chart.
+    repository: file://../nd-common

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: istio-alerts
-    version: 0.1.2
+    version: 0.1.3
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,16 @@ in Kubernetes][statefulsets]. The chart provides all of the common pieces like
 ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
+
+### 0.2.x -> 0.3.x
+
+**Automatic NodeSelectors**
+
+By default the chart now sets the `kubernetes.io/os` and `kubernetes.io/arch`
+values in the `nodeSelector` field for your pods! The default values are
+targeted towards our most common deployment environments - `linux` on `amd64`
+hosts. Pay close attention to the `targetOperatingSystem` and
+`targetArchitecture` values to customize this behavior.
 
 ### 0.1.3 -> 0.2.x
 
@@ -92,7 +102,8 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../istio-alerts/ | istio-alerts | 0.1.1 |
+| file://../nd-common | nd-common | 0.0.1 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.1.2 |
 
 ## Values
 
@@ -134,7 +145,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
 | nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
+| nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | object | `{}` | (`Map`) List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |
 | podLabels | object | `{}` | (`Map`) List of Labels to be added to the PodSpec |
@@ -170,6 +181,8 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
+| targetArchitecture | string | `"amd64"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target host architecture. If set to null/empty-string, then this value will not be set. |
+| targetOperatingSystem | string | `"linux"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target Operating System. Must be set. |
 | terminationGracePeriodSeconds | string | `nil` | https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution |
 | tests.connection.args | list | `["{{ include \"stateful-app.fullname\" . }}"]` | A list of arguments passed into the command. These are run through the tpl function. |
 | tests.connection.command | list | `["curl","--retry-connrefused","--retry","5"]` | The command used to trigger the test. |

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -103,7 +103,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../nd-common | nd-common | 0.0.1 |
-| https://k8s-charts.nextdoor.com | istio-alerts | 0.1.2 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
 

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -12,6 +12,16 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
+### 0.2.x -> 0.3.x
+
+**Automatic NodeSelectors**
+
+By default the chart now sets the `kubernetes.io/os` and `kubernetes.io/arch`
+values in the `nodeSelector` field for your pods! The default values are
+targeted towards our most common deployment environments - `linux` on `amd64`
+hosts. Pay close attention to the `targetOperatingSystem` and
+`targetArchitecture` values to customize this behavior.
+
 ### 0.1.3 -> 0.2.x
 
 **New Feature: Secrets Management**

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -140,10 +140,8 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "nd-common.nodeSelector" $ | nindent 8 }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -360,6 +360,18 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target Operating
+# System. Must be set.
+targetOperatingSystem: linux
+
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target host
+# architecture. If set to null/empty-string, then this value will not be set.
+targetArchitecture: amd64
+
+# -- (`map`) A list of key/value pairs that will be added in to the
+# nodeSelector spec for the pods.
 nodeSelector: {}
 
 tolerations: []

--- a/ct.yaml
+++ b/ct.yaml
@@ -9,3 +9,5 @@ chart-repos:
   - flink-operator=https://googlecloudplatform.github.io/flink-on-k8s-operator
   - jetstack=https://charts.jetstack.io
   - k8s-charts=https://k8s-charts.nextdoor.com
+excluded-charts:
+  - nd-common


### PR DESCRIPTION
This PR introduces a whole new "Library" chart**. The new "nd-common"
library chart will be a single place where we keep all of our common
goodies and helpers. These helpers can then be leveraged by our various
common (or app-specific) charts to provide common behaviors across the
board, without requiring complex dependency chart management.

The simple-app, statefull-app and daemonset-app charts have all been
updated to use the new "nd-common.nodeSelectors" definition, which adds
in default behaviors for setting the "kubernetes.io/os" and
"kubernetes.io/arch" nodeSelectors on our pods.

**: https://helm.sh/docs/topics/library_charts/