### PR TITLE
Fix simple-app ignoring the sidecar image tag

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.21.10
+version: 0.21.11
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.21.10](https://img.shields.io/badge/Version-0.21.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.21.11](https://img.shields.io/badge/Version-0.21.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Gathers the application image tag. This allows overriding the tag with a master
 setting.
 */}}
 {{- define "simple-app.proxyImageFqdn" -}}
-{{- $tag := include "nd-common.imageTag" . }}
+{{- $tag := .Values.proxySidecar.image.tag | default (include "nd-common.imageTag" .) }}
 {{- if hasPrefix "sha256:" $tag }}
 {{- .Values.proxySidecar.image.repository }}@{{ $tag }}
 {{- else }}


### PR DESCRIPTION
The value for `proxySidecar.image.tag` was being ignored in `simple-app.proxyImageFqdn` leading to the main image tag always being used