### PR TITLE
[simple-app/stateful-app] Increase the Minimum Replica Count and set …

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,16 @@ in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
+
+### 0.19.x -> 0.20.x
+
+**Default Replica Count is now 2!**
+
+In order to make sure that even our staging/development deployments have some
+guarantees of uptime, the defaults for the chart have changed. We now set
+`replicaCount: 2` and create a `podDisruptionBudget` by default. This ensures
+that a developer needs to _intentionally_ disable these settings in order to
+create a single-pod deployment.
 
 ### 0.18.x -> 0.19.x
 
@@ -167,7 +177,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | object | `{}` | (`Map`) List of Annotations to be added to the PodSpec |
-| podDisruptionBudget | object | `{}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |
+| podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |
 | podLabels | object | `{}` | (`Map`) List of Labels to be added to the PodSpec |
 | podSecurityContext | object | `{}` |  |
 | ports | list | `[{"containerPort":80,"name":"http","port":null,"protocol":"TCP"}]` | (`ContainerPort[]`) A list of Port objects that are exposed by the service. These ports are applied to the main container, or the proxySidecar container (if enabled). The port list is also used to generate Network Policies that allow ingress into the pods. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#containerport-v1-core for details. **Note: We have added an optional "port" field to this list that allows the user to override the Service Port (for example 80) that a client  connects to, without altering the Container Port (say, 8080) that is listening for connections. |
@@ -194,7 +204,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | proxySidecar.resources | object | `{}` | A PodSpec "Resources" object for the proxy container |
 | proxySidecar.volumeMounts | list | `[]` | List of VolumeMounts that are applied to the proxySidecar container - these must refer to volumes set in the `Values.volumes` parameter. |
 | readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "readinessProbe" configuration object. Note that this readinessProbe will be applied to the proxySidecar container instead if that is enabled. |
-| replicaCount | `int` | `nil` | The number of Pods to start up by default. If the `autoscaling.enabled` parameter is set, then this serves as the "start scale" for an application. Setting this to `null` prevents the setting from being applied at all in the PodSpec, leaving it to Kubernetes to use the default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas |
+| replicaCount | int | `2` | (`int`) The number of Pods to start up by default. If the `autoscaling.enabled` parameter is set, then this serves as the "start scale" for an application. Setting this to `null` prevents the setting from being applied at all in the PodSpec, leaving it to Kubernetes to use the default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas |
 | resources | object | `{}` |  |
 | revisionHistoryLimit | int | `3` | (`int`) The default revisionHistoryLimit in Kubernetes is 10 - which is just really noisy. Set our default to 3. https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy |
 | runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/simple-app/README.md"` | The URL of the runbook for this service. |

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -12,6 +12,16 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
+### 0.19.x -> 0.20.x
+
+**Default Replica Count is now 2!**
+
+In order to make sure that even our staging/development deployments have some
+guarantees of uptime, the defaults for the chart have changed. We now set
+`replicaCount: 2` and create a `podDisruptionBudget` by default. This ensures
+that a developer needs to _intentionally_ disable these settings in order to
+create a single-pod deployment.
+
 ### 0.18.x -> 0.19.x
 
 **Automatic NodeSelectors**

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -3,7 +3,7 @@
 # scale" for an application. Setting this to `null` prevents the setting from
 # being applied at all in the PodSpec, leaving it to Kubernetes to use the
 # default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas
-replicaCount: null
+replicaCount: 2
 
 # -- (`int`) The default revisionHistoryLimit in Kubernetes is 10 - which is
 # just really noisy. Set our default to 3. https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
@@ -12,7 +12,8 @@ revisionHistoryLimit: 3
 # -- Set up a PodDisruptionBudget for the Deployment. See
 # https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more
 # details.
-podDisruptionBudget: {}
+podDisruptionBudget:
+  maxUnavailable: 1
 
 image:
   # -- (String) The Docker image name and repository for your application

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,16 @@ in Kubernetes][statefulsets]. The chart provides all of the common pieces like
 ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
+
+### 0.3.x -> 0.4.x
+
+**Default Replica Count is now 2!**
+
+In order to make sure that even our staging/development deployments have some
+guarantees of uptime, the defaults for the chart have changed. We now set
+`replicaCount: 2` and create a `podDisruptionBudget` by default. This ensures
+that a developer needs to _intentionally_ disable these settings in order to
+create a single-pod deployment.
 
 ### 0.2.x -> 0.3.x
 
@@ -147,7 +157,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | object | `{}` | (`Map`) List of Annotations to be added to the PodSpec |
-| podDisruptionBudget | object | `{}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |
+| podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |
 | podLabels | object | `{}` | (`Map`) List of Labels to be added to the PodSpec |
 | podManagementPolicy | `string` | `nil` | podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once. |
 | podSecurityContext | object | `{}` |  |
@@ -163,7 +173,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | proxySidecar.resources | object | `{}` | A PodSpec "Resources" object for the proxy container |
 | proxySidecar.volumeMounts | list | `[]` | List of VolumeMounts that are applied to the proxySidecar container - these must refer to volumes set in the `Values.volumes` parameter. |
 | readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "readinessProbe" configuration object. Note that this readinessProbe will be applied to the proxySidecar container instead if that is enabled. |
-| replicaCount | `int` | `nil` | The number of Pods to start up by default. If the `autoscaling.enabled` parameter is set, then this serves as the "start scale" for an application. Setting this to `null` prevents the setting from being applied at all in the PodSpec, leaving it to Kubernetes to use the default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas |
+| replicaCount | int | `2` | (`int`) The number of Pods to start up by default. If the `autoscaling.enabled` parameter is set, then this serves as the "start scale" for an application. Setting this to `null` prevents the setting from being applied at all in the PodSpec, leaving it to Kubernetes to use the default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas |
 | resources | object | `{}` |  |
 | revisionHistoryLimit | int | `3` | (`int`) The default revisionHistoryLimit in Kubernetes is 10 - which is just really noisy. Set our default to 3. https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy |
 | secrets | object | `{}` | (`Map`) Map of environment variables to plaintext secrets or KMS encrypted secrets. |

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -12,6 +12,16 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
+### 0.3.x -> 0.4.x
+
+**Default Replica Count is now 2!**
+
+In order to make sure that even our staging/development deployments have some
+guarantees of uptime, the defaults for the chart have changed. We now set
+`replicaCount: 2` and create a `podDisruptionBudget` by default. This ensures
+that a developer needs to _intentionally_ disable these settings in order to
+create a single-pod deployment.
+
 ### 0.2.x -> 0.3.x
 
 **Automatic NodeSelectors**

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -13,7 +13,7 @@ podManagementPolicy: null
 # scale" for an application. Setting this to `null` prevents the setting from
 # being applied at all in the PodSpec, leaving it to Kubernetes to use the
 # default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas
-replicaCount: null
+replicaCount: 2
 
 # -- (`int`) The default revisionHistoryLimit in Kubernetes is 10 - which is
 # just really noisy. Set our default to 3. https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
@@ -39,7 +39,8 @@ volumeClaimTemplates: null
 # -- Set up a PodDisruptionBudget for the Deployment. See
 # https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more
 # details.
-podDisruptionBudget: {}
+podDisruptionBudget:
+  maxUnavailable: 1
 
 image:
   # -- (String) The Docker image name and repository for your application


### PR DESCRIPTION
…a PDB

Our devlopers are (rightfully) not setting `replicaCount` or
`podDisruptionBudget` configurations in staging because they haven't
felt the need to. However this means that during node replacements and
even during code rollouts we get the ArgoCD Notifications App reporting
that the service is "failed" just because something like the HPA wasn't
able to find metrics for a pod during the rollout.

It is reasonable to make our minimum default deployment include at least
2 pods, and have a `PodDisruptionBudget` created that allows only one
pod to be unavailable at a time. This more accurately reflects the
behaviors we have in production anyways.