### PR TITLE
[nd-common] Update the PodMonitor relabelings configuration

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.4
+    version: 0.0.6
     # Temporary while we're under active development of this dependency chart.
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -152,7 +152,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.4 |
+| file://../nd-common | nd-common | 0.0.6 |
 
 ## Values
 
@@ -200,6 +200,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
 | monitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| monitor.sampleLimit | int | `25000` | (`int`) The maximum number of metrics that can be scraped - if there are more than this, then scraping will fail entirely by Prometheus. This is used as a circuit breaker to avoid blowing up Prometheus memory footprints. |
 | monitor.scheme | string | `"http"` | (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well |
 | monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -315,6 +315,11 @@ monitor:
   # -- ServiceMonitor scrape interval
   interval: null
 
+  # -- (`int`) The maximum number of metrics that can be scraped - if there are
+  # more than this, then scraping will fail entirely by Prometheus. This is
+  # used as a circuit breaker to avoid blowing up Prometheus memory footprints.
+  sampleLimit: 25000
+
   # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
 

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.5
+version: 0.0.6
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.21.3
+version: 0.21.4
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.5
+    version: 0.0.6
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.21.3](https://img.shields.io/badge/Version-0.21.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.21.4](https://img.shields.io/badge/Version-0.21.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -172,7 +172,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.5 |
+| file://../nd-common | nd-common | 0.0.6 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -226,6 +226,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
 | monitor.relabelings | list | `[]` | PodMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| monitor.sampleLimit | int | `25000` | (`int`) The maximum number of metrics that can be scraped - if there are more than this, then scraping will fail entirely by Prometheus. This is used as a circuit breaker to avoid blowing up Prometheus memory footprints. |
 | monitor.scheme | string | `"http"` | (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well |
 | monitor.scrapeTimeout | string | `nil` | PodMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | PodMonitor will use these tlsConfig settings to make the health check requests |

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -415,6 +415,11 @@ monitor:
   # -- PodMonitor scrape interval
   interval: null
 
+  # -- (`int`) The maximum number of metrics that can be scraped - if there are
+  # more than this, then scraping will fail entirely by Prometheus. This is
+  # used as a circuit breaker to avoid blowing up Prometheus memory footprints.
+  sampleLimit: 25000
+
   # -- PodMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
 

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.5.2
+version: 0.5.3
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,6 +13,6 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.5
+    version: 0.0.6
     # Temporary while we're under active development of this dependency chart.
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -157,7 +157,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.5 |
+| file://../nd-common | nd-common | 0.0.6 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -206,6 +206,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
 | monitor.relabelings | list | `[]` | PodMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| monitor.sampleLimit | int | `25000` | (`int`) The maximum number of metrics that can be scraped - if there are more than this, then scraping will fail entirely by Prometheus. This is used as a circuit breaker to avoid blowing up Prometheus memory footprints. |
 | monitor.scheme | string | `"http"` | (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well |
 | monitor.scrapeTimeout | string | `nil` | PodMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | PodMonitor will use these tlsConfig settings to make the health check requests |

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -416,6 +416,11 @@ monitor:
   # -- PodMonitor scrape interval
   interval: null
 
+  # -- (`int`) The maximum number of metrics that can be scraped - if there are
+  # more than this, then scraping will fail entirely by Prometheus. This is
+  # used as a circuit breaker to avoid blowing up Prometheus memory footprints.
+  sampleLimit: 25000
+
   # -- PodMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
 


### PR DESCRIPTION
We were missing some default labels that we apply to all of our metrics.
All the `app.kubernetes.io/` and `tags.datadoghq.com` labels. Adding
these back in should fix some dashboards.