### PR TITLE
[local-kafka] Update strimzi kafka operator to 0.28.0

### DIFF
--- a/charts/local-kafka/Chart.yaml
+++ b/charts/local-kafka/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: local-kafka
 description: Local Development spinup of Strimzi-managed Kafka
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.26.0
+    version: 0.28.0
     repository: https://strimzi.io/charts
     condition: strimzi-kafka-operator.enabled

--- a/charts/local-kafka/README.md
+++ b/charts/local-kafka/README.md
@@ -2,7 +2,7 @@
 
 Local Development spinup of Strimzi-managed Kafka
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [strimzi_op]: https://github.com/strimzi/strimzi-kafka-operator
 
@@ -34,7 +34,7 @@ project's development namespace.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://strimzi.io/charts | strimzi-kafka-operator | 0.26.0 |
+| https://strimzi.io/charts | strimzi-kafka-operator | 0.28.0 |
 
 ## Values
 
@@ -47,6 +47,10 @@ project's development namespace.
 | listeners | list | `[{"configuration":{"brokers":[{"advertisedHost":"127.0.0.1","broker":0,"nodePort":32000}]},"name":"external","port":9094,"tls":false,"type":"nodeport"}]` | Additional configurable listeners for connecting to brokers. |
 | namespaceOverride | string | `nil` | Optionally force the namespace that the resources in this stack are launched in. Without this, the default namespace that the Helm chart is being put into is used. It is recommended to keep this empty. |
 | strimzi-kafka-operator.enabled | bool | `true` | Set to `false` to intentionally disable installation of the Operator. This is useful if you are running this stack in a local dev environment where you might have multiple Kafka environments, and are already running the Strimzi operator. |
+| strimzi-kafka-operator.image.name | string | `"operator"` |  |
+| strimzi-kafka-operator.image.registry | string | `""` |  |
+| strimzi-kafka-operator.image.repository | string | `""` |  |
+| strimzi-kafka-operator.image.tag | string | `""` |  |
 | strimzi-kafka-operator.livenessProbe.initialDelaySeconds | int | `300` |  |
 | strimzi-kafka-operator.logLevel | string | `"DEBUG"` | Run the Operator in a pretty verbose mode - allowing developers to more easily understand if there are any problems with the operator installation or its behavior. |
 | strimzi-kafka-operator.readinessProbe.initialDelaySeconds | int | `300` |  |

--- a/charts/local-kafka/README.md
+++ b/charts/local-kafka/README.md
@@ -47,10 +47,10 @@ project's development namespace.
 | listeners | list | `[{"configuration":{"brokers":[{"advertisedHost":"127.0.0.1","broker":0,"nodePort":32000}]},"name":"external","port":9094,"tls":false,"type":"nodeport"}]` | Additional configurable listeners for connecting to brokers. |
 | namespaceOverride | string | `nil` | Optionally force the namespace that the resources in this stack are launched in. Without this, the default namespace that the Helm chart is being put into is used. It is recommended to keep this empty. |
 | strimzi-kafka-operator.enabled | bool | `true` | Set to `false` to intentionally disable installation of the Operator. This is useful if you are running this stack in a local dev environment where you might have multiple Kafka environments, and are already running the Strimzi operator. |
-| strimzi-kafka-operator.image.name | string | `"operator"` |  |
-| strimzi-kafka-operator.image.registry | string | `""` |  |
-| strimzi-kafka-operator.image.repository | string | `""` |  |
-| strimzi-kafka-operator.image.tag | string | `""` |  |
+| strimzi-kafka-operator.image.name | string | `"operator"` | (`str`) Cluster Operator image name |
+| strimzi-kafka-operator.image.registry | string | `""` | (`str`) Override default Cluster Operator image registry |
+| strimzi-kafka-operator.image.repository | string | `""` | (`str`) Override default Cluster Operator image repository |
+| strimzi-kafka-operator.image.tag | string | `""` | (`str`) Override default Cluster Operator image tag |
 | strimzi-kafka-operator.livenessProbe.initialDelaySeconds | int | `300` |  |
 | strimzi-kafka-operator.logLevel | string | `"DEBUG"` | Run the Operator in a pretty verbose mode - allowing developers to more easily understand if there are any problems with the operator installation or its behavior. |
 | strimzi-kafka-operator.readinessProbe.initialDelaySeconds | int | `300` |  |

--- a/charts/local-kafka/values.yaml
+++ b/charts/local-kafka/values.yaml
@@ -35,6 +35,15 @@ listeners:
 
 # These settings directly get passed into the Strimzi Kafka Operator helm chart.
 strimzi-kafka-operator:
+
+  # These overwrite default Cluster Operator image settings.
+  # E.g. one may need to set image.tag "0.28.0-arm64" explicitly for ARM64 arch
+  image:
+    registry: ""
+    repository: ""
+    name: operator
+    tag: ""
+
   # -- Set to `false` to intentionally disable installation of the Operator.
   # This is useful if you are running this stack in a local dev environment
   # where you might have multiple Kafka environments, and are already running

--- a/charts/local-kafka/values.yaml
+++ b/charts/local-kafka/values.yaml
@@ -39,9 +39,13 @@ strimzi-kafka-operator:
   # These overwrite default Cluster Operator image settings.
   # E.g. one may need to set image.tag "0.28.0-arm64" explicitly for ARM64 arch
   image:
+    # -- (`str`) Override default Cluster Operator image registry
     registry: ""
+    # -- (`str`) Override default Cluster Operator image repository
     repository: ""
+    # -- (`str`) Cluster Operator image name
     name: operator
+    # -- (`str`) Override default Cluster Operator image tag
     tag: ""
 
   # -- Set to `false` to intentionally disable installation of the Operator.


### PR DESCRIPTION
`strimzi-kafka-operator` 0.26.0 takes forever to start on M1 chip, and it seems that version doesn't have a tag for arm64 neither. 0.28.0 takes 4-5mins on my M1, which is still be slower than Intel, but is significantly faster than previous version. Also exposed image config in values.yaml for customized settings.