### PR TITLE
[simple-app/stateful-app] Avoid creating the VirtualService if there are no ports

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.21.14
+version: 0.22.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.21.14](https://img.shields.io/badge/Version-0.21.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,20 @@ in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
+
+### 0.21.x -> 0.22.x
+
+**BREAKING: If you do not set .Values.ports, then no VirtualService will be created**
+
+In the past, the `.Values.virtualService.enabled` flag was the only control
+used to determine whether or not to create the `VirtualService` resource. This
+meant that you could accidentally create a `VirtualService` pointing to a
+non-existent `Service` if your application exposes no ports (like a
+"taskworker" type application).
+
+Going forward, the chart will not create a `VirtualService` unless the
+`Values.ports` array is populated as well. This links the logic for `Service`
+and `VirtualService` creation together.
 
 ### 0.20.x -> 0.21.x
 

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -12,6 +12,20 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
+### 0.21.x -> 0.22.x
+
+**BREAKING: If you do not set .Values.ports, then no VirtualService will be created**
+
+In the past, the `.Values.virtualService.enabled` flag was the only control
+used to determine whether or not to create the `VirtualService` resource. This
+meant that you could accidentally create a `VirtualService` pointing to a
+non-existent `Service` if your application exposes no ports (like a
+"taskworker" type application).
+
+Going forward, the chart will not create a `VirtualService` unless the
+`Values.ports` array is populated as well. This links the logic for `Service`
+and `VirtualService` creation together.
+
 ### 0.20.x -> 0.21.x
 
 **BREAKING: Default behavior is to turn on the Istio Annotations/Labels**

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -19,13 +19,15 @@ simplify exposing a customer-facing port number (eg 80) while maintaining an
 internal application port-number (eg, 8080)
 */}}
 {{- define "simple-app.containerPorts" -}}
+{{- if .Values.ports }}
 {{- range $p := index .Values.ports }}
 - name: {{ required "Must set a port name" $p.name }}
   containerPort: {{ required "Must set a containerPort" $p.containerPort }}
   {{- with $p.protocol }}
   protocol: {{ . }}
   {{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/simple-app/templates/istio/virtualservice.yaml
+++ b/charts/simple-app/templates/istio/virtualservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.virtualService.enabled }}
+{{- if and .Values.virtualService.enabled .Values.ports }}
 {{- $global := . }}
 {{- $istioNs := .Values.virtualService.namespace }}
 apiVersion: networking.istio.io/v1alpha3

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.5.12
+version: 0.6.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.5.12](https://img.shields.io/badge/Version-0.5.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,20 @@ in Kubernetes][statefulsets]. The chart provides all of the common pieces like
 ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
+
+### 0.5.x -> 0.6.x
+
+**BREAKING: If you do not set .Values.ports, then no VirtualService will be created**
+
+In the past, the `.Values.virtualService.enabled` flag was the only control
+used to determine whether or not to create the `VirtualService` resource. This
+meant that you could accidentally create a `VirtualService` pointing to a
+non-existent `Service` if your application exposes no ports (like a
+"taskworker" type application).
+
+Going forward, the chart will not create a `VirtualService` unless the
+`Values.ports` array is populated as well. This links the logic for `Service`
+and `VirtualService` creation together.
 
 ### 0.4.x -> 0.5.x
 

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -12,6 +12,20 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
+### 0.5.x -> 0.6.x
+
+**BREAKING: If you do not set .Values.ports, then no VirtualService will be created**
+
+In the past, the `.Values.virtualService.enabled` flag was the only control
+used to determine whether or not to create the `VirtualService` resource. This
+meant that you could accidentally create a `VirtualService` pointing to a
+non-existent `Service` if your application exposes no ports (like a
+"taskworker" type application).
+
+Going forward, the chart will not create a `VirtualService` unless the
+`Values.ports` array is populated as well. This links the logic for `Service`
+and `VirtualService` creation together.
+
 ### 0.4.x -> 0.5.x
 
 **BREAKING: Default behavior is to turn on the Istio Annotations/Labels**

--- a/charts/stateful-app/templates/istio/virtualservice.yaml
+++ b/charts/stateful-app/templates/istio/virtualservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.virtualService.enabled }}
+{{- if and .Values.virtualService.enabled .Values.ports }}
 {{- $global := . }}
 {{- $istioNs := .Values.virtualService.namespace }}
 apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
If there are no `.Values.ports` exposed, then we do not create a `Service` for the application. In that case, we should also not create a `VirtualService` because it would not have anything to point to and it represents an "error" in Istio.