### PR TITLE
[rollout-app] New Argo Rollouts based Deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,15 +24,13 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
 
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.2.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -40,6 +38,9 @@ jobs:
           changed=$(ct --config ct.yaml list-changed)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
+          fi
+          if [[ "$changed" == *"rollout-app"* ]]; then
+            echo "::set-output name=rollout::true"
           fi
 
       - name: Run chart-testing (lint)
@@ -49,14 +50,14 @@ jobs:
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Install Argo Rollouts Controller
+        if: steps.list-changed.outputs.rollout == 'true'
+        run: |
+          make -C charts/rollout-app install_rollouts
+
       - name: Install CRDs
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml \
-                        -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml \
-                        -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml \
-                        -f https://raw.githubusercontent.com/istio/istio/1.13.2/manifests/charts/base/crds/crd-all.gen.yaml \
-                        -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.crds.yaml
+        run: make crds
 
       - name: Run chart-testing (install)
         run: ct --config ct.yaml install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: crds
+crds: 
+	kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml \
+		-f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml \
+		-f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml \
+		-f https://raw.githubusercontent.com/istio/istio/1.13.2/manifests/charts/base/crds/crd-all.gen.yaml \
+		-f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.crds.yaml

--- a/charts/rollout-app/.helmignore
+++ b/charts/rollout-app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: rollout-app
+description: Argo Rollout-based Application Helm Chart
+type: application
+version: 0.0.1
+appVersion: latest
+maintainers:
+  - name: diranged
+    email: matt@nextdoor.com
+dependencies:
+  - name: istio-alerts
+    version: 0.1.3
+    repository: https://k8s-charts.nextdoor.com
+    condition: istio-alerts.enabled
+  - name: nd-common
+    version: 0.0.10
+    repository: file://../nd-common

--- a/charts/rollout-app/Makefile
+++ b/charts/rollout-app/Makefile
@@ -1,0 +1,16 @@
+NAMESPACE := rollout-app
+
+LOCAL_DEPS_TARGET := install_rollouts
+
+.PHONY: crds
+crds:
+	make -C ../.. crds
+
+.PHONY: install_rollouts
+install_rollouts: crds
+	kubectl create namespace argo-rollouts || true
+	kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml && \
+	kubectl wait deployment -n argo-rollouts argo-rollouts --for condition=Available=True --timeout=90s
+
+include ../../contrib/Helm.mk
+include ../../contrib/Testing.mk

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -1,0 +1,270 @@
+# rollout-app
+
+Argo Rollout-based Application Helm Chart
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+
+[analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
+[argo_rollouts]: https://argoproj.github.io/argo-rollouts/
+[bluegreen]: https://argoproj.github.io/argo-rollouts/features/bluegreen/
+[canary]: https://argoproj.github.io/argo-rollouts/features/canary/
+[experiment]: https://argoproj.github.io/argo-rollouts/features/experiment/
+[rollout]: https://argoproj.github.io/argo-rollouts/features/specification/
+
+This chart launches a horizontally scalable application through the use of the
+Argo [`Rollout`][rollout] custom resource. See the [Argo Rollouts - Kubernetes
+Progressive Delivery Controller][argo_rollouts] for more information about
+how these work, and the various custom resource definitions.
+
+## Rollout Resources Supported
+
+### [`Rollout`][rollout]
+
+The [`templates/rollout.yaml`](templates/rollout.yaml) template controls the
+creation of the [`Rollout`][rollout] resource. This resource is the replacement
+for the standard Kubernetes `Deployment` resource, but has two new deployment
+strategies - [`BlueGreen`][bluegreen] and [`Canary`][canary].
+
+The `.strategy` value can be set to `blueGreen` or `canary` to control which
+behavior you are looking for in your `Rollout` resource. From there, you can
+customize the deployment behavior through the `.blueGreen` or `.canary` values.
+
+### [`AnalysisTemplate`][analysistemplate] (_Not Supported_)
+
+At this time, you will need to create your own
+[`AnalysisTemplate`][analysistemplate] resources to describe how to analyze the
+behavior of an application and decide if it is healthy or not. In future
+releases, we may build support into this chart to manage those resources.
+
+_You can refer to an `AnalysisTemplate` you have created through the
+`.blueGreen.postPromotionAnalysis`, `.blueGreen.prePromotionAnalysis` and
+`.canary.analysis` parameters_.
+
+### [`Experiment`][experiment] (_Not Supported_)
+
+At this time, you will need to create your own [`Experiment`][experiment]
+resources. These resources are highly customized, and likely not worth trying
+to build in any default experiments into this chart.
+
+## Monitoring
+
+This chart makes the assumption that you _do_ have a Prometheus-style
+monitoring endpoint configured. See the `Values.monitor.portName`,
+`Values.monitor.portNumber` and `Values.monitor.path` settings for informing
+the chart of where your metrics are exposed.
+
+If you are operating in an Istio Service Mesh, see the
+[Istio](#istio-networking-support) section below for details on how monitoring
+works. Otherwise, see the `Values.serviceMonitor` settings to configure a
+Prometheus ServiceMonitor resource to monitor your application.
+
+## Datadog Agent Support
+
+This chart supports operating in environments where the Datadog Agent is
+running. If you set the `Values.datadog.enabled` flag, then a series of
+additional Pod Annotations, Labels and Environment Variables will be
+automatically added in to your deployment. See the `Values.datadog` parameters
+for further information.
+
+## Istio Networking Support
+
+### Monitoring through the Sidecar Proxy
+
+[metrics_merging]: https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging
+
+When running your Pod within an Istio Mesh, access to the `metrics` endpoint
+for your Pod can be obscured by the mesh itself which sits in front of the
+metrics port and may require that all clients are coming in through the
+mesh natively. The simplest way around this is to use [Istio Metrics
+Merging][metrics_merging] - where the Sidecar container is responsible for
+scraping your application's `metrics` port, merging the metrics with its own,
+and then Prometheus is configured to pull all of the metrics from the Sidecar.
+
+There are several advantages to this model.
+
+* It's much simpler - developers do not need to create `ServiceMonitor` or
+  `PodMonitor` resources because the Prometheus system is already configured to
+  discover all `istio-proxy` sidecar containers and collect their metrics.
+
+* Your application is not exposed outside of the service mesh to anybody - the
+  `istio-proxy` sidecar handles that for you.
+
+* There are fewer individual configurations for Prometheus, letting it's
+  configuration be simpler and lighter weight. It runs fewer "scrape" jobs,
+  improving its overall performance.
+
+This feature is turned on by default if you set `Values.istio.enabled=true` and
+`Values.monitor.enabled=true`.
+
+## Secrets
+A `Secret` or `KMSSecret` resource would be created and mounted into the container
+based upon the `Values.secrets` and `Values.secretsEngine` being populated.
+The `Secret` resource is generally used for local dev and/or CI test.
+Secret` resources can be created by setting the following:
+```
+secrets:
+  FOO_BAR: my plaintext secret
+secretsEngine: plaintext
+```
+Alternatively, `KMSSecret` can be generated using the following example:
+```
+secrets:
+  FOO_BAR: AQIA...
+secretsEngine: kms
+kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
+```
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../nd-common | nd-common | 0.0.10 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` | The arguments passed to the command. If unspecified the container defaults are used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
+| autoscaling.enabled | bool | `false` | Controls whether or not an HorizontalPodAutoscaler resource is created. |
+| autoscaling.maxReplicas | int | `100` | Sets the maximum number of Pods to run |
+| autoscaling.minReplicas | int | `1` | Sets the minimum number of Pods to run |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Configures the HPA to target a particular CPU utilization percentage |
+| blueGreen.antiAffinity | `map` | `nil` | Check out the Anti Affinity document document for more information. |
+| blueGreen.autoPromotionEnabled | `bool` | `nil` | The AutoPromotionEnabled will make the rollout automatically promote the new ReplicaSet to the active service once the new ReplicaSet is healthy. This field is defaulted to true if it is not specified. |
+| blueGreen.autoPromotionSeconds | `int` | `nil` | The AutoPromotionSeconds will make the rollout automatically promote the new ReplicaSet to active Service after the AutoPromotionSeconds time has passed since the rollout has entered a paused state. If the AutoPromotionEnabled field is set to true, this field will be ignored |
+| blueGreen.maxUnavailable | `int` | `nil` | The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxSurge is 0. |
+| blueGreen.postPromotionAnalysis | `map` | `nil` | Configures the [Analysis](https://argoproj.github.io/argo-rollouts/features/analysis/#bluegreen-pre-promotion-analysis) after the traffic switch to new version. If the analysis run fails or errors out, the Rollout enters an aborted state and switch traffic back to the previous stable Replicaset. If `scaleDownDelaySeconds` is specified, the controller will cancel any AnalysisRuns at time of `scaleDownDelay` to scale down the ReplicaSet. If it is omitted, and post analysis is specified, it will scale down the ReplicaSet only after the AnalysisRun completes (with a minimum of 30 seconds). |
+| blueGreen.prePromotionAnalysis | `map` | `nil` | Configures the [Analysis](https://argoproj.github.io/argo-rollouts/features/analysis/#bluegreen-pre-promotion-analysis) before it switches traffic to the new version. The AnalysisRun can be used to block the Service selector switch until the AnalysisRun finishes successful. The success or failure of the analysis run decides if the Rollout will switch traffic, or abort the Rollout completely. |
+| blueGreen.previewReplicaCount | `int` | `nil` | The PreviewReplicaCount field will indicate the number of replicas that the new version of an application should run. Once the application is ready to promote to the active service, the controller will scale the new ReplicaSet to the value of the spec.replicas. The rollout will not switch over the active service to the new ReplicaSet until it matches the spec.replicas count. This feature is mainly used to save resources during the testing phase. If the application does not need a fully scaled up application for the tests, this feature can help save some resources. If omitted, the preview ReplicaSet stack will be scaled to 100% of the replicas. |
+| blueGreen.scaleDownDelayRevisionLimit | `int` | `nil` | The ScaleDownDelayRevisionLimit limits the number of old active ReplicaSets to keep scaled up while they wait for the scaleDownDelay to pass after being removed from the active service. If omitted, all ReplicaSets will be retained for the specified scaleDownDelay |
+| blueGreen.scaleDownDelaySeconds | `int` | `nil` | The ScaleDownDelaySeconds is used to delay scaling down the old ReplicaSet after the active Service is switched to the new ReplicaSet. |
+| canary.analysis | `map` | `nil` | Configure the background [Analysis](https://argoproj.github.io/argo-rollouts/features/analysis/) to execute during the rollout. If the analysis is unsuccessful the rollout will be aborted. |
+| canary.antiAffinity | `map` | `nil` | Check out the Anti Affinity document document for more information. |
+| canary.canaryMetadata | `map` | `nil` | Metadata which will be attached to the canary pods. This metadata will only exist during an update, since there are no canary pods in a fully promoted rollout. |
+| canary.maxSurge | `int` or `string` | `nil` | The maximum number of pods that can be scheduled above the original number of pods. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of the update (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used.# Example: when this is set to 30%, the new RC can be scaled up by 30% immediately when the rolling update starts. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of original pods. +optional |
+| canary.maxUnavailable | `int` or `string` | `nil` | The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if  MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down by 30% immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that at least 70% of original number of pods are available at all times during the update. +optional |
+| canary.scaleDownDelayRevisionLimit | `int` | `nil` | Limits the number of old RS that can run at one time before getting scaled down. Defaults to nil |
+| canary.scaleDownDelaySeconds | `int` | `nil` | Adds a delay before scaling down the previous ReplicaSet when the canary strategy is used with traffic routing (default 30 seconds). A delay in scaling down the previous ReplicaSet is needed after switching the stable service selector to point to the new ReplicaSet, in order to give time for traffic providers to re-target the new pods. This value is ignored with basic, replica-weighted canary without traffic routing. |
+| canary.stableMetadata | `map` | `nil` | metadata which will be attached to the stable pods |
+| canary.steps | list | `[{"setWeight":20},{"pause":{"duration":"5m"}},{"setWeight":40},{"pause":{"duration":"5m"}},{"setWeight":80}]` | (`map[]`) This **required** parameter defines the canary rollout process. Strictly speaking, the Argo Rollouts controller does not require that you define a set of steps .. but the ArgoCD integration with Argo Rollouts does require that these steps be defined, otherwise it fails. Read the [documentation here](https://argoproj.github.io/argo-rollouts/features/canary/#example) to learn more about the available steps, and how you can configure them. |
+| command | list | `[]` | The command run by the container. This overrides `ENTRYPOINT`. If not specified, the container's default entrypoint is used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
+| containerName | string | `""` |  |
+| datadog.enabled | bool | `true` | (`bool`) Whether or not the various datadog labels and options should be included or not. |
+| datadog.env | `string` | `nil` | The "env" tag to configure for the application - this maps to the Datadog environment concept for isolating traces/apm data. _We default to not setting this, so that the Datadog Agent's own "ENV" setting is used as the default behavior. Only override this in special cases._ |
+| datadog.metricsNamespace | string | `"eks"` | (`string`) The prefix to append to all metrics that are scraped by Datadog. We set this to one common value so that common metrics (like `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier dashboard creation as well as comparision between applications. |
+| datadog.metricsToScrape | list | `["\"*\""]` | (`strings[]`) A list of strings that match the metric names that Datadog should scrape from the endpoint. This defaults to `"*"` to tell it to scrape ALL metrics - however, if your app exposes too many metrics (> 2000), Datadog will drop them all on the ground. |
+| datadog.scrapeLogs.enabled | bool | `false` | (`bool`) If true, then it will enable application logging to datadog. |
+| datadog.scrapeLogs.processingRules | list | `[]` | (`map[]`) A list of map that sets different log processing rules. https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile |
+| datadog.scrapeLogs.source | `string` | `nil` | If set, this configures the "source" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
+| datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the application pod via the values set in the .Values.monitor.* map. |
+| datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
+| env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
+| envFrom | list | `[]` | Pull all of the environment variables listed in a ConfigMap into the Pod. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables for more details. |
+| fullnameOverride | string | `""` |  |
+| image.forceTag | String | `nil` | Forcefully overrides the `image.tag` setting - this is useful if you have an outside too that automatically updates the `image.tag` value, but you want your application operators to be able to squash that override themselves. |
+| image.pullPolicy | string | `"IfNotPresent"` | (String) Always, Never or IfNotPresent |
+| image.repository | string | `"nginx"` | (String) The Docker image name and repository for your application |
+| image.tag | String | `nil` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | Supply a reference to a Secret that can be used by Kubernetes to pull down the Docker image. This is only used in local development, in combination with our `kube_create_ecr_creds` function from dotfiles. |
+| ingress.annotations | object | `{}` | Any annotations you wish to add to the ALB. See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/ for more details. |
+| ingress.enabled | bool | `false` |  |
+| ingress.host | string | `"{{ include \"nd-common.fullname\" . }}.{{ .Release.Namespace }}"` | This setting configures the ALB to listen specifically to requests for this hostname. It _also_ ties into the external-dns controller and automatically provisions DNS hostnames matching this value (presuming that they are allowed by the cluster settings). |
+| ingress.path | string | `"/"` | See the `ingress.pathType` setting documentation. |
+| ingress.pathType | string | `"Prefix"` | https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types |
+| ingress.port | string | `nil` | If set, this will override the `service.portName` parameter, and the `Service` object will point specifically to this port number on the backing Pods. |
+| ingress.portName | string | `"http"` | This is the port "name" that the `Service` will point to on the backing Pods. This value must match one of the values of `.name` in the `Values.ports` configuration. |
+| ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
+| istio-alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
+| istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `PodMonitor` object. |
+| istio.excludeInboundPorts | list | `[]` | (`int[]`) If supplied, this is a list of TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. _The `.Values.monitor.portNumber` is already included by default. |
+| istio.metricsMerging | bool | `false` | (`bool`) If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
+| istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down. eg: preStopCommand: [ /bin/sleep, "30" ] |
+| kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
+| livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
+| minReadySeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds |
+| monitor.annotations | object | `{}` | (`map`) PodMonitor annotations. |
+| monitor.enabled | bool | `true` | (`bool`) If enabled, PodMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
+| monitor.interval | string | `nil` | PodMonitor scrape interval |
+| monitor.labels | object | `{}` | Additional PodMonitor labels. |
+| monitor.metricRelabelings | list | `[]` | PodMonitor MetricRelabelConfigs to apply to samples before ingestion. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
+| monitor.path | string | `"/metrics"` | (`string`) Path to scrape metrics from within your Pod. |
+| monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
+| monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
+| monitor.relabelings | list | `[]` | PodMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| monitor.sampleLimit | int | `25000` | (`int`) The maximum number of metrics that can be scraped - if there are more than this, then scraping will fail entirely by Prometheus. This is used as a circuit breaker to avoid blowing up Prometheus memory footprints. |
+| monitor.scheme | string | `"http"` | (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well |
+| monitor.scrapeTimeout | string | `nil` | PodMonitor scrape timeout in Go duration format (e.g. 15s) |
+| monitor.tlsConfig | string | `nil` | PodMonitor will use these tlsConfig settings to make the health check requests |
+| nameOverride | string | `""` |  |
+| network.allowedNamespaces | list | `[]` | (`strings[]`) A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
+| nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
+| podAnnotations | object | `{}` | (`Map`) List of Annotations to be added to the PodSpec |
+| podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |
+| podLabels | object | `{}` | (`Map`) List of Labels to be added to the PodSpec |
+| podSecurityContext | object | `{}` |  |
+| ports | list | `[{"containerPort":80,"name":"http","port":null,"protocol":"TCP"}]` | (`ContainerPort[]`) A list of Port objects that are exposed by the service. These ports are applied to the main container, or the proxySidecar container (if enabled). The port list is also used to generate Network Policies that allow ingress into the pods. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#containerport-v1-core for details. **Note: We have added an optional "port" field to this list that allows the user to override the Service Port (for example 80) that a client  connects to, without altering the Container Port (say, 8080) that is listening for connections. |
+| preStopCommand | list | `["/bin/sleep","10"]` | Before a pod gets terminated, Kubernetes sends a SIGTERM signal to every container and waits for period of time (10s by default) for all containers to exit gracefully. If your app doesn't handle the SIGTERM signal or if it doesn't exit within the grace period, Kubernetes will kill the container and any inflight requests that your app is processing will fail. Make sure you set this to SHORTER than the terminationGracePeriod (30s default) setting. https://docs.flagger.app/tutorials/zero-downtime-deployments#graceful-shutdown |
+| progressDeadlineSeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds |
+| prometheusRules.CPUThrottlingHigh | object | `{"for":"15m","severity":"warning","threshold":65}` | Container is being throttled by the CGroup - needs more resources. |
+| prometheusRules.ContainerWaiting | object | `{"for":"1h","severity":"warning"}` | Pod container waiting longer than threshold |
+| prometheusRules.DeploymentGenerationMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment generation mismatch due to possible roll-back |
+| prometheusRules.DeploymentReplicasMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment has not matched the expected number of replicas |
+| prometheusRules.HpaMaxedOut | object | `{"for":"15m","severity":"warning"}` | HPA is running at max replicas |
+| prometheusRules.HpaReplicasMismatch | object | `{"for":"15m","severity":"warning"}` | HPA has not matched descired number of replicas |
+| prometheusRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
+| prometheusRules.PodCrashLooping | object | `{"for":"15m","severity":"warning"}` | Pod is crash looping |
+| prometheusRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| prometheusRules.additionalRuleLabels | object | `{}` | (`map`) Additional custom labels attached to every PrometheusRule |
+| prometheusRules.enabled | bool | `true` | (`bool`) Whether or not to enable the container rules template |
+| proxySidecar.enabled | bool | `false` | (Boolean) Enables injecting a pre-defined reverse proxy sidecar container into the Pod containers list. |
+| proxySidecar.env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
+| proxySidecar.envFrom | list | `[]` | Pull all of the environment variables listed in a ConfigMap into the Pod. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables for more details. |
+| proxySidecar.image.pullPolicy | string | `"IfNotPresent"` | (String) Always, Never or IfNotPresent |
+| proxySidecar.image.repository | string | `"nginx"` | (String) The Docker image name and repository for the sidecar |
+| proxySidecar.image.tag | string | `"latest"` | (String) The Docker tag for the sidecar |
+| proxySidecar.name | string | `"proxy"` | (String) The name of the proxy sidecar container |
+| proxySidecar.resources | object | `{}` | A PodSpec "Resources" object for the proxy container |
+| proxySidecar.volumeMounts | list | `[]` | List of VolumeMounts that are applied to the proxySidecar container - these must refer to volumes set in the `Values.volumes` parameter. |
+| readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "readinessProbe" configuration object. Note that this readinessProbe will be applied to the proxySidecar container instead if that is enabled. |
+| replicaCount | int | `2` | (`int`) The number of Pods to start up by default. If the `autoscaling.enabled` parameter is set, then this serves as the "start scale" for an application. Setting this to `null` prevents the setting from being applied at all in the PodSpec, leaving it to Kubernetes to use the default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas |
+| resources | object | `{}` |  |
+| revisionHistoryLimit | int | `3` | (`int`) The default revisionHistoryLimit in Kubernetes is 10 - which is just really noisy. Set our default to 3. https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy |
+| runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/simple-app/README.md"` | The URL of the runbook for this service. |
+| secrets | object | `{}` | (`Map`) Map of environment variables to plaintext secrets or KMS encrypted secrets. |
+| secretsEngine | string | `"plaintext"` | (String) Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `Secret`). kms || plaintext are possible values. |
+| securityContext | object | `{}` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| startupProbe | string | `nil` | A PodSpec container "startupProbe" configuration object. Note that this startupProbe will be applied to the proxySidecar container instead if that is enabled. |
+| strategy | string | `"blueGreen"` | (`map`) Required - Either a [`BlueGreen`](https://argoproj.github.io/argo-rollouts/features/bluegreen/) or [`Canary`](https://argoproj.github.io/argo-rollouts/features/canary/) strategy map. -- (`string`) Chooses which Rollout strategy to use - either `blueGreen` or `canary`. Use `.Values.blueGreen` and `.Values.canary` to customize the actual behavior of the rollout. |
+| targetArchitecture | string | `"amd64"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target host architecture. If set to null/empty-string, then this value will not be set. |
+| targetOperatingSystem | string | `"linux"` | (`string`) If set, this value will be used in the .spec.nodeSelector to ensure that these pods specifically launch on the desired target Operating System. Must be set. |
+| terminationGracePeriodSeconds | string | `nil` | https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution |
+| tests.connection.args | list | `["{{ include \"nd-common.fullname\" . }}"]` | A list of arguments passed into the command. These are run through the tpl function. |
+| tests.connection.command | list | `["curl","--retry-connrefused","--retry","5"]` | The command used to trigger the test. |
+| tests.connection.image.repository | string | `"curlimages/curl"` | Sets the image-name that will be used in the "connection" integration test. If this is left empty, then the .image.repository value will be used instead (and the .image.tag will also be used). By default, prefer the latest official version to handle cases where the app image provides either no curl binary or an outdated one. |
+| tests.connection.image.tag | string | `nil` | Sets the tag that will be used in the "connection" integration test. If this is left empty, the default is "latest" |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| virtualService.annotations | object | `{}` | Any annotations you wish to add to the `VirtualService` resource. See https://istio.io/latest/docs/reference/config/annotations/ for more details. |
+| virtualService.corsPolicy | object | `{}` | (`map`) If set, this will populate the corsPolicy setting for the VirtualService. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy for more details. |
+| virtualService.enabled | bool | `false` | (Boolean) Maps the Service to an Istio IngressGateway, exposing the service outside of the Kubernetes cluster. |
+| virtualService.gateways | list | `[]` | The name of the Istio `Gateway` resource that this `VirtualService` will register with. You can get a list of the avaialable `Gateways` by running `kubectl -n istio-system get gateways`. Not specifying a Gateway means that you are creating a VirtualService routing definition only inside of the Kubernetes cluster, which is totally reasonable if you want to do that. |
+| virtualService.hosts | list | `["{{ include \"nd-common.fullname\" . }}"]` | A list of destination hostnames that this VirtualService will accept traffic for. Multiple names can be listed here. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService for more details. |
+| virtualService.matches | object | `{}` | (`map[]`) A list of Istio `HTTPMatchRequest` objects that will be applied to the VirtualService. This is the more advanced and customizable way of controlling which paths get sent to your backend. These are added _in addition_ to the `paths` or `path` settings. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest for examples. |
+| virtualService.namespace | string | `"istio-system"` | The namespace where the Istio services are operating. Do not change this. |
+| virtualService.path | string | `"/"` | The default path prefix that the `VirtualService` will match requests against to pass to the default `Service` object in this deployment. |
+| virtualService.paths | list | `[]` | (`string[]`) List of optional path prefixes that the `VirtualService` will use to match requests against and will pass to the `Service` object in this deployment. This list replaces the `path` prefix above - use one or the other, do not use both. |
+| virtualService.port | int | `80` | This is the backing Pod port _number_ to route traffic to. This must match a `containerPort` in the `Values.ports` list. |
+| virtualService.retries | object | `{}` | (`map`) Pass in an optional [`HTTPRetry`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRetry) configuration here to control how services retry their failed requests to the backend service. The default behavior is to retry 2 times if a 503 is returned. |
+| virtualService.tls | string | `""` |  |
+| volumeMounts | list | `[]` | List of VolumeMounts that are applied to the application container - these must refer to volumes set in the `Values.volumes` parameter. |
+| volumes | list | `[]` | A list of 'volumes' that can be mounted into the Pod. See https://kubernetes.io/docs/concepts/storage/volumes/. |
+| volumesString | string | `""` | A stringified list of 'volumes' similar to the `Values.volumes` parameter, but this one gets run through the `tpl` function so that you can use templatized values if you need to. See https://kubernetes.io/docs/concepts/storage/volumes/. |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -1,0 +1,120 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" .  }}{{ template "chart.typeBadge" .  }}{{ template "chart.appVersionBadge" .  }}
+
+[analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
+[argo_rollouts]: https://argoproj.github.io/argo-rollouts/
+[bluegreen]: https://argoproj.github.io/argo-rollouts/features/bluegreen/
+[canary]: https://argoproj.github.io/argo-rollouts/features/canary/
+[experiment]: https://argoproj.github.io/argo-rollouts/features/experiment/
+[rollout]: https://argoproj.github.io/argo-rollouts/features/specification/
+
+This chart launches a horizontally scalable application through the use of the
+Argo [`Rollout`][rollout] custom resource. See the [Argo Rollouts - Kubernetes
+Progressive Delivery Controller][argo_rollouts] for more information about
+how these work, and the various custom resource definitions.
+
+## Rollout Resources Supported
+
+### [`Rollout`][rollout]
+
+The [`templates/rollout.yaml`](templates/rollout.yaml) template controls the
+creation of the [`Rollout`][rollout] resource. This resource is the replacement
+for the standard Kubernetes `Deployment` resource, but has two new deployment
+strategies - [`BlueGreen`][bluegreen] and [`Canary`][canary].
+
+The `.strategy` value can be set to `blueGreen` or `canary` to control which
+behavior you are looking for in your `Rollout` resource. From there, you can
+customize the deployment behavior through the `.blueGreen` or `.canary` values.
+
+### [`AnalysisTemplate`][analysistemplate] (_Not Supported_)
+
+At this time, you will need to create your own
+[`AnalysisTemplate`][analysistemplate] resources to describe how to analyze the
+behavior of an application and decide if it is healthy or not. In future
+releases, we may build support into this chart to manage those resources.
+
+_You can refer to an `AnalysisTemplate` you have created through the
+`.blueGreen.postPromotionAnalysis`, `.blueGreen.prePromotionAnalysis` and
+`.canary.analysis` parameters_.
+
+### [`Experiment`][experiment] (_Not Supported_)
+
+At this time, you will need to create your own [`Experiment`][experiment]
+resources. These resources are highly customized, and likely not worth trying
+to build in any default experiments into this chart.
+
+## Monitoring
+
+This chart makes the assumption that you _do_ have a Prometheus-style
+monitoring endpoint configured. See the `Values.monitor.portName`,
+`Values.monitor.portNumber` and `Values.monitor.path` settings for informing
+the chart of where your metrics are exposed.
+
+If you are operating in an Istio Service Mesh, see the
+[Istio](#istio-networking-support) section below for details on how monitoring
+works. Otherwise, see the `Values.serviceMonitor` settings to configure a
+Prometheus ServiceMonitor resource to monitor your application.
+
+## Datadog Agent Support
+
+This chart supports operating in environments where the Datadog Agent is
+running. If you set the `Values.datadog.enabled` flag, then a series of
+additional Pod Annotations, Labels and Environment Variables will be
+automatically added in to your deployment. See the `Values.datadog` parameters
+for further information.
+
+## Istio Networking Support
+
+### Monitoring through the Sidecar Proxy
+
+[metrics_merging]: https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging
+
+When running your Pod within an Istio Mesh, access to the `metrics` endpoint
+for your Pod can be obscured by the mesh itself which sits in front of the
+metrics port and may require that all clients are coming in through the
+mesh natively. The simplest way around this is to use [Istio Metrics
+Merging][metrics_merging] - where the Sidecar container is responsible for
+scraping your application's `metrics` port, merging the metrics with its own,
+and then Prometheus is configured to pull all of the metrics from the Sidecar.
+
+There are several advantages to this model.
+
+* It's much simpler - developers do not need to create `ServiceMonitor` or
+  `PodMonitor` resources because the Prometheus system is already configured to
+  discover all `istio-proxy` sidecar containers and collect their metrics.
+
+* Your application is not exposed outside of the service mesh to anybody - the
+  `istio-proxy` sidecar handles that for you.
+
+* There are fewer individual configurations for Prometheus, letting it's
+  configuration be simpler and lighter weight. It runs fewer "scrape" jobs,
+  improving its overall performance.
+
+This feature is turned on by default if you set `Values.istio.enabled=true` and
+`Values.monitor.enabled=true`.
+
+## Secrets
+A `Secret` or `KMSSecret` resource would be created and mounted into the container
+based upon the `Values.secrets` and `Values.secretsEngine` being populated.
+The `Secret` resource is generally used for local dev and/or CI test.
+Secret` resources can be created by setting the following:
+```
+secrets:
+  FOO_BAR: my plaintext secret
+secretsEngine: plaintext
+```
+Alternatively, `KMSSecret` can be generated using the following example:
+```
+secrets:
+  FOO_BAR: AQIA...
+secretsEngine: kms
+kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
+```
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/rollout-app/ci/bluegreen-values.yaml
+++ b/charts/rollout-app/ci/bluegreen-values.yaml
@@ -1,0 +1,10 @@
+strategy: blueGreen
+blueGreen:
+  autoPromotionEnabled: false
+  autoPromotionSeconds: 30
+  maxUnavailable: 0
+  scaleDownDelaySeconds: 30
+ingress:
+  enabled: true
+virtualService:
+  enabled: true

--- a/charts/rollout-app/ci/canary-values.yaml
+++ b/charts/rollout-app/ci/canary-values.yaml
@@ -1,0 +1,17 @@
+strategy: canary
+canary:
+  maxUnavailable: 0
+  canaryMetadata:
+    annotations:
+      foo: canary
+    labels:
+      foo: canary
+  stableMetadata:
+    annotations:
+      foo: stable
+    labels:
+      foo: stable
+ingress:
+  enabled: true
+virtualService:
+  enabled: true

--- a/charts/rollout-app/ci/local-values.yaml
+++ b/charts/rollout-app/ci/local-values.yaml
@@ -1,0 +1,1 @@
+../values.local.yaml

--- a/charts/rollout-app/templates/NOTES.txt
+++ b/charts/rollout-app/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nd-common.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nd-common.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nd-common.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nd-common.fullname" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/rollout-app/templates/_helpers.tpl
+++ b/charts/rollout-app/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Gathers the application image tag. This allows overriding the tag with a master
+`forceTag` setting, as well as the more common mechanism of setting the `tag`
+setting.
+*/}}
+{{- define "rollout-app.proxyImageFqdn" -}}
+{{- $tag := .Values.proxySidecar.image.tag | default (include "nd-common.imageTag" .) }}
+{{- if hasPrefix "sha256:" $tag }}
+{{- .Values.proxySidecar.image.repository }}@{{ $tag }}
+{{- else }}
+{{- .Values.proxySidecar.image.repository }}:{{ $tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Creates a Container "ports" map based on .Values.ports. We do this because we
+have customized the values that can be put into the list of "port" maps to
+simplify exposing a customer-facing port number (eg 80) while maintaining an
+internal application port-number (eg, 8080)
+*/}}
+{{- define "rollout-app.containerPorts" -}}
+{{- range $p := index .Values.ports }}
+- name: {{ required "Must set a port name" $p.name }}
+  containerPort: {{ required "Must set a containerPort" $p.containerPort }}
+  {{- with $p.protocol }}
+  protocol: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+This is the Service-side of the Ports mapping - we take the .Values.ports map
+and turn it into a list of ports that are exposed by the Service resource.
+Again, we do not use all of the values, we only use the values that make sense.
+*/}}
+{{- define "rollout-app.servicePorts" -}}
+{{- range $port := .Values.ports }}
+- port: {{ default $port.containerPort $port.port }}
+  targetPort: {{ $port.name }}
+  protocol: {{ $port.protocol }}
+  name: {{ $port.name }}
+{{- end }}
+{{- end -}}

--- a/charts/rollout-app/templates/hpa.yaml
+++ b/charts/rollout-app/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "nd-common.fullname" . }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: {{ include "nd-common.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- /* https://github.com/kubernetes/kubernetes/issues/74099 */}}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/rollout-app/templates/ingress/ingress.yaml
+++ b/charts/rollout-app/templates/ingress/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "nd-common.fullname" . }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ingress.sslRedirect }}
+    alb.ingress.kubernetes.io/actions.ssl-redirect: >-
+      {
+        "Type": "redirect",
+        "RedirectConfig": {
+          "Protocol": "HTTPS",
+          "Port": "443",
+          "StatusCode": "HTTP_301"
+        }
+      }
+    {{- end }}
+spec:
+  rules:
+    - host: {{ tpl .Values.ingress.host . | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  {{- if .Values.ingress.port }}
+                  number: {{ .Values.ingress.port }}
+                  {{- else }}
+                  name: {{ .Values.ingress.portName }}
+                  {{- end }}
+          {{- if .Values.ingress.sslRedirect }}
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+          {{- end }}
+  {{- end }}

--- a/charts/rollout-app/templates/ingress/networkpolicy.yaml
+++ b/charts/rollout-app/templates/ingress/networkpolicy.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.ingress.enabled .Values.ports }}
+{{- if gt (len .Values.ports) 0 }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "nd-common.fullname" . }}-ingress-access
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  policyTypes: [Ingress]
+  podSelector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+      {{- range $port := .Values.ports }}
+      - port: {{ $port.containerPort }}
+        protocol: {{ $port.protocol }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rollout-app/templates/istio/networkpolicy.yaml
+++ b/charts/rollout-app/templates/istio/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.virtualService.enabled .Values.ports }}
+{{- if gt (len .Values.ports) 0 }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "nd-common.fullname" . }}-ingressgateway-access
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  policyTypes: [Ingress]
+  podSelector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+      {{- range $port := .Values.ports }}
+      - port: {{ $port.containerPort }}
+        protocol: {{ $port.protocol }}
+      {{- end }}
+      from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app: istio-ingressgateway
+{{- end }}
+{{- end }}

--- a/charts/rollout-app/templates/istio/virtualservice.yaml
+++ b/charts/rollout-app/templates/istio/virtualservice.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.virtualService.enabled }}
+{{- $global := . }}
+{{- $istioNs := .Values.virtualService.namespace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "nd-common.fullname" . }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+  {{- with .Values.virtualService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.virtualService.gateways }}
+  gateways:
+    {{- range $gw := . }}
+    - {{ $istioNs }}/{{ $gw }}
+    {{- end }}
+  {{- end }}
+  hosts:
+    {{- range .Values.virtualService.hosts }}
+    - {{ tpl . $global | quote }}
+    {{- end }}
+
+  {{- /*
+  https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute
+  */}}
+  http:
+    - match:
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest */}}
+      {{- with .Values.virtualService.matches }}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest */}}
+      {{- if .Values.virtualService.paths }}
+      {{- range $path := .Values.virtualService.paths }}
+      - uri:
+          prefix: {{ $path }}
+      {{- end }}
+      {{- else }}
+      - uri:
+          prefix: {{ .Values.virtualService.path }}
+      {{- end }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy */}}
+      {{- with .Values.virtualService.corsPolicy }}
+      corsPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRetry */}}
+      {{- with .Values.virtualService.retries }}
+      retries:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRouteDestination */}}
+      route:
+        {{- /*
+        This is the primary "active" or "stable" service that we will route traffic
+        to most of the time. The weight is set to 100 here in the template, but Argo
+        Rollouts will override it during rollout sessions.
+        */}}
+        - destination:
+            host: {{ include "nd-common.fullname" . }}
+            port:
+              number: {{ .Values.virtualService.port }}
+          weight: 100
+
+        {{- /*
+        This is the optional "canary" service that we will route to for the "canary"
+        deployment strategy. This extra route is used by Rollouts to precicely
+        control the traffic routing to the new service through the Istio weight
+        settings. Weight is set to 0 in here, and then Rollouts controls it.
+        */}}
+        {{- if eq .Values.strategy "canary" }}
+        - destination:
+            host: {{ include "nd-common.fullname" . }}-canary
+            port:
+              number: {{ .Values.virtualService.port }}
+          weight: 0
+        {{- end }}
+
+  {{- with .Values.virtualService.tls }}
+  tls:
+    {{- tpl . $global | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/rollout-app/templates/kmssecret.yaml
+++ b/charts/rollout-app/templates/kmssecret.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.secrets) (eq .Values.secretsEngine "kms") }}
+apiVersion: secret.h3poteto.dev/v1beta1
+kind: KMSSecret
+metadata:
+  name: {{ .Release.Name }}-secrets
+spec:
+  region: {{ .Values.kmsSecretsRegion }}
+  encryptedData:
+    {{- range $key, $value := .Values.secrets }}
+    {{ $key | upper }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/rollout-app/templates/networkpolicy.yaml
+++ b/charts/rollout-app/templates/networkpolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "nd-common.networkPolicy" . }}

--- a/charts/rollout-app/templates/poddisruptionbudget.yaml
+++ b/charts/rollout-app/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "nd-common.fullname" . }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" . | nindent 8 }}
+  {{ toYaml .Values.podDisruptionBudget | nindent 2 }}
+{{- end }}

--- a/charts/rollout-app/templates/podmonitor.yaml
+++ b/charts/rollout-app/templates/podmonitor.yaml
@@ -1,0 +1,1 @@
+{{- include "nd-common.podMonitor" . }}

--- a/charts/rollout-app/templates/prometheusrules.yaml
+++ b/charts/rollout-app/templates/prometheusrules.yaml
@@ -1,0 +1,280 @@
+{{- $values          := .Values }}
+{{- $global          := . }}
+{{- $targetNamespace := .Release.Namespace }}
+{{- $runbookUrl      := required "Values.runbookUrl can not be blank!" .Values.runbookUrl }}
+{{- $appName         := include "nd-common.fullname" . }}
+{{- $podName         := trunc 56 $appName | printf "%s.*" }}
+{{- if .Values.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  groups:
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules
+    rules:
+
+    {{- with .Values.prometheusRules.PodContainerTerminated }}
+    - alert: PodContainerTerminated
+      annotations:
+        summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
+        runbook_url: {{ $runbookUrl }}#kube-pod-container-terminated
+        description: >-
+          Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
+          has a container that has been terminated ({{`{{ $value }}`}} times) due to
+          {{`{{$labels.reason}}`}} in the last {{ .for }}.
+      expr: |-
+        sum by (container, namespace, pod, reason) (
+          sum_over_time(
+            kube_pod_container_status_terminated_reason{
+              reason=~"{{ join "|" .reasons }}",
+              namespace="{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[{{ .over }}]
+          )
+        ) > {{ .threshold }}
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodCrashLooping }}
+    - alert: PodCrashLooping
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} is crash looping.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod
+          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+      expr: |-
+        rate(
+          kube_pod_container_status_restarts_total{
+            job="kube-state-metrics",
+            namespace=~"{{ $targetNamespace }}",
+            pod=~"{{ $podName }}"
+          }[5m]
+        ) * 60 * 5 > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodNotReady }}
+    - alert: PodNotReady
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} has been in a non-ready state for more than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          Pod {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          has been in a non-ready state for longer than {{ .for }}.
+      expr: |-
+        sum by (namespace, pod) (
+          max by(namespace, pod) (
+            kube_pod_status_phase{
+              job="kube-state-metrics",
+              namespace=~"{{ $targetNamespace }}",
+              phase=~"Pending|Unknown",
+              pod=~"{{ $podName }}"
+            }
+          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.ContainerRules
+    rules:
+
+    {{- with .Values.prometheusRules.CPUThrottlingHigh }}
+    - alert: CPUThrottlingHigh
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} processes are experiencing elevated CPU throttling
+        runbook_url: {{ $runbookUrl }}#CPUThrottlingHigh
+        description: >-
+          {{`{{ $value | humanizePercentage }}`}} throttling of CPU in
+          namespace {{`{{ $labels.namespace }}`}} for container
+          {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}.
+      expr: |-
+        sum(
+          increase(
+            container_cpu_cfs_throttled_periods_total{
+              container!="",
+              namespace=~"{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[5m]
+          )
+        ) by (container, pod, namespace)
+
+          /
+
+        sum(
+          increase(
+            container_cpu_cfs_periods_total{}[5m]
+          )
+        ) by (container, pod, namespace)
+
+        > ( {{ .threshold }} / 100 )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.ContainerWaiting }}
+    - alert: ContainerWaiting
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} container ({{`{{ $labels.container }}`}}) waiting longer than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#containerwaiting
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}
+          (namespace: {{`{{ $labels.namespace }}`}} has been in a waiting
+          state for longer than 1 hour.
+      expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.DeploymentRules
+    rules:
+
+    {{- with .Values.prometheusRules.DeploymentGenerationMismatch }}
+    - alert: DeploymentGenerationMismatch
+      annotations:
+        summary: >-
+          {{`{{ $labels.deployment }}`}} deployment generation mismatch due to possible roll-back
+        runbook_url: {{ $runbookUrl }}#deploymentgenerationmismatch
+        description: >-
+          Deployment generation for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment }}`}}
+          does not match, this indicates that the Deployment has failed but has not been rolled
+          back.
+      expr: |-
+        sum by(namespace, deployment) (
+          kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+            !=
+          kube_deployment_metadata_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.DeploymentReplicasMismatch }}
+    - alert: DeploymentReplicasMismatch
+      annotations:
+        summary: >-
+          {{`{{ $labels.deployment }}`}} deployment has not matched the expected number of replicas.
+        runbook_url: {{ $runbookUrl }}#deploymentreplicasmismatch
+        description: >-
+          Deployment {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment }}`}}
+          has not matched the expected number of replicas for longer than {{ .for }}.
+      expr: |-
+        sum by(namespace, deployment) (
+          (
+            kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+              !=
+            kube_deployment_status_replicas_available{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+          ) and (
+            changes(kube_deployment_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}[5m])
+              ==
+            0
+          )
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  {{- if .Values.autoscaling.enabled }}
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.HorizontalPodAutoscalerRules
+    rules:
+
+    {{- with .Values.prometheusRules.HpaReplicasMismatch }}
+    - alert: HpaReplicasMismatch
+      annotations:
+        summary: >-
+          {{`{{ $labels.horizontalpodautoscaler }}`}} HPA has not matched descired number of replicas.
+        runbook_url: {{ $runbookUrl }}#hpareplicasmismatch
+        description: >-
+          HPA {{`{{ $labels.namespace }}`}}/{{`{{ $labels.horizontalpodautoscaler }}`}}
+          has not matched the desired number of replicas for longer than 15
+          minutes.
+      expr: |-
+        sum by(namespace, horizontalpodautoscaler) (
+          (kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            !=
+          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"})
+            and
+          (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            >
+          kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"})
+            and
+          (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            <
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"})
+            and
+          changes(kube_horizontalpodautoscaler_status_current_replicas[15m]) == 0
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.HpaMaxedOut }}
+    - alert: HpaMaxedOut
+      annotations:
+        summary: >-
+          {{`{{ $labels.horizontalpodautoscaler }}`}} HPA is running at max replicas
+        runbook_url: {{ $runbookUrl }}#hpamaxedout
+        description: >-
+          HPA {{`{{ $labels.namespace }}`}}/{{`{{ $labels.horizontalpodautoscaler }}`}}
+          has been running at max replicas for longer than 15 minutes.
+      expr: |-
+        sum by(namespace, horizontalpodautoscaler) (
+          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            ==
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -1,0 +1,309 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include "nd-common.fullname" . }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
+  {{- with .Values.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ . }}
+  {{- end }}
+  {{- if and .Values.replicaCount (not .Values.autoscaling.enabled) }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- if (eq .Values.strategy "blueGreen") }}
+    blueGreen:
+      activeService: {{ include "nd-common.fullname" . }}
+      previewService: {{ include "nd-common.fullname" . }}-preview
+
+      {{- if (ne .Values.blueGreen.autoPromotionEnabled nil) }}
+      autoPromotionEnabled: {{ .Values.blueGreen.autoPromotionEnabled }}
+      {{- end }}
+
+      {{- with .Values.blueGreen.autoPromotionSeconds }}
+      autoPromotionSeconds: {{ int . }}
+      {{- end }}
+
+      {{- with .Values.blueGreen.previewReplicaCount }}
+      previewReplicaCount: {{ int . }}
+      {{- end }}
+
+      {{- if (ne .Values.blueGreen.maxUnavailable nil) }}
+      maxUnavailable: {{ .Values.blueGreen.maxUnavailable }}
+      {{- end }}
+
+      {{- with .Values.blueGreen.prePromotionAnalysis }}
+      prePromotionAnalysis:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.blueGreen.postPromotionAnalysis }}
+      postPromotionAnalysis:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.blueGreen.scaleDownDelaySeconds }}
+      scaleDownDelaySeconds: {{ int . }}
+      {{- end }}
+
+      {{- with .Values.blueGreen.scaleDownDelayRevisionLimit }}
+      scaleDownDelayRevisionLimit: {{ int . }}
+      {{- end }}
+
+      {{- with .Values.blueGreen.antiAffinity }}
+      antiAffinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }} 
+
+    {{- else if (eq .Values.strategy "canary") }}
+    canary:
+      stableService: {{ include "nd-common.fullname" . }}
+      canaryService: {{ include "nd-common.fullname" . }}-canary
+
+      {{- if or .Values.virtualService.enabled .Values.ingress.enabled }}
+      trafficRouting:
+        {{- if .Values.virtualService.enabled }}
+        istio:
+          virtualService:
+            name: {{ include "nd-common.fullname" . }}
+        {{- end }}
+        {{- if .Values.ingress.enabled }}
+        alb:
+          ingress: {{ include "nd-common.fullname" . }}
+          servicePort: {{ default (first .Values.ports).containerPort .Values.ingress.port }}
+        {{- end }}
+      {{- end }}
+
+      {{- with .Values.canary.canaryMetadata }}
+      canaryMetadata:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.canary.stableMetadata }}
+      stableMetadata:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- if (ne .Values.canary.maxUnavailable nil) }}
+      maxUnavailable: {{ .Values.canary.maxUnavailable }}
+      {{- end }}
+
+      {{- if (ne .Values.canary.maxSurge nil) }}
+      maxSurge: {{ .Values.canary.maxSurge }}
+      {{- end }}
+
+      {{- with .Values.canary.scaleDownDelaySeconds }}
+      scaleDownDelaySeconds: {{ int . }}
+      {{- end }}
+
+      {{- with .Values.canary.scaleDownDelayRevisionLimit }}
+      scaleDownDelayRevisionLimit: {{ int . }}
+      {{- end }}
+
+      {{- with .Values.canary.analysis }}
+      analysis:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.canary.antiAffinity }}
+      antiAffinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }} 
+
+      {{- with .Values.canary.steps }}
+      steps:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+    {{- else }}
+    {{- fail (printf "Must set .Values.strategy to 'blueGreen' or 'canary', '%s' is invalid" .Values.strategy) }}
+    {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/secrets: {{ toYaml .Values.secrets | sha256sum }}
+        {{- include "nd-common.istioAnnotations" . | nindent 8 }}
+        {{- include "nd-common.datadogAnnotations" . | nindent 8 }}
+        {{- with .Values.podAnnotations }}
+        {{- range $annotation, $value := index . }}
+        {{ $annotation }}: {{ tpl $value $ | quote }}
+        {{- end }}
+        {{- end }}
+      labels:
+        {{- include "nd-common.labels" . | nindent 8 }}
+        {{- include "nd-common.datadogLabels" . | nindent 8 }}
+        {{- include "nd-common.istioLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+    spec:
+      nodeSelector:
+        {{- include "nd-common.nodeSelector" $ | nindent 8 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "nd-common.serviceAccountName" . }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      {{- if or .Values.volumes .Values.volumesString }}
+      volumes:
+        {{- with .Values.volumes }}{{ toYaml . | nindent 8 }}{{ end }}
+        {{- with .Values.volumesString }}{{ tpl . $ | nindent 8 }}{{ end }}
+      {{- end }}
+      containers:
+        {{- if .Values.proxySidecar.enabled }}
+        - name: {{ .Values.proxySidecar.name }}
+          image: {{ include "rollout-app.proxyImageFqdn" . }}
+          imagePullPolicy: {{ .Values.proxySidecar.image.pullPolicy }}
+          {{- with .Values.preStopCommand }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  {{ toYaml . | nindent 18 }}
+          {{- end }}
+
+          {{- with .Values.proxySidecar.envFrom }}
+          envFrom:
+            {{- range $env := index .}}
+            {{- with $env.configMapRef }}
+            - configMapRef:
+                name: {{ tpl (required ".name key must be set in configMapRef" .name) $ }}
+            {{- end }}
+            {{- with $env.secretRef }}
+            - secretRef:
+                name: {{ tpl (required ".name key must be set on secretRef" .name) $ }}
+            {{- end }}
+            {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.proxySidecar.env }}
+          env:
+            {{- range $env := index . }}
+            - name: {{ tpl $env.name $ }}
+              {{- if $env.value }}
+              value: {{ tpl $env.value $ | quote }}
+              {{- else if $env.valueFrom }}
+              valueFrom: {{ tpl (toYaml $env.valueFrom) $ | nindent 16 }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.proxySidecar.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.ports }}
+          ports:
+            {{- include "rollout-app.containerPorts" . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.proxySidecar.resources | nindent 12 }}
+        {{- end }}
+        - name: {{ include "nd-common.containerName" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "nd-common.imageFqdn" . }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.preStopCommand }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  {{- toYaml . | nindent 18 }}
+          {{- end }}
+          {{- if or .Values.envFrom .Values.secrets }}
+          envFrom:
+            {{- if .Values.secrets }}
+            - secretRef:
+                name:  {{ .Release.Name }}-secrets
+            {{- end }}
+            {{- with .Values.envFrom}}
+            {{- range $env := index .}}
+            {{- with $env.configMapRef }}
+            - configMapRef:
+                name: {{ tpl (required ".name key must be set in configMapRef" .name) $ }}
+            {{- end }}
+            {{- with $env.secretRef }}
+            - secretRef:
+                name: {{ tpl (required ".name key must be set on secretRef" .name) $ }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if or .Values.env .Values.datadog.enabled }}
+          env:
+            {{- with .Values.env }}
+            {{- range $env := index . }}
+            - name: {{ tpl $env.name $ }}
+              {{- if $env.value }}
+              value: {{ tpl $env.value $ | quote }}
+              {{- else if $env.valueFrom }}
+              valueFrom: {{ tpl (toYaml $env.valueFrom) $ | nindent 16 }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- include "nd-common.datadogEnv" . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.proxySidecar.enabled }}
+          {{- else }}
+          ports:
+            {{- include "rollout-app.containerPorts" . | nindent 12 }}
+            {{- include "nd-common.monitorPodPorts" . | nindent 12 }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}

--- a/charts/rollout-app/templates/secret.yaml
+++ b/charts/rollout-app/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- /*
+This template is used for local development.
+*/}}
+{{- if and (.Values.secrets) (eq .Values.secretsEngine "plaintext") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key | upper }}: {{ $value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/rollout-app/templates/serviceaccount.yaml
+++ b/charts/rollout-app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nd-common.serviceAccountName" . }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/rollout-app/templates/services.yaml
+++ b/charts/rollout-app/templates/services.yaml
@@ -1,0 +1,73 @@
+{{/*
+The "Active" service is the primary service that is receiving web traffic from
+users. This is the always-created and always-on service that Argo will use to
+route traffic to.
+*/}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nd-common.fullname" . }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- include "rollout-app.servicePorts" . | nindent 4 }}
+  selector:
+    {{- include "nd-common.selectorLabels" . | nindent 4 }}
+
+---
+
+{{/*
+This optional "Preview" service is created when the .Values.strategy is set to
+"blueGreen". The intention is that this service is used either for running
+experiments against, or for humans to manually test and verify before allowing
+a deployment to continue.
+
+https://argoproj.github.io/argo-rollouts/features/bluegreen/#previewservice
+
+*/}}
+
+{{- if eq .Values.strategy "blueGreen" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nd-common.fullname" . }}-preview
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- include "rollout-app.servicePorts" . | nindent 4 }}
+  selector:
+    {{- include "nd-common.selectorLabels" . | nindent 4 }}
+{{- end }}
+
+---
+
+{{/*
+This optional "Canary" service is created only when the .Values.strategy is set
+to "canary". Rollouts will then use this service to route canary traffic to, in
+order to test releases.
+
+When using Istio VirtualServices (if .Values.virtualService.enabled=true), the
+VirtualService will be configured to use this Service as the canary service,
+and it will automatically adjust the weights to move traffic between the stable
+and canary service.
+*/}}
+
+{{- if eq .Values.strategy "canary" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nd-common.fullname" . }}-canary
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- include "rollout-app.servicePorts" . | nindent 4 }}
+  selector:
+    {{- include "nd-common.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/rollout-app/templates/tests/test-connection.yaml
+++ b/charts/rollout-app/templates/tests/test-connection.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nd-common.fullname" . }}-test-connection"
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: >-
+        {{- if .Values.tests.connection.image.repository }}
+        {{ .Values.tests.connection.image.repository }}:{{ default "latest" .Values.tests.connection.image.tag }}
+        {{- else }}
+        {{ include "nd-common.imageFqdn" . }}
+        {{- end }}
+      command:
+        {{- toYaml .Values.tests.connection.command | nindent 8 }}
+      args:
+        {{- $global := . }}
+        {{- range $arg := index .Values.tests.connection.args }}
+        - {{ tpl $arg $global }}
+        {{- end }}

--- a/charts/rollout-app/values.local.yaml
+++ b/charts/rollout-app/values.local.yaml
@@ -1,0 +1,60 @@
+# Simplify local dev testing
+targetArchitecture: null
+
+canary:
+  maxUnavailable: 0
+  canaryMetadata:
+    annotations:
+      foo: canary
+    labels:
+      foo: canary
+  stableMetadata:
+    annotations:
+      foo: stable
+    labels:
+      foo: stable
+
+# Various settings to test slowing down the rollout process for local development
+blueGreen:
+  autoPromotionEnabled: false
+  autoPromotionSeconds: 30
+  maxUnavailable: 0
+  scaleDownDelaySeconds: 30
+
+# For local development, we turn on the Ingress controller and set up a simple
+# local ingress.
+ingress:
+  # -- Enable local ingress for local development.
+  enabled: true
+
+  # -- Disable the SSL-Redirect explicitly because it only applies to
+  # ALB-ingress controllers.
+  sslRedirect: false
+
+ports:
+  - name: http
+    containerPort: 80
+    protocol: TCP
+    # Optional flag to override the client-facing port for service requests.
+    port:
+  - name: https
+    containerPort: 8443
+    protocol: TCP
+    # Optional flag to override the client-facing port for service requests.
+    port: 443
+
+
+terminationGracePeriodSeconds: 30
+autoscaling:
+  enabled: true
+
+secrets:
+  TEST_SECRET: junksecret
+
+datadog:
+  scrapeMetrics: true
+  scrapeLogs:
+    enabled: true
+
+network:
+  allowedNamespaces: [foo, bar]

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -1,0 +1,774 @@
+# -- (`int`) The number of Pods to start up by default. If the
+# `autoscaling.enabled` parameter is set, then this serves as the "start
+# scale" for an application. Setting this to `null` prevents the setting from
+# being applied at all in the PodSpec, leaving it to Kubernetes to use the
+# default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas
+replicaCount: 2
+
+# -- (`int`) The default revisionHistoryLimit in Kubernetes is 10 - which is
+# just really noisy. Set our default to 3. https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
+revisionHistoryLimit: 3
+
+# -- Set up a PodDisruptionBudget for the Deployment. See
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more
+# details.
+podDisruptionBudget:
+  maxUnavailable: 1
+
+image:
+  # -- (String) The Docker image name and repository for your application
+  repository: nginx
+
+  # -- (String) Always, Never or IfNotPresent
+  pullPolicy: IfNotPresent
+
+  # -- (String) Overrides the image tag whose default is the chart appVersion.
+  tag: null
+
+  # -- (String) Forcefully overrides the `image.tag` setting - this is useful
+  # if you have an outside too that automatically updates the `image.tag`
+  # value, but you want your application operators to be able to squash that
+  # override themselves.
+  forceTag: null
+
+# -- The command run by the container. This overrides `ENTRYPOINT`. If not
+# specified, the container's default entrypoint is used. The exact rules of how
+# commadn and args are interpreted can be # found at:
+# https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+command: []
+
+# -- The arguments passed to the command. If unspecified the container defaults
+# are used. The exact rules of how commadn and args are interpreted can be #
+# found at:
+# https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+args: []
+
+# -- A list of 'volumes' that can be mounted into the Pod. See
+# https://kubernetes.io/docs/concepts/storage/volumes/.
+volumes: []
+
+# -- A stringified list of 'volumes' similar to the `Values.volumes` parameter,
+# but this one gets run through the `tpl` function so that you can use
+# templatized values if you need to. See
+# https://kubernetes.io/docs/concepts/storage/volumes/.
+volumesString: ""
+# eg:
+#
+# volumesString: |-
+#   - name: test-html-mount
+#     configMap:
+#       name: "{{ include "nd-common.fullname" . }}-test-map"
+
+# An optional proxy sidecar configuration is provided - but its a rough
+# beginning here, it doesn't provide any real configuration for the proxy, so
+# we expect that the proxy container is preconfigured (for example,
+# Okta-proxy). In the future we'll add support in for creating ConfigMaps and
+# Secrets that can be bound into the sidecar container for a more complete
+# solution.
+proxySidecar:
+  # -- (Boolean) Enables injecting a pre-defined reverse proxy sidecar
+  # container into the Pod containers list.
+  enabled: false
+
+  # -- (String) The name of the proxy sidecar container
+  name: proxy
+
+  image:
+    # -- (String) The Docker image name and repository for the sidecar
+    repository: nginx
+
+    # -- (String) The Docker tag for the sidecar
+    tag: latest
+
+    # -- (String) Always, Never or IfNotPresent
+    pullPolicy: IfNotPresent
+
+  # -- Environment Variables for the primary container. These are all run
+  # through the tpl function (the key name and value), so you can dynamically
+  # name resources as you need.
+  env: []
+
+  # -- Pull all of the environment variables listed in a ConfigMap into the
+  # Pod. See
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # for more details.
+  envFrom: []
+
+  # -- List of VolumeMounts that are applied to the proxySidecar container -
+  # these must refer to volumes set in the `Values.volumes` parameter.
+  volumeMounts: []
+
+  # -- A PodSpec "Resources" object for the proxy container
+  resources: {}
+
+# -- A PodSpec container "startupProbe" configuration object. Note that this
+# startupProbe will be applied to the proxySidecar container instead if that
+# is enabled.
+startupProbe:
+
+# -- A PodSpec container "livenessProbe" configuration object. Note that this
+# livenessProbe will be applied to the proxySidecar container instead if that
+# is enabled.
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# -- A PodSpec container "readinessProbe" configuration object. Note that this
+# readinessProbe will be applied to the proxySidecar container instead if that
+# is enabled.
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# -- (`ContainerPort[]`) A list of Port objects that are exposed by the
+# service. These ports are applied to the main container, or the proxySidecar
+# container (if enabled). The port list is also used to generate Network
+# Policies that allow ingress into the pods. See
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#containerport-v1-core
+# for details.
+#
+# **Note: We have added an optional "port" field to this list that allows the
+# user to override the Service Port (for example 80) that a client  connects
+# to, without altering the Container Port (say, 8080) that is listening for
+# connections.
+ports:
+  - name: http
+    containerPort: 80
+    protocol: TCP
+    # Optional flag to override the client-facing port for service requests.
+    port:
+
+# -- Supply a reference to a Secret that can be used by Kubernetes to pull down
+# the Docker image. This is only used in local development, in combination with
+# our `kube_create_ecr_creds` function from dotfiles.
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+containerName: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
+terminationGracePeriodSeconds: null
+
+# -- Environment Variables for the primary container. These are all run
+# through the tpl function (the key name and value), so you can dynamically
+# name resources as you need.
+env: []
+  # Example
+  # - name: VAR
+  #   value: MyString
+  #
+  # - name: MY-DYNAMIC-VAR-{{ .Release.Name }}
+  #   value:
+  #     secretKeyRef:
+  #       name: {{ .Release.Name }}-secret
+  #       key: foo
+  #
+
+# -- Pull all of the environment variables listed in a ConfigMap into the
+# Pod. See
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+# for more details.
+envFrom: []
+  # Example:
+  # - configMapRef:
+  #     name: my-config-vars
+
+# -- (`Map`) Map of environment variables to plaintext secrets or KMS encrypted secrets.
+secrets: {}
+
+# -- (String) AWS region where the KMS key is located
+kmsSecretsRegion:
+
+# -- (String) Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `Secret`). kms || plaintext are possible values.
+secretsEngine: plaintext
+
+# -- List of VolumeMounts that are applied to the application container -
+# these must refer to volumes set in the `Values.volumes` parameter.
+volumeMounts: []
+
+# -- (`Map`) List of Labels to be added to the PodSpec
+podLabels: {}
+
+# -- (`Map`) List of Annotations to be added to the PodSpec
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds
+minReadySeconds: null
+
+# -- https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds
+progressDeadlineSeconds: null
+
+# -- (`map`) Required - Either a
+# [`BlueGreen`](https://argoproj.github.io/argo-rollouts/features/bluegreen/)
+# or [`Canary`](https://argoproj.github.io/argo-rollouts/features/canary/)
+# strategy map.
+#
+# -- (`string`) Chooses which Rollout strategy to use - either `blueGreen` or
+# `canary`. Use `.Values.blueGreen` and `.Values.canary` to customize the
+# actual behavior of the rollout.
+strategy: blueGreen
+
+blueGreen:
+  # -- (`bool`) The AutoPromotionEnabled will make the rollout automatically
+  # promote the new ReplicaSet to the active service once the new ReplicaSet is
+  # healthy. This field is defaulted to true if it is not specified.
+  autoPromotionEnabled: null
+
+  # -- (`int`) The AutoPromotionSeconds will make the rollout automatically
+  # promote the new ReplicaSet to active Service after the AutoPromotionSeconds
+  # time has passed since the rollout has entered a paused state. If the
+  # AutoPromotionEnabled field is set to true, this field will be ignored
+  autoPromotionSeconds: null
+
+  # -- (`map`) Check out the Anti Affinity document document for more information.
+  antiAffinity: null
+
+  # -- (`int`) The PreviewReplicaCount field will indicate the number of
+  # replicas that the new version of an application should run. Once the
+  # application is ready to promote to the active service, the controller will
+  # scale the new ReplicaSet to the value of the spec.replicas. The rollout
+  # will not switch over the active service to the new ReplicaSet until it
+  # matches the spec.replicas count.
+  #
+  # This feature is mainly used to save resources during the testing phase. If
+  # the application does not need a fully scaled up application for the tests,
+  # this feature can help save some resources.
+  #
+  # If omitted, the preview ReplicaSet stack will be scaled to 100% of the
+  # replicas.
+  previewReplicaCount: null
+
+  # -- (`int`) The maximum number of pods that can be unavailable during the
+  # update. Value can be an absolute number (ex: 5) or a percentage of desired
+  # pods (ex: 10%). This can not be 0 if MaxSurge is 0.
+  maxUnavailable: null
+
+  # -- (`map`) Configures the
+  # [Analysis](https://argoproj.github.io/argo-rollouts/features/analysis/#bluegreen-pre-promotion-analysis)
+  # before it switches traffic to the new version. The AnalysisRun can be used
+  # to block the Service selector switch until the AnalysisRun finishes
+  # successful. The success or failure of the analysis run decides if the
+  # Rollout will switch traffic, or abort the Rollout completely.
+  prePromotionAnalysis: null
+
+  # -- (`map`) Configures the
+  # [Analysis](https://argoproj.github.io/argo-rollouts/features/analysis/#bluegreen-pre-promotion-analysis)
+  # after the traffic switch to new version. If the analysis run fails or
+  # errors out, the Rollout enters an aborted state and switch traffic back to
+  # the previous stable Replicaset. If `scaleDownDelaySeconds` is specified, the
+  # controller will cancel any AnalysisRuns at time of `scaleDownDelay` to scale
+  # down the ReplicaSet. If it is omitted, and post analysis is specified, it
+  # will scale down the ReplicaSet only after the AnalysisRun completes (with a
+  # minimum of 30 seconds).
+  postPromotionAnalysis: null
+
+  # -- (`int`) The ScaleDownDelaySeconds is used to delay scaling down the old
+  # ReplicaSet after the active Service is switched to the new ReplicaSet.
+  scaleDownDelaySeconds: null
+
+  # -- (`int`) The ScaleDownDelayRevisionLimit limits the number of old active
+  # ReplicaSets to keep scaled up while they wait for the scaleDownDelay to
+  # pass after being removed from the active service.
+  #
+  # If omitted, all ReplicaSets will be retained for the specified
+  # scaleDownDelay
+  scaleDownDelayRevisionLimit: null
+
+canary:
+  # -- (`map`) Check out the Anti Affinity document document for more information.
+  antiAffinity: null
+
+  # -- (`map`) Metadata which will be attached to the canary pods. This
+  # metadata will only exist during an update, since there are no canary pods
+  # in a fully promoted rollout.
+  canaryMetadata: null
+
+  # -- (`map`) metadata which will be attached to the stable pods
+  stableMetadata: null
+
+  # -- (`int` or `string`) The maximum number of pods that can be unavailable
+  # during the update. Value can be an absolute number (ex: 5) or a percentage
+  # of total pods at the start of update (ex: 10%). Absolute number is
+  # calculated from percentage by rounding down. This can not be 0 if  MaxSurge
+  # is 0. By default, a fixed value of 1 is used. Example: when this is set to
+  # 30%, the old RC can be scaled down by 30% immediately when the rolling
+  # update starts. Once new pods are ready, old RC can be scaled down further,
+  # followed by scaling up the new RC, ensuring that at least 70% of original
+  # number of pods are available at all times during the update. +optional
+  maxUnavailable: null
+
+  # -- (`int` or `string`) The maximum number of pods that can be scheduled
+  # above the original number of pods. Value can be an absolute number (ex: 5)
+  # or a percentage of total pods at the start of the update (ex: 10%). This
+  # can not be 0 if MaxUnavailable is 0. Absolute number is calculated from
+  # percentage by rounding up. By default, a value of 1 is used.# Example: when
+  # this is set to 30%, the new RC can be scaled up by 30% immediately when the
+  # rolling update starts. Once old pods have been killed, new RC can be scaled
+  # up further, ensuring that total number of pods running at any time during
+  # the update is at most 130% of original pods. +optional
+  maxSurge: null
+
+  # -- (`int`) Adds a delay before scaling down the previous ReplicaSet when
+  # the canary strategy is used with traffic routing (default 30 seconds). A
+  # delay in scaling down the previous ReplicaSet is needed after switching the
+  # stable service selector to point to the new ReplicaSet, in order to give
+  # time for traffic providers to re-target the new pods. This value is ignored
+  # with basic, replica-weighted canary without traffic routing.
+  scaleDownDelaySeconds: null
+
+  # -- (`int`) Limits the number of old RS that can run at one time before
+  # getting scaled down. Defaults to nil
+  scaleDownDelayRevisionLimit: null
+
+  # -- (`map`) Configure the background
+  # [Analysis](https://argoproj.github.io/argo-rollouts/features/analysis/) to
+  # execute during the rollout. If the analysis is unsuccessful the rollout
+  # will be aborted.
+  analysis: null
+
+  # -- (`map[]`) This **required** parameter defines the canary rollout
+  # process. Strictly speaking, the Argo Rollouts controller does not require
+  # that you define a set of steps .. but the ArgoCD integration with Argo
+  # Rollouts does require that these steps be defined, otherwise it fails.
+  #
+  # Read the [documentation
+  # here](https://argoproj.github.io/argo-rollouts/features/canary/#example) to
+  # learn more about the available steps, and how you can configure them.
+  steps:
+    - setWeight: 20
+    - pause:
+        duration: 5m
+    - setWeight: 40
+    - pause:
+        duration: 5m
+    - setWeight: 80
+
+# -- Before a pod gets terminated, Kubernetes sends a SIGTERM signal to every
+# container and waits for period of time (10s by default) for all containers to
+# exit gracefully. If your app doesn't handle the SIGTERM signal or if it
+# doesn't exit within the grace period, Kubernetes will kill the container and
+# any inflight requests that your app is processing will fail.
+#
+# Make sure you set this to SHORTER than the terminationGracePeriod (30s
+# default) setting.
+#
+# https://docs.flagger.app/tutorials/zero-downtime-deployments#graceful-shutdown
+preStopCommand:
+  - /bin/sleep
+  - '10'
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+
+# Configuration for creating a dedicated ALB for your service. This is
+# acceptable - but not the preferred method (see the IngressGateway setup
+# below).
+ingress:
+  enabled: false
+
+  # -- Any annotations you wish to add to the ALB. See
+  # https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/
+  # for more details.
+  annotations: {}
+
+  # -- This setting configures the ALB to listen specifically to requests for
+  # this hostname. It _also_ ties into the external-dns controller and
+  # automatically provisions DNS hostnames matching this value (presuming that
+  # they are allowed by the cluster settings).
+  host: '{{ include "nd-common.fullname" . }}.{{ .Release.Namespace }}'
+
+  # -- https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  pathType: Prefix
+
+  # -- See the `ingress.pathType` setting documentation.
+  path: '/'
+
+  # -- If `true`, then this will annotate the Ingress with a special AWS ALB
+  # Ingress Controller annotation that configures an SSL-redirect at the ALB
+  # level.
+  sslRedirect: true  # ties into "actions.ssl-redirect" above
+
+  # -- This is the port "name" that the `Service` will point to on the backing
+  # Pods. This value must match one of the values of `.name` in the
+  # `Values.ports` configuration.
+  portName: http
+
+  # -- If set, this will override the `service.portName` parameter, and the
+  # `Service` object will point specifically to this port number on the backing
+  # Pods.
+  port: null
+
+# Configuration for creating a VirtualService inside the Istio Service Mesh
+# Ingress Gateways. This is the preferred method for exposing a service because
+# we have far greater visbility and granularity into the performance, it costs
+# less, and deployments are actually faster this way.
+virtualService:
+  # -- (Boolean) Maps the Service to an Istio IngressGateway, exposing the
+  # service outside of the Kubernetes cluster.
+  enabled: false
+
+  # -- Any annotations you wish to add to the `VirtualService` resource. See
+  # https://istio.io/latest/docs/reference/config/annotations/ for more
+  # details.
+  annotations: {}
+
+  # -- (`map`) If set, this will populate the corsPolicy setting for the
+  # VirtualService. See
+  # https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy
+  # for more details.
+  corsPolicy: {}
+
+  # -- (`map[]`) A list of Istio `HTTPMatchRequest` objects that will be
+  # applied to the VirtualService. This is the more advanced and customizable
+  # way of controlling which paths get sent to your backend. These are added
+  # _in addition_ to the `paths` or `path` settings. See
+  # https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest
+  # for examples.
+  matches: {}
+
+  # -- A list of destination hostnames that this VirtualService will accept
+  # traffic for. Multiple names can be listed here. See
+  # https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService
+  # for more details.
+  hosts:
+    - '{{ include "nd-common.fullname" . }}'
+
+  # -- The name of the Istio `Gateway` resource that this `VirtualService`
+  # will register with. You can get a list of the avaialable `Gateways` by
+  # running `kubectl -n istio-system get gateways`. Not specifying a Gateway
+  # means that you are creating a VirtualService routing definition only inside
+  # of the Kubernetes cluster, which is totally reasonable if you want to do
+  # that.
+  gateways: []
+
+  # -- The namespace where the Istio services are operating. Do not change this.
+  namespace: istio-system
+
+  # -- The default path prefix that the `VirtualService` will match requests
+  # against to pass to the default `Service` object in this deployment.
+  path: '/'
+
+  # -- (`string[]`) List of optional path prefixes that the `VirtualService`
+  # will use to match requests against and will pass to the `Service` object in
+  # this deployment. This list replaces the `path` prefix above - use one or
+  # the other, do not use both.
+  paths: []
+
+  # -- This is the backing Pod port _number_ to route traffic to. This must
+  # match a `containerPort` in the `Values.ports` list.
+  port: 80
+
+  tls: ""
+
+  # -- (`map`) Pass in an optional
+  # [`HTTPRetry`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRetry)
+  # configuration here to control how services retry their failed requests to
+  # the backend service. The default behavior is to retry 2 times if a 503 is returned.
+  retries: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Enabling Horizontal Pod Autoscaling (HPA) ensures that your application
+# scales up to meet demand.
+autoscaling:
+  # -- Controls whether or not an HorizontalPodAutoscaler resource is created.
+  enabled: false
+  # -- Sets the minimum number of Pods to run
+  minReplicas: 1
+  # -- Sets the maximum number of Pods to run
+  maxReplicas: 100
+  # -- Configures the HPA to target a particular CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  # -- If supplied, configures the HPA to target a particular Memory utilization percentage
+  # targetMemoryUtilizationPercentage: 80
+
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target Operating
+# System. Must be set.
+targetOperatingSystem: linux
+
+# -- (`string`) If set, this value will be used in the .spec.nodeSelector to
+# ensure that these pods specifically launch on the desired target host
+# architecture. If set to null/empty-string, then this value will not be set.
+targetArchitecture: amd64
+
+# -- (`map`) A list of key/value pairs that will be added in to the
+# nodeSelector spec for the pods.
+nodeSelector: {}
+
+tolerations: []
+
+topologySpreadConstraints: []
+
+affinity: {}
+
+# Monitoring configuration for metric scraping against the Prometheus-style
+# metrics endpoint.
+monitor:
+  # -- (`bool`) If enabled, PodMonitor resources for Prometheus Operator
+  # are created or if `Values.istio.enabled` is `True`, then the appropriate
+  # Pod Annotations will be added for the istio-proxy sidecar container to
+  # scrape the metrics.
+  enabled: true
+
+  # -- (`string`) Name of the port to scrape for metrics - this is the name of
+  # the port that will be exposed in your `PodSpec` for scraping purposes.
+  portName: metrics
+
+  # -- (`int`) Number of the port to scrape for metrics - this port will be
+  # exposed in your `PodSpec` to ensure it can be scraped.
+  portNumber: 9090
+
+  # -- (`string`) Path to scrape metrics from within your Pod.
+  path: /metrics
+
+  # -- (`map`) PodMonitor annotations.
+  annotations: {}
+
+  # -- Additional PodMonitor labels.
+  labels: {}
+
+  # -- PodMonitor scrape interval
+  interval: null
+
+  # -- (`int`) The maximum number of metrics that can be scraped - if there are
+  # more than this, then scraping will fail entirely by Prometheus. This is
+  # used as a circuit breaker to avoid blowing up Prometheus memory footprints.
+  sampleLimit: 25000
+
+  # -- PodMonitor scrape timeout in Go duration format (e.g. 15s)
+  scrapeTimeout: null
+
+  # -- PodMonitor relabel configs to apply to samples before scraping
+  # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  relabelings: []
+
+  # -- PodMonitor MetricRelabelConfigs to apply to samples before ingestion.
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+  metricRelabelings: []
+
+  # -- (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well
+  scheme: http
+
+  # -- PodMonitor will use these tlsConfig settings to make the health check requests
+  tlsConfig: null
+
+# Configuration that lets the chart know that it's operating inside of an Istio
+# service mesh or not. If it is, certain defaults are applied to various Pod
+# and other resource configurations.
+istio:
+  # -- (`bool`) Whether or not the service should be part of an Istio Service
+  # Mesh. If this is turned on and `Values.monitor.enabled=true`, then the
+  # Istio Sidecar containers will be configured to pull and merge the metrics
+  # from the application, rather than creating a new `PodMonitor` object.
+  enabled: true
+
+  # -- (`int[]`) If supplied, this is a list of TCP ports that are excluded from being
+  # proxied by the Istio-proxy Envoy sidecar process. _The
+  # `.Values.monitor.portNumber` is already included by default.
+  excludeInboundPorts: []
+
+  # -- (`list <str>`) If supplied, this is the command that will be passed into
+  # the `istio-proxy` sidecar container as a pre-stop function. This is used to
+  # delay the shutdown of the istio-proxy sidecar in some way or another. Our
+  # own default behavior is applied if this value is not set - which is that
+  # the sidecar will wait until it does not see the application container
+  # listening on any TCP ports, and then it will shut down.
+  #
+  # eg:
+  # preStopCommand: [ /bin/sleep, "30" ]
+  preStopCommand: null
+
+  # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
+  # turned on and Envoy will attempt to scrape metrics from the application pod
+  # and merge them with its own. This defaults to False beacuse in most
+  # environments we want to explicitly split up the metrics and collect Istio
+  # metrics separate from Application metrics.
+  metricsMerging: false
+
+# Network access controls for the Pods in this application
+network:
+  # -- (`strings[]`) A list of namespaces that are allowed to access the Pods
+  # in this application. If not supplied, then no `NetworkPolicy` is created,
+  # and your application may be isolated to itself. Note, enabling
+    # `VirtualService` or `Ingress` configurations will create their own
+  # dedicated `NetworkPolicy` resources, so this is only intended for internal
+  # service-to-service communication grants.
+  allowedNamespaces: []
+
+# Configures labels and other parameters assuming that the Datadog Agent is
+# installed on the underlying hosts and is part of the Kubernetes cluster.
+datadog:
+  # -- (`bool`) Whether or not the various datadog labels and options should be
+  # included or not.
+  enabled: true
+
+  # -- (`string`) The "env" tag to configure for the application - this maps to
+  # the Datadog environment concept for isolating traces/apm data. _We default
+  # to not setting this, so that the Datadog Agent's own "ENV" setting is used
+  # as the default behavior. Only override this in special cases._
+  env: null
+
+  # -- (`string`) If set, this configures the "service" tag. If this is not
+  # set, the tag defaults to the `.Release.Name` for the application.
+  service: null
+
+  # -- (`bool`) If true, then we will configure the Datadog agent to scrape
+  # metrics from the application pod via the values set in the
+  # .Values.monitor.* map.
+  scrapeMetrics: false
+
+  # -- (`string`) The prefix to append to all metrics that are scraped by
+  # Datadog. We set this to one common value so that common metrics (like
+  # `istio_.*` or `go_.*`) are shared across all apps in Datadog for easier
+  # dashboard creation as well as comparision between applications.
+  metricsNamespace: eks
+
+  # -- (`strings[]`) A list of strings that match the metric names that Datadog
+  # should scrape from the endpoint. This defaults to `"*"` to tell it to
+  # scrape ALL metrics - however, if your app exposes too many metrics (>
+  # 2000), Datadog will drop them all on the ground.
+  metricsToScrape:
+    - '"*"'
+
+  scrapeLogs:
+    # -- (`bool`) If true, then it will enable application logging to datadog.
+    enabled: false
+    # -- (`string`) If set, this configures the "source" tag. If this is not
+    # set, the tag defaults to the `.Release.Name` for the application.
+    source: null
+    # -- (`map[]`) A list of map that sets different log processing rules.
+    # https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
+    processingRules: []
+
+tests:
+  connection:
+    # -- The command used to trigger the test.
+    command: ['curl', '--retry-connrefused', '--retry', '5']
+    # -- A list of arguments passed into the command. These are run through the tpl function.
+    args:
+      - '{{ include "nd-common.fullname" . }}'
+    # By default, we actually use the source-image for the main application as
+    # the image for testing, This allows the image to contain its own "client"
+    # (curl, in this example) for testing the application. Alternatively, you
+    # can configure your own testing image.
+    image:
+      # -- Sets the image-name that will be used in the "connection"
+      # integration test. If this is left empty, then the .image.repository
+      # value will be used instead (and the .image.tag will also be used).
+      # By default, prefer the latest official version to handle cases where the
+      # app image provides either no curl binary or an outdated one.
+      repository: curlimages/curl
+      # -- Sets the tag that will be used in the "connection" integration test.
+      # If this is left empty, the default is "latest"
+      tag:
+
+# -- The URL of the runbook for this service.
+runbookUrl: https://github.com/Nextdoor/k8s-charts/blob/main/charts/simple-app/README.md
+
+# Configure alerts for all istio VirtualServices in the namespace this chart is launched in.
+# If you are launching a single copy of simple-app in a namespace, just leave this enabled
+# to reproduce similar behavior to services launched on ECS with dedicated ALBs. For more
+# complex scenarios, you may want to disable this, and have your application chart directly
+# depend on istio-alerts.
+istio-alerts:
+  # -- (`bool`) Whether or not to enable the istio-alerts chart.
+  enabled: true
+
+# Container Alerting Rules
+#
+# These rules are designed to provide very basic but critical monitoring for
+# the health of your containers and pods. More specific alerts can be created
+# by you - but these apply to the pods and resources managed by this chart.
+prometheusRules:
+  # -- (`bool`) Whether or not to enable the container rules template
+  enabled: true
+
+  # -- (`map`) Additional custom labels attached to every PrometheusRule
+  additionalRuleLabels: {}
+
+  # -- Monitors Pods for Containers that are terminated either for unexpected
+  # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
+  # for $for (1m), then it will alert.
+  PodContainerTerminated:
+    severity: warning
+    threshold: 0
+    over: 10m
+    for: 1m
+    reasons:
+      # - Error  < when a container is evicted gracefully, the "error" state is used.
+      - ContainerCannotRun
+      - DeadlineExceeded
+
+  # -- Pod is crash looping
+  PodCrashLooping:
+    severity: warning
+    for: 15m
+
+  # -- Pod has been in a non-ready state for more than a specific threshold
+  PodNotReady:
+    severity: warning
+    for: 15m
+
+  # -- Container is being throttled by the CGroup - needs more resources.
+  CPUThrottlingHigh:
+    severity: warning
+    threshold: 65
+    for: 15m
+
+  # -- Pod container waiting longer than threshold
+  ContainerWaiting:
+    severity: warning
+    for: 1h
+
+  # -- Deployment generation mismatch due to possible roll-back
+  DeploymentGenerationMismatch:
+    severity: warning
+    for: 15m
+
+  # -- Deployment has not matched the expected number of replicas
+  DeploymentReplicasMismatch:
+    severity: warning
+    for: 15m
+
+  # -- HPA has not matched descired number of replicas
+  HpaReplicasMismatch:
+    severity: warning
+    for: 15m
+
+  # -- HPA is running at max replicas
+  HpaMaxedOut:
+    severity: warning
+    for: 15m


### PR DESCRIPTION
**What did I want?**

As we begin using [Argo Rollouts](https://argoproj.github.io/argo-rollouts/) - we need a new default application template that can create the `Rollout` objects, as well as the more customized `VirtualService` and `Service` resources. I wanted to enable us to begin experimenting with these deployment models in a simple way.

**What did I do?**

A newly created `rollout-app` chart has been created along with some customization to the Github Workflow. The workflow now detects if the `rollout-app` chart was updated, and if it was, we then install the Argo Rollouts controller/CRD for the tests. When the tests run, we verify that we can create both a `BlueGreen` and `Canary` rollout resource type. We are explicitly not testing actually triggering a rollout - we don't need to test the fundamental behavior of Argo, just that our chart basically works.