### PR TITLE
Add nd-common.podAnnotations helper and demonstrate it with simple-app

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.12
+version: 0.0.13
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_annotations.tpl
+++ b/charts/nd-common/templates/_annotations.tpl
@@ -1,0 +1,14 @@
+{{/*
+
+The "podAnnotations" function includes a number of broadly useful annotations
+that should be applied to Pod resources created by our charts.
+
+*/}}
+{{- define "nd-common.podAnnotations" -}}
+kubectl.kubernetes.io/default-container: {{ include "nd-common.containerName" . }}
+{{- with .Values.secrets }}
+checksum/secrets: {{ toYaml . | sha256sum }}
+{{- end }}
+{{ include "nd-common.istioAnnotations" . }}
+{{ include "nd-common.datadogAnnotations" . }}
+{{- end }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.21.13
+version: 0.21.14
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.12
+    version: 0.0.13
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.21.13](https://img.shields.io/badge/Version-0.21.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.21.14](https://img.shields.io/badge/Version-0.21.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -172,7 +172,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.12 |
+| file://../nd-common | nd-common | 0.0.13 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -27,9 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/secrets: {{ toYaml .Values.secrets | sha256sum }}
-        {{- include "nd-common.istioAnnotations" . | nindent 8 }}
-        {{- include "nd-common.datadogAnnotations" . | nindent 8 }}
+        {{- include "nd-common.podAnnotations" . | nindent 8 }}
         {{- with .Values.podAnnotations }}
         {{- range $annotation, $value := index . }}
         {{ $annotation }}: {{ tpl $value $ | quote }}


### PR DESCRIPTION
Per an outside discussion, this adds a common definition of labels that we use on the majority of Pods we create, and (initially) demonstrates its use on simple-app. Other charts will follow once the approach is settled.