### PR TITLE
[istio-alerts] Bugfixes on the HighRequestLatency alarm

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.0.1
 maintainers:
   - name: sabw8217

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -37,6 +37,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $release.Namespace }}
         {{- with $values.defaults.additionalRuleLabels}}
         {{ toYaml . | nindent 8}}
         {{- end }}
@@ -55,7 +56,7 @@ spec:
           Average request latency of {{`{{ $value | humanizePercentage }}`}} is above threshold ({{ .threshold }}s)
           in namespace {{`{{ $labels.namespace }}`}} for pod {{`{{ $labels.pod }}`}} (container: {{`{{ $labels.container }}`}}).
       expr: |-
-        sum by (destination_service_name) (
+        avg by (destination_service_name) (
           irate(
             istio_request_duration_milliseconds_bucket{reporter=~"destination",destination_service_namespace="{{ $release.Namespace }}"}[1m]
           ) / 1000
@@ -64,6 +65,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $release.Namespace }}
         {{- with $values.defaults.additionalRuleLabels}}
         {{ toYaml . | nindent 8}}
         {{- end }}


### PR DESCRIPTION
1. We were not setting the namespace label, which meant the alerts were
   going into the ether.
2. We were not using avg() but instead sum() - which meant that we were
   ADDING all the cumulative latency numbers!