### PR TITLE
[nd-common/simple/daemon/stateful-app]: Support for custom container name and Datadog logging configuration

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.6
+    version: 0.0.7
     # Temporary while we're under active development of this dependency chart.
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -152,7 +152,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.6 |
+| file://../nd-common | nd-common | 0.0.7 |
 
 ## Values
 
@@ -161,10 +161,14 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | affinity | object | `{}` |  |
 | args | list | `[]` | The arguments passed to the command. If unspecified the container defaults are used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
 | command | list | `[]` | The command run by the container. This overrides `ENTRYPOINT`. If not specified, the container's default entrypoint is used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
+| containerName | string | `""` |  |
 | datadog.enabled | bool | `true` | (`bool`) Whether or not the various datadog labels and options should be included or not. |
 | datadog.env | `string` | `nil` | The "env" tag to configure for the application - this maps to the Datadog environment concept for isolating traces/apm data. _We default to not setting this, so that the Datadog Agent's own "ENV" setting is used as the default behavior. Only override this in special cases._ |
 | datadog.metricsNamespace | string | `"eks"` | (`string`) The prefix to append to all metrics that are scraped by Datadog. We set this to one common value so that common metrics (like `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier dashboard creation as well as comparision between applications. |
 | datadog.metricsToScrape | list | `["\"*\""]` | (`strings[]`) A list of strings that match the metric names that Datadog should scrape from the endpoint. This defaults to `"*"` to tell it to scrape ALL metrics - however, if your app exposes too many metrics (> 2000), Datadog will drop them all on the ground. |
+| datadog.scrapeLogs.enabled | bool | `false` | (`bool`) If true, then it will enable application logging to datadog. |
+| datadog.scrapeLogs.processingRules | list | `[]` | (`map[]`) A list of map that sets different log processing rules. https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile |
+| datadog.scrapeLogs.source | `string` | `nil` | If set, this configures the "source" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the application pod via the values set in the .Values.monitor.* map. |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
         {{- with .Values.volumesString }}{{ tpl . $ | nindent 8 }}{{ end }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "nd-common.containerName" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "nd-common.imageFqdn" . }}

--- a/charts/daemonset-app/values.local.yaml
+++ b/charts/daemonset-app/values.local.yaml
@@ -1,3 +1,7 @@
 terminationGracePeriodSeconds: 30
 priorityClassName: system-node-critical
 hostNetwork: true  # makes the tests work
+datadog:
+  scrapeMetrics: true
+  scrapeLogs:
+    enabled: true

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -403,6 +403,16 @@ datadog:
   metricsToScrape:
     - '"*"'
 
+  scrapeLogs:
+    # -- (`bool`) If true, then it will enable application logging to datadog.
+    enabled: false
+    # -- (`string`) If set, this configures the "source" tag. If this is not
+    # set, the tag defaults to the `.Release.Name` for the application.
+    source: null
+    # -- (`map[]`) A list of map that sets different log processing rules.
+    # https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
+    processingRules: []
+
 tests:
   connection:
     # -- The command used to trigger the test.

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -132,6 +132,7 @@ ports:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+containerName: ""
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.6
+version: 0.0.7
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -65,6 +65,27 @@ metadata:
   ...
 ```
 
+### `nd-common.containerName`
+
+Returns the name of the application container which by default
+is set to (`.Chart.Name`), or optionally returns an override of
+the string from `.Values.containerName`. This is mostly used for
+specifying application container name.
+
+_Example Usage_:
+```yaml
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: {{ include "nd-common.fullname" . }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{ include "nd-common.containerName" . }}
+  ...
+```
+
 ### `nd-common.labels`
 
 Creates a set of common and reasonable labels applied to most of the resources

--- a/charts/nd-common/README.md.gotmpl
+++ b/charts/nd-common/README.md.gotmpl
@@ -65,6 +65,27 @@ metadata:
   ...
 ```
 
+### `nd-common.containerName`
+
+Returns the name of the application container which by default
+is set to (`.Chart.Name`), or optionally returns an override of
+the string from `.Values.containerName`. This is mostly used for
+specifying application container name.
+
+_Example Usage_:
+```yaml
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: {{`{{ include "nd-common.fullname" . }}`}}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{`{{ include "nd-common.containerName" . }}`}}
+  ...
+```
+
 ### `nd-common.labels`
 
 Creates a set of common and reasonable labels applied to most of the resources

--- a/charts/nd-common/templates/_common.tpl
+++ b/charts/nd-common/templates/_common.tpl
@@ -30,6 +30,12 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{/*
+Create a container name.
+*/}}
+{{- define "nd-common.containerName" -}}
+{{- default .Chart.Name .Values.containerName | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 
 {{- /*

--- a/charts/nd-common/templates/_datadog.tpl
+++ b/charts/nd-common/templates/_datadog.tpl
@@ -27,7 +27,22 @@ ad.datadoghq.com/{{ .Chart.Name }}.instances: |-
     }
   ]
 {{- end }}
-
+{{- /*
+This is datadog logging configuration. We take the .Values.scrapeLogs and
+.Values.scrapeLogsProcessingRules map and convert into list of objects converted
+into json supported by datadog config. If source and service tag values not provided
+we add default values to it.
+*/ -}}
+{{- if and .Values.datadog.enabled .Values.datadog.scrapeLogs.enabled }}
+ad.datadoghq.com/{{ include "nd-common.containerName" . }}.logs: |-
+  [
+    {
+      "source": {{- default .Chart.Name .Values.datadog.scrapeLogs.source }},
+      "service": {{- default .Chart.Name .Values.datadog.service  }},
+      "log_processing_rules": {{- tpl (toJson .Values.datadog.scrapeLogs.processingRules) $ }}
+    }
+  ]
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/nd-common/templates/_datadog.tpl
+++ b/charts/nd-common/templates/_datadog.tpl
@@ -28,9 +28,7 @@ ad.datadoghq.com/{{ .Chart.Name }}.instances: |-
   ]
 {{- end }}
 {{- /*
-This is datadog logging configuration. We take the .Values.scrapeLogs and
-.Values.scrapeLogsProcessingRules map and convert into list of objects converted
-into json supported by datadog config. If source and service tag values not provided
+This is datadog logging configuration. If source and service tag values not provided
 we add default values to it.
 */ -}}
 {{- if and .Values.datadog.enabled .Values.datadog.scrapeLogs.enabled }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.21.4
+version: 0.21.5
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.6
+    version: 0.0.7
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.21.4](https://img.shields.io/badge/Version-0.21.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.21.5](https://img.shields.io/badge/Version-0.21.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -172,7 +172,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.6 |
+| file://../nd-common | nd-common | 0.0.7 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -186,10 +186,14 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | autoscaling.minReplicas | int | `1` | Sets the minimum number of Pods to run |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Configures the HPA to target a particular CPU utilization percentage |
 | command | list | `[]` | The command run by the container. This overrides `ENTRYPOINT`. If not specified, the container's default entrypoint is used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
+| containerName | string | `""` |  |
 | datadog.enabled | bool | `true` | (`bool`) Whether or not the various datadog labels and options should be included or not. |
 | datadog.env | `string` | `nil` | The "env" tag to configure for the application - this maps to the Datadog environment concept for isolating traces/apm data. _We default to not setting this, so that the Datadog Agent's own "ENV" setting is used as the default behavior. Only override this in special cases._ |
 | datadog.metricsNamespace | string | `"eks"` | (`string`) The prefix to append to all metrics that are scraped by Datadog. We set this to one common value so that common metrics (like `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier dashboard creation as well as comparision between applications. |
 | datadog.metricsToScrape | list | `["\"*\""]` | (`strings[]`) A list of strings that match the metric names that Datadog should scrape from the endpoint. This defaults to `"*"` to tell it to scrape ALL metrics - however, if your app exposes too many metrics (> 2000), Datadog will drop them all on the ground. |
+| datadog.scrapeLogs.enabled | bool | `false` | (`bool`) If true, then it will enable application logging to datadog. |
+| datadog.scrapeLogs.processingRules | list | `[]` | (`map[]`) A list of map that sets different log processing rules. https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile |
+| datadog.scrapeLogs.source | `string` | `nil` | If set, this configures the "source" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the application pod via the values set in the .Values.monitor.* map. |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |

--- a/charts/simple-app/ci/datadog-with-env-values.yaml
+++ b/charts/simple-app/ci/datadog-with-env-values.yaml
@@ -1,6 +1,14 @@
 # TEST: Make sure it works to set the env
 datadog:
   env: some_value
+  service: ci_test
+  scrapeLogs:
+    enabled: true
+    source: ci
+    processingRules:
+      - type: include_at_match
+        name: include_ci_test_users
+        pattern: "@nextdoorci-test.com"
 
 # For local development, we turn on the Ingress controller and set up a simple
 # local ingress.

--- a/charts/simple-app/ci/datadog-without-env-values.yaml
+++ b/charts/simple-app/ci/datadog-without-env-values.yaml
@@ -1,6 +1,8 @@
 # TEST: Make sure it works to NOT set the env
 datadog:
   env: null
+  scrapeLogs:
+    enabled: true
 
 # For local development, we turn on the Ingress controller and set up a simple
 # local ingress.

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           resources:
             {{- toYaml .Values.proxySidecar.resources | nindent 12 }}
         {{- end }}
-        - name: {{ .Chart.Name }}
+        - name: {{ include "nd-common.containerName" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "nd-common.imageFqdn" . }}

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -30,3 +30,5 @@ secrets:
 
 datadog:
   scrapeMetrics: true
+  scrapeLogs:
+    enabled: true

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -141,6 +141,7 @@ ports:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+containerName: ""
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -505,6 +505,16 @@ datadog:
   metricsToScrape:
     - '"*"'
 
+  scrapeLogs:
+    # -- (`bool`) If true, then it will enable application logging to datadog.
+    enabled: false
+    # -- (`string`) If set, this configures the "source" tag. If this is not
+    # set, the tag defaults to the `.Release.Name` for the application.
+    source: null
+    # -- (`map[]`) A list of map that sets different log processing rules.
+    # https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
+    processingRules: []
+
 tests:
   connection:
     # -- The command used to trigger the test.

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,6 +13,6 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.6
+    version: 0.0.7
     # Temporary while we're under active development of this dependency chart.
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -157,7 +157,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.6 |
+| file://../nd-common | nd-common | 0.0.7 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -167,10 +167,14 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | affinity | object | `{}` |  |
 | args | list | `[]` | The arguments passed to the command. If unspecified the container defaults are used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
 | command | list | `[]` | The command run by the container. This overrides `ENTRYPOINT`. If not specified, the container's default entrypoint is used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
+| containerName | string | `""` |  |
 | datadog.enabled | bool | `true` | (`bool`) Whether or not the various datadog labels and options should be included or not. |
 | datadog.env | `string` | `nil` | The "env" tag to configure for the application - this maps to the Datadog environment concept for isolating traces/apm data. _We default to not setting this, so that the Datadog Agent's own "ENV" setting is used as the default behavior. Only override this in special cases._ |
 | datadog.metricsNamespace | string | `"eks"` | (`string`) The prefix to append to all metrics that are scraped by Datadog. We set this to one common value so that common metrics (like `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier dashboard creation as well as comparision between applications. |
 | datadog.metricsToScrape | list | `["\"*\""]` | (`strings[]`) A list of strings that match the metric names that Datadog should scrape from the endpoint. This defaults to `"*"` to tell it to scrape ALL metrics - however, if your app exposes too many metrics (> 2000), Datadog will drop them all on the ground. |
+| datadog.scrapeLogs.enabled | bool | `false` | (`bool`) If true, then it will enable application logging to datadog. |
+| datadog.scrapeLogs.processingRules | list | `[]` | (`map[]`) A list of map that sets different log processing rules. https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile |
+| datadog.scrapeLogs.source | `string` | `nil` | If set, this configures the "source" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the application pod via the values set in the .Values.monitor.* map. |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
           resources:
             {{- toYaml .Values.proxySidecar.resources | nindent 12 }}
         {{- end }}
-        - name: {{ .Chart.Name }}
+        - name: {{ include "nd-common.containerName" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "nd-common.imageFqdn" . }}

--- a/charts/stateful-app/values.local.yaml
+++ b/charts/stateful-app/values.local.yaml
@@ -11,3 +11,5 @@ ingress:
 terminationGracePeriodSeconds: 30
 datadog:
   scrapeMetrics: true
+  scrapeLogs:
+    enabled: true

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -506,6 +506,16 @@ datadog:
   metricsToScrape:
     - '"*"'
 
+  scrapeLogs:
+    # -- (`bool`) If true, then it will enable application logging to datadog.
+    enabled: false
+    # -- (`string`) If set, this configures the "source" tag. If this is not
+    # set, the tag defaults to the `.Release.Name` for the application.
+    source: null
+    # -- (`map[]`) A list of map that sets different log processing rules.
+    # https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
+    processingRules: []
+
 tests:
   connection:
     # -- The command used to trigger the test.

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -162,6 +162,7 @@ ports:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+containerName: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This PR adds support for providing custom container name to simple-app/daemonset/stateful-app. If not specified, it will default to `.Chart.Name` . Also it adds functionality to scrape application logs by Datadog. It adds support for providing tags (service and source) along with advanced log processing rules configuration https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=docker .

Proof it works 

![Screen Shot 2022-03-24 at 4 47 46 PM](https://user-images.githubusercontent.com/99209256/160007809-53820af3-4a76-462a-b877-7956e60d693d.png)

![Screen Shot 2022-03-24 at 4 48 23 PM](https://user-images.githubusercontent.com/99209256/160007811-d0903679-e6db-4a54-8dce-20b0a5f94a7c.png)

![Screen Shot 2022-03-24 at 4 48 55 PM](https://user-images.githubusercontent.com/99209256/160007813-d118f370-dce1-4b5c-a550-da8363e6df9a.png)


