### PR TITLE
[stateful/simple/nd-common] Implement a smarter TopologySpreadConstraint configuration

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.4.10
+version: 0.4.11
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.11
+    version: 0.0.12
     # Temporary while we're under active development of this dependency chart.
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -152,7 +152,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.11 |
+| file://../nd-common | nd-common | 0.0.12 |
 
 ## Values
 

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.11
+version: 0.0.12
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`
@@ -141,6 +141,35 @@ _Example Usage_:
 ```yaml
 # templates/podmonitor.yaml
 {{- include "nd-common.podMonitor" . }}
+```
+
+## [TopologySpreadConstraint Functions](templates/_topology_spread_constraints.tpl)
+
+This common function creates some sane `TopologySpreadConstraint` settings in a
+PodSpec. The default behavior can be turned on with a simple boolean flag,
+which spreads pods across AZs. More custom topologies can be described as well.
+
+### Values Parameters
+
+* `.Values.topologySpreadConstraints`: A list of maps that conform to the
+    [`TopologySpreadConstraint` API](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api).
+* `.Values.enableTopologySpread`: A boolean to control the creation of the
+    "default" topology spread constraint across AZs.
+* `.Values.topologyKey`: The default `topologyKey` to use when the
+    `enableTopologySpread` boolean flag is enabled.
+* `.Values.topologySkew`: The default `maxSkew` to use when
+    `enableTopologySpread` boolean flag is enabled.
+
+### `nd-common.topologySpreadConstraints`
+
+_Example Usage_:
+```yaml
+
+{{- if or .Values.topologySpreadConstraints .Values.enableTopologySpread }}
+topologySpreadConstraints:
+  {{- include "nd-common.topologySpreadConstraints" . | nindent 8 }}
+{{- end }}
+
 ```
 
 ## [Network Functions](templates/_networkpolicy.tpl)

--- a/charts/nd-common/README.md.gotmpl
+++ b/charts/nd-common/README.md.gotmpl
@@ -143,6 +143,35 @@ _Example Usage_:
 {{`{{- include "nd-common.podMonitor" . }}`}}
 ```
 
+## [TopologySpreadConstraint Functions](templates/_topology_spread_constraints.tpl)
+
+This common function creates some sane `TopologySpreadConstraint` settings in a
+PodSpec. The default behavior can be turned on with a simple boolean flag,
+which spreads pods across AZs. More custom topologies can be described as well.
+
+### Values Parameters
+
+* `.Values.topologySpreadConstraints`: A list of maps that conform to the
+    [`TopologySpreadConstraint` API](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api).
+* `.Values.enableTopologySpread`: A boolean to control the creation of the
+    "default" topology spread constraint across AZs.
+* `.Values.topologyKey`: The default `topologyKey` to use when the
+    `enableTopologySpread` boolean flag is enabled.
+* `.Values.topologySkew`: The default `maxSkew` to use when
+    `enableTopologySpread` boolean flag is enabled.
+
+### `nd-common.topologySpreadConstraints`
+
+_Example Usage_:
+```yaml
+{{`
+{{- if or .Values.topologySpreadConstraints .Values.enableTopologySpread }}
+topologySpreadConstraints:
+  {{- include "nd-common.topologySpreadConstraints" . | nindent 8 }}
+{{- end }}
+`}}
+```
+
 ## [Network Functions](templates/_networkpolicy.tpl)
 
 These functions are focused around providing network-level access into the

--- a/charts/nd-common/templates/_topology_spread_constraints.tpl
+++ b/charts/nd-common/templates/_topology_spread_constraints.tpl
@@ -1,0 +1,55 @@
+{{/*
+
+The "nd-common.topologySpreadConstraints" function turns on a standard
+topologySpreadConstraint for pods to spread them evenly by zone within a given
+maximum skew.
+
+In your Values.yaml file, the following value keys are used and/or required:
+
+** .Values.topologySpreadConstraints **
+
+This is a list of maps that conform to the TopologySpreadConstraints API at
+https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api.
+These will be set up in-order as the first priority.
+
+** .Values.enableTopologySpread **
+
+This boolean setting enables or disables a "default" topologySpreadConstraint
+that forces pods to be launched evenly across zones.
+
+** .Values.topologyKey **
+
+This setting is used by the default TopologySpreadConstraint that we configure
+to evenly distribute pods across AZs. The default value if not supplied is
+`topology.kubernetes.io/zone`.
+
+** .Values.topologySkew **
+
+This translates into the "maximum skew" for the default
+TopologySpreadConstraint. The default value if not supplied is `1`.
+
+*/}}
+{{- define "nd-common.topologySpreadConstraints" -}}
+{{- range $c := index .Values.topologySpreadConstraints -}}
+{{- if $c.labelSelector -}}
+{{ fail "Do not set labelSelector in .Values.toplogySpreadConstraints maps." }}
+{{- end -}}
+- maxSkew: {{ required "Must set maxSkew in .Values.topologySpreadConstraints maps." $c.maxSkew }}
+  topologyKey: {{ required "Must set topologyKey in .Values.topologySpreadConstraints maps." $c.topologyKey }}
+  whenUnsatisfiable: {{ required "Must set whenUnsatisfiable in .Values.topologySpreadConstraints maps." $c.whenUnsatisfiable }}
+  {{- with $c.minDomains }}
+  minDomains: {{ . }}
+  {{- end }}
+  labelSelector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" $ | nindent 6 }}
+{{- end }}
+{{- if .Values.enableTopologySpread }}
+- labelSelector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" . | nindent 6 }}
+  maxSkew: {{ default .Values.topologySkew 1 }}
+  topologyKey: {{ default "topology.kubernetes.io/zone" .Values.topologyKey }}
+  whenUnsatisfiable: DoNotSchedule
+{{- end }}
+{{- end }}

--- a/charts/nd-common/templates/_topology_spread_constraints.tpl
+++ b/charts/nd-common/templates/_topology_spread_constraints.tpl
@@ -48,7 +48,7 @@ TopologySpreadConstraint. The default value if not supplied is `1`.
 - labelSelector:
     matchLabels:
       {{- include "nd-common.selectorLabels" . | nindent 6 }}
-  maxSkew: {{ default .Values.topologySkew 1 }}
+  maxSkew: {{ default 1 .Values.topologySkew }}
   topologyKey: {{ default "topology.kubernetes.io/zone" .Values.topologyKey }}
   whenUnsatisfiable: DoNotSchedule
 {{- end }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.21.12
+version: 0.21.13
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.11
+    version: 0.0.12
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.21.12](https://img.shields.io/badge/Version-0.21.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.21.13](https://img.shields.io/badge/Version-0.21.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -172,7 +172,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.11 |
+| file://../nd-common | nd-common | 0.0.12 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -197,6 +197,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the application pod via the values set in the .Values.monitor.* map. |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
+| enableTopologySpread | bool | `false` | (`bool`) If set to `true`, then a default `TopologySpreadConstraint` will be created that forces your pods to be evenly distributed across nodes based on the `topologyKey` setting. The maximum skew between the spread is controlled with `topologySkew`. |
 | env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
 | envFrom | list | `[]` | Pull all of the environment variables listed in a ConfigMap into the Pod. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables for more details. |
 | fullnameOverride | string | `""` |  |
@@ -285,7 +286,9 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | tests.connection.image.repository | string | `"curlimages/curl"` | Sets the image-name that will be used in the "connection" integration test. If this is left empty, then the .image.repository value will be used instead (and the .image.tag will also be used). By default, prefer the latest official version to handle cases where the app image provides either no curl binary or an outdated one. |
 | tests.connection.image.tag | string | `nil` | Sets the tag that will be used in the "connection" integration test. If this is left empty, the default is "latest" |
 | tolerations | list | `[]` |  |
-| topologySpreadConstraints | list | `[]` |  |
+| topologyKey | string | `"topology.kubernetes.io/zone"` | (`string`) The topologyKey to use when asking Kubernetes to schedule the pods in a particular distribution. The default is to spread across zones evenly. Other options could be `kubernetes.io/hostname` to spread across EC2 instances, or `node.kubernetes.io/instance-type` to spread across instance types for example. |
+| topologySkew | int | `1` | (`int`) The maxSkew setting applied to the default TopologySpreadConstraint if `enableTopologySpread` is set to `true`. |
+| topologySpreadConstraints | list | `[]` | (`string`) An array of custom TopologySpreadConstraint settings applied to the PodSpec within the Deployment. Each of these TopologySpreadObjects should conform to the [`pod.spec.topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api) API - but the `labelSelector` field should be left out, it will be inserted automatically for you. |
 | virtualService.annotations | object | `{}` | Any annotations you wish to add to the `VirtualService` resource. See https://istio.io/latest/docs/reference/config/annotations/ for more details. |
 | virtualService.corsPolicy | object | `{}` | (`map`) If set, this will populate the corsPolicy setting for the VirtualService. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy for more details. |
 | virtualService.enabled | bool | `false` | (Boolean) Maps the Service to an Istio IngressGateway, exposing the service outside of the Kubernetes cluster. |

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -53,9 +53,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- if or .Values.topologySpreadConstraints .Values.enableTopologySpread }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- include "nd-common.topologySpreadConstraints" . | nindent 8 }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -20,6 +20,7 @@ ports:
     # Optional flag to override the client-facing port for service requests.
     port: 443
 
+topologyKey: kubernetes.io/hostname
 enableTopologySpread: true
 terminationGracePeriodSeconds: 30
 autoscaling:

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -20,7 +20,7 @@ ports:
     # Optional flag to override the client-facing port for service requests.
     port: 443
 
-
+enableTopologySpread: true
 terminationGracePeriodSeconds: 30
 autoscaling:
   enabled: true

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -388,7 +388,30 @@ nodeSelector: {}
 
 tolerations: []
 
+# -- (`string`) An array of custom TopologySpreadConstraint settings applied to
+# the PodSpec within the Deployment. Each of these TopologySpreadObjects should
+# conform to the
+# [`pod.spec.topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api)
+# API - but the `labelSelector` field should be left out, it will be inserted
+# automatically for you.
 topologySpreadConstraints: []
+
+# -- (`string`) The topologyKey to use when asking Kubernetes to schedule the
+# pods in a particular distribution. The default is to spread across zones
+# evenly. Other options could be `kubernetes.io/hostname` to spread across EC2
+# instances, or `node.kubernetes.io/instance-type` to spread across instance
+# types for example.
+topologyKey: topology.kubernetes.io/zone
+
+# -- (`int`) The maxSkew setting applied to the default
+# TopologySpreadConstraint if `enableTopologySpread` is set to `true`.
+topologySkew: 1
+
+# -- (`bool`) If set to `true`, then a default `TopologySpreadConstraint` will
+# be created that forces your pods to be evenly distributed across nodes based
+# on the `topologyKey` setting. The maximum skew between the spread is
+# controlled with `topologySkew`.
+enableTopologySpread: false
 
 affinity: {}
 

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.5.10
+version: 0.5.11
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,6 +13,6 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.11
+    version: 0.0.12
     # Temporary while we're under active development of this dependency chart.
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.5.10](https://img.shields.io/badge/Version-0.5.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.5.11](https://img.shields.io/badge/Version-0.5.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -157,7 +157,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.11 |
+| file://../nd-common | nd-common | 0.0.12 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values
@@ -178,6 +178,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | datadog.scrapeMetrics | bool | `false` | (`bool`) If true, then we will configure the Datadog agent to scrape metrics from the application pod via the values set in the .Values.monitor.* map. |
 | datadog.service | `string` | `nil` | If set, this configures the "service" tag. If this is not set, the tag defaults to the `.Release.Name` for the application. |
 | deploymentStrategy | object | `{}` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
+| enableTopologySpread | bool | `false` | (`bool`) If set to `true`, then a default `TopologySpreadConstraint` will be created that forces your pods to be evenly distributed across nodes based on the `topologyKey` setting. The maximum skew between the spread is controlled with `topologySkew`. |
 | env | list | `[]` | Environment Variables for the primary container. These are all run through the tpl function (the key name and value), so you can dynamically name resources as you need. |
 | envFrom | list | `[]` | Pull all of the environment variables listed in a ConfigMap into the Pod. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables for more details. |
 | fullnameOverride | string | `""` |  |
@@ -253,7 +254,9 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | tests.connection.image.repository | string | `nil` | Sets the image-name that will be used in the "connection" integration test. If this is left empty, then the .image.repository value will be used instead (and the .image.tag will also be used). |
 | tests.connection.image.tag | string | `nil` | Sets the tag that will be used in the "connection" integration test. If this is left empty, the default is "latest" |
 | tolerations | list | `[]` |  |
-| topologySpreadConstraints | list | `[]` |  |
+| topologyKey | string | `"topology.kubernetes.io/zone"` | (`string`) The topologyKey to use when asking Kubernetes to schedule the pods in a particular distribution. The default is to spread across zones evenly. Other options could be `kubernetes.io/hostname` to spread across EC2 instances, or `node.kubernetes.io/instance-type` to spread across instance types for example. |
+| topologySkew | int | `1` | (`int`) The maxSkew setting applied to the default TopologySpreadConstraint if `enableTopologySpread` is set to `true`. |
+| topologySpreadConstraints | list | `[]` | (`string`) An array of custom TopologySpreadConstraint settings applied to the PodSpec within the Deployment. Each of these TopologySpreadObjects should conform to the [`pod.spec.topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api) API - but the `labelSelector` field should be left out, it will be inserted automatically for you. |
 | updateStrategy | `StatefulSetUpdateStrategy` | `nil` | updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template. https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#statefulsetupdatestrategy-v1-apps |
 | virtualService.annotations | object | `{}` | Any annotations you wish to add to the `VirtualService` resource. See https://istio.io/latest/docs/reference/config/annotations/ for more details. |
 | virtualService.corsPolicy | object | `{}` | (`map`) If set, this will populate the corsPolicy setting for the VirtualService. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy for more details. |

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -55,9 +55,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- if or .Values.topologySpreadConstraints .Values.enableTopologySpread }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- include "nd-common.topologySpreadConstraints" . | nindent 8 }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/stateful-app/values.local.yaml
+++ b/charts/stateful-app/values.local.yaml
@@ -8,6 +8,7 @@ ingress:
   # ALB-ingress controllers.
   sslRedirect: false
 
+enableTopologySpread: true
 terminationGracePeriodSeconds: 30
 datadog:
   scrapeMetrics: true

--- a/charts/stateful-app/values.local.yaml
+++ b/charts/stateful-app/values.local.yaml
@@ -8,6 +8,7 @@ ingress:
   # ALB-ingress controllers.
   sslRedirect: false
 
+topologyKey: kubernetes.io/hostname
 enableTopologySpread: true
 terminationGracePeriodSeconds: 30
 datadog:

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -389,7 +389,30 @@ nodeSelector: {}
 
 tolerations: []
 
+# -- (`string`) An array of custom TopologySpreadConstraint settings applied to
+# the PodSpec within the Deployment. Each of these TopologySpreadObjects should
+# conform to the
+# [`pod.spec.topologySpreadConstraints`](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api)
+# API - but the `labelSelector` field should be left out, it will be inserted
+# automatically for you.
 topologySpreadConstraints: []
+
+# -- (`string`) The topologyKey to use when asking Kubernetes to schedule the
+# pods in a particular distribution. The default is to spread across zones
+# evenly. Other options could be `kubernetes.io/hostname` to spread across EC2
+# instances, or `node.kubernetes.io/instance-type` to spread across instance
+# types for example.
+topologyKey: topology.kubernetes.io/zone
+
+# -- (`int`) The maxSkew setting applied to the default
+# TopologySpreadConstraint if `enableTopologySpread` is set to `true`.
+topologySkew: 1
+
+# -- (`bool`) If set to `true`, then a default `TopologySpreadConstraint` will
+# be created that forces your pods to be evenly distributed across nodes based
+# on the `topologyKey` setting. The maximum skew between the spread is
+# controlled with `topologySkew`.
+enableTopologySpread: false
 
 affinity: {}
 


### PR DESCRIPTION
The original setup allowed you to pass in a `TopologySpreadConstraints`
list of maps ... but we did no template parsing, no validation, and we
provided no intelligent way to set the `labelSelector` key.

This PR does two things. First we intelligently parse the
`TopologySpreadConstraints` maps that the user supplies, error out
appropriately, and then insert the `labelSelector` automatically.

Second, we create a default topology spread constraint that spreads
across AZs, allowing users to just flip a boolean flag and get the
spread done in the simplest possible way.