### PR TITLE
[simple/daemon/stateful-app] Explicitly enable or disable metrics merging

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -186,6 +186,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | ingress.portName | string | `"http"` | This is the port "name" that the `Service` will point to on the backing Pods. This value must match one of the values of `.name` in the `Values.ports` configuration. |
 | ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
 | istio.enabled | bool | `false` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `ServiceMonitor` object. This is disabled by default on DaemonSets because it is fairly uncommon for a DaemonSet to be part of the service mesh. |
+| istio.metricsMerging | bool | `false` | (`bool`) If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
 | istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down. eg: preStopCommand: [ /bin/sleep, "30" ] |
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -356,6 +356,13 @@ istio:
   # preStopCommand: [ /bin/sleep, "30" ]
   preStopCommand: null
 
+  # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
+  # turned on and Envoy will attempt to scrape metrics from the application pod
+  # and merge them with its own. This defaults to False beacuse in most
+  # environments we want to explicitly split up the metrics and collect Istio
+  # metrics separate from Application metrics.
+  metricsMerging: false
+
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.
 datadog:

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.4
+version: 0.0.5
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`
@@ -206,6 +206,8 @@ spec:
 ### Values Parameters
 
 * `.Values.podLabels`
+* `.Values.monitor.path`
+* `.Values.monitor.portNumber`
 
 * `.Values.istio.enabled` (default: `True`): Controls whether or not the Istio
   functions are enabled or disabled. Also used in some other monitoring
@@ -228,6 +230,12 @@ spec:
   until it finds no TCP ports in the `LISTENING` state. This is a reasonably
   safe default behavior to ensure that the proxy does not shut down until all
   other traffic has stopped.
+
+* `.Values.istio.metricsMerging`: If set to "True", then the Istio Metrics
+  Merging system will be turned on and Envoy will attempt to scrape metrics
+  from the application pod and merge them with its own. This defaults to False
+  beacuse in most environments we want to explicitly split up the metrics and
+  collect Istio metrics separate from Application metrics.
 
 ### `nd-common.istioAnnotations`
 

--- a/charts/nd-common/README.md.gotmpl
+++ b/charts/nd-common/README.md.gotmpl
@@ -206,6 +206,8 @@ spec:
 ### Values Parameters
 
 * `.Values.podLabels`
+* `.Values.monitor.path`
+* `.Values.monitor.portNumber`
 
 * `.Values.istio.enabled` (default: `True`): Controls whether or not the Istio
   functions are enabled or disabled. Also used in some other monitoring
@@ -228,6 +230,12 @@ spec:
   until it finds no TCP ports in the `LISTENING` state. This is a reasonably
   safe default behavior to ensure that the proxy does not shut down until all
   other traffic has stopped.
+
+* `.Values.istio.metricsMerging`: If set to "True", then the Istio Metrics
+  Merging system will be turned on and Envoy will attempt to scrape metrics
+  from the application pod and merge them with its own. This defaults to False
+  beacuse in most environments we want to explicitly split up the metrics and
+  collect Istio metrics separate from Application metrics.
 
 ### `nd-common.istioAnnotations`
 

--- a/charts/nd-common/templates/_istio.tpl
+++ b/charts/nd-common/templates/_istio.tpl
@@ -91,7 +91,27 @@ mesh.
 {{- $tag  := $_tag | replace "@" "_" | replace ":" "_" | trunc 63 | quote -}}
 
 {{- /* https://istio.io/latest/docs/ops/configuration/mesh/injection-concepts/ */ -}}
-sidecar.istio.io/inject: "{{ eq true .Values.istio.enabled }}"
+sidecar.istio.io/inject: {{ eq true .Values.istio.enabled | quote }}
+
+{{- /*
+Explicitly disable or enable Metrics Merging - we want to keep our Envoy
+sidecar metrics separate from the Application metrics and not force the two to
+be merged, but we also want to allow a developer to make this choice if it
+makes sense. The default is False here, but can be overridden by
+.Values.istio.metricsMerging being set to "true".
+
+See https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging
+
+*/}}
+{{- if eq true .Values.istio.metricsMerging }}
+prometheus.istio.io/merge-metrics: "true"
+prometheus.io/scrape: "true"
+prometheus.io/port: {{ .Values.monitor.portNumber | quote }}
+prometheus.io/path: {{ .Values.monitor.path }}
+{{- else }}
+prometheus.istio.io/merge-metrics: "false"
+{{- end }}
+
 {{- /* https://istio.io/latest/docs/ops/deployment/requirements/ */ -}}
 {{- if not (hasKey .Values.podLabels "app") }}
 app: {{ .Release.Name }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.21.2
+version: 0.21.3
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.4
+    version: 0.0.5
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.21.2](https://img.shields.io/badge/Version-0.21.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.21.3](https://img.shields.io/badge/Version-0.21.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -172,7 +172,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.4 |
+| file://../nd-common | nd-common | 0.0.5 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -212,6 +212,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | istio-alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
 | istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `PodMonitor` object. |
 | istio.excludeInboundPorts | list | `[]` | (`int[]`) If supplied, this is a list of TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. _The `.Values.monitor.portNumber` is already included by default. |
+| istio.metricsMerging | bool | `false` | (`bool`) If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
 | istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down. eg: preStopCommand: [ /bin/sleep, "30" ] |
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -458,6 +458,13 @@ istio:
   # preStopCommand: [ /bin/sleep, "30" ]
   preStopCommand: null
 
+  # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
+  # turned on and Envoy will attempt to scrape metrics from the application pod
+  # and merge them with its own. This defaults to False beacuse in most
+  # environments we want to explicitly split up the metrics and collect Istio
+  # metrics separate from Application metrics.
+  metricsMerging: false
+
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.
 datadog:

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,6 +13,6 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.4
+    version: 0.0.5
     # Temporary while we're under active development of this dependency chart.
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -157,7 +157,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.4 |
+| file://../nd-common | nd-common | 0.0.5 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -193,6 +193,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | istio-alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
 | istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `PodMonitor` object. |
 | istio.excludeInboundPorts | list | `[]` | (`int[]`) If supplied, this is a list of TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. _The `.Values.monitor.portNumber` is already included by default. |
+| istio.metricsMerging | bool | `false` | (`bool`) If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
 | istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down. eg: preStopCommand: [ /bin/sleep, "30" ] |
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -459,6 +459,13 @@ istio:
   # preStopCommand: [ /bin/sleep, "30" ]
   preStopCommand: null
 
+  # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
+  # turned on and Envoy will attempt to scrape metrics from the application pod
+  # and merge them with its own. This defaults to False beacuse in most
+  # environments we want to explicitly split up the metrics and collect Istio
+  # metrics separate from Application metrics.
+  metricsMerging: false
+
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.
 datadog:


### PR DESCRIPTION
By explicitly enabling or disabling it, we don't have any accidental situations where someone will get metrics scraped by Envoy and a separate PodMonitor all at the same time. We maintain the ability to turn this feature on, but default it to Off.