### PR TITLE
[prometheus-alerts/nd-common] Scope down the prometheus-alerts

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,13 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.13
-    # Temporary while we're under active development of this dependency chart.
+    version: 0.0.14
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.13
+version: 0.0.14
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_common.tpl
+++ b/charts/nd-common/templates/_common.tpl
@@ -109,7 +109,7 @@ setting.
 
 Generates a fully qualified Docker image name.
 
-*/}}}
+*/}}
 {{- define "nd-common.imageFqdn" -}}
 {{- $tag := include "nd-common.imageTag" . }}
 {{- if hasPrefix "sha256:" $tag }}

--- a/charts/nd-common/templates/_common.tpl
+++ b/charts/nd-common/templates/_common.tpl
@@ -62,7 +62,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels - two functions here, one for "matchLabels" uses, and one for "matchExpressions".
+Selector labels - two functions here:
+  * one for "matchLabels"
+  * one for "matchExpressions"
 */}}
 {{- define "nd-common.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "nd-common.name" . }}
@@ -96,14 +98,18 @@ setting.
 
 */}}
 {{- define "nd-common.imageTag" -}}
+{{- if .Values.image -}}
 {{- default .Chart.AppVersion (default .Values.image.tag .Values.image.forceTag) }}
-{{- end }}
+{{- else -}}
+{{ .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 
 Generates a fully qualified Docker image name.
 
-*/}}
+*/}}}
 {{- define "nd-common.imageFqdn" -}}
 {{- $tag := include "nd-common.imageTag" . }}
 {{- if hasPrefix "sha256:" $tag }}

--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,8 +2,12 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 0.2.3
+version: 1.0.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
+dependencies:
+  - name: nd-common
+    version: 0.0.14
+    repository: file://../nd-common

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -1,14 +1,42 @@
-# prometheus-alerts
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+# prometheus-alerts
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-## Maintainers
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| diranged | matt@nextdoor.com |  |
+[deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+
+This chart provides a default deployment for a simple application that operates
+in a [Deployment][deployments]. The chart automatically configures various
+defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
+
+## Upgrade Notes
+
+### 0.2.x -> 1.0.x
+
+**BREAKING: All PrometheusRules are now scoped to `.Release.Name` resources by default**
+
+All of the `PrometheusRules` within this chart are now scoped to try to
+narrowly match resources that have the {{ .Release.Name }} prefix. This means
+that rather than looking at _all_ `Deployment` resources in a Namespace, we're
+now only looking at deployment=~{{ .Release.Name }} by default now.
+
+The motivation for this change is to allow the `prometheus-rules` chart to be
+applied to each individual `Application` within a Namespace, without
+conflicting.
+
+This behavior can be tuned via the `defaults.podNameSelector`,
+`defaults.jobNameSelector`, `defaults.deploymentNameSelector`,
+`defaults.statefulsetNameSelector`, `defaults.daemonsetNameSelector` and
+`defaults.hpaNameSelector` values below.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../nd-common | nd-common | 0.0.14 |
 
 ## Values
 
@@ -55,8 +83,14 @@ Helm Chart that provisions a series of common Prometheus Alerts
 | containerRules.PodContainerOOMKilled | object | `{"for":"1m","over":"60m","severity":"warning","threshold":0}` | Sums up all of the OOMKilled events per pod over the $over time (60m). If that number breaches the $threshold (0) for $for (1m), then it will alert. |
 | containerRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
-| defaults.additionalRuleLabels | object | `{}` | Additional custom labels attached to every PrometheusRule |
-| defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/prometheus-alerts/runbook.md"` | The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
+| defaults.additionalRuleLabels | object | `{}` | (`map`) Additional custom labels attached to every PrometheusRule |
+| defaults.daemonsetNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |
+| defaults.deploymentNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the Deployment alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the Deployments in the namespace. This string is run through the `tpl` function. |
+| defaults.hpaNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the HorizontalPodAutoscaler alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the HorizontalPodAutoscalers in the namespace. This string is run through the `tpl` function. |
+| defaults.jobNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the alerts to only Jobs that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all Jobs in the namespace. This string is run through the `tpl` function. |
+| defaults.podNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the alerts to only Pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all Pods in the namespace. This string is run through the `tpl` function. |
+| defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/prometheus-alerts/runbook.md"` | (`string`) The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
+| defaults.statefulsetNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the StatefulSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the StatefulSets in the namespace. This string is run through the `tpl` function. |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/prometheus-alerts/README.md.gotmpl
+++ b/charts/prometheus-alerts/README.md.gotmpl
@@ -1,0 +1,38 @@
+
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" .  }}{{ template "chart.typeBadge" .  }}{{ template "chart.appVersionBadge" .  }}
+
+[deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+
+This chart provides a default deployment for a simple application that operates
+in a [Deployment][deployments]. The chart automatically configures various
+defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
+
+## Upgrade Notes
+
+### 0.2.x -> 1.0.x
+
+**BREAKING: All PrometheusRules are now scoped to `.Release.Name` resources by default**
+
+All of the `PrometheusRules` within this chart are now scoped to try to
+narrowly match resources that have the {{`{{ .Release.Name }}`}} prefix. This means
+that rather than looking at _all_ `Deployment` resources in a Namespace, we're
+now only looking at {{`deployment=~{{ .Release.Name }}`}} by default now.
+
+The motivation for this change is to allow the `prometheus-rules` chart to be
+applied to each individual `Application` within a Namespace, without
+conflicting.
+
+This behavior can be tuned via the `defaults.podNameSelector`,
+`defaults.jobNameSelector`, `defaults.deploymentNameSelector`,
+`defaults.statefulsetNameSelector`, `defaults.daemonsetNameSelector` and
+`defaults.hpaNameSelector` values below.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/prometheus-alerts/templates/_helpers.tpl
+++ b/charts/prometheus-alerts/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{- define "prometheus-alerts.namespaceSelector" -}}
+namespace="{{ .Release.Namespace }}"
+{{- end }}
+
+{{- define "prometheus-alerts.podSelector" -}}
+{{- if .Values.defaults.podNameSelector -}}
+pod=~"{{ tpl .Values.defaults.podNameSelector $ }}"
+{{- else -}}
+pod!=""
+{{- end -}}
+{{- end -}}
+
+{{- define "prometheus-alerts.hpaSelector" -}}
+{{- if .Values.defaults.hpaNameSelector -}}
+job="kube-state-metrics", horizontalpodautoscaler=~"{{ tpl .Values.defaults.hpaNameSelector $ }}", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- else -}}
+job="kube-state-metrics", horizontalpodautoscaler!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- end -}}
+{{- end -}}
+
+{{- define "prometheus-alerts.jobSelector" -}}
+{{- if .Values.defaults.jobNameSelector -}}
+job="kube-state-metrics", job_name=~"{{ tpl .Values.defaults.jobNameSelector $ }}", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- else -}}
+job="kube-state-metrics", job_name!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- end -}}
+{{- end -}}
+
+{{- define "prometheus-alerts.deploymentSelector" -}}
+{{- if .Values.defaults.deploymentNameSelector -}}
+job="kube-state-metrics", kube_deployment=~"{{ tpl .Values.defaults.deploymentNameSelector $ }}", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- else -}}
+job="kube-state-metrics", kube_deployment!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- end -}}
+{{- end -}}
+
+{{- define "prometheus-alerts.statefulsetSelector" -}}
+{{- if .Values.defaults.statefulsetNameSelector -}}
+job="kube-state-metrics", statefulset=~"{{ tpl .Values.defaults.statefulsetNameSelector $ }}", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- else -}}
+job="kube-state-metrics", statefulset!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- end -}}
+{{- end -}}
+
+{{- define "prometheus-alerts.daemonsetSelector" -}}
+{{- if .Values.defaults.daemonsetNameSelector -}}
+job="kube-state-metrics", daemonset=~"{{ tpl .Values.defaults.daemonsetNameSelector $ }}", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- else -}}
+job="kube-state-metrics", daemonset!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -1,6 +1,13 @@
-{{ $values           := .Values }}
-{{ $targetNamespace  := .Release.Namespace }}
-{{ if .Values.containerRules.enabled }}
+{{ $values              := .Values }}
+{{ $daemonsetSelector   := include "prometheus-alerts.daemonsetSelector" . }}
+{{ $deploymentSelector  := include "prometheus-alerts.deploymentSelector" . }}
+{{ $namespaceSelector   := include "prometheus-alerts.namespaceSelector" . }}
+{{ $podSelector         := include "prometheus-alerts.podSelector" . }}
+{{ $jobSelector         := include "prometheus-alerts.jobSelector" . }}
+{{ $hpaSelector         := include "prometheus-alerts.hpaSelector" . }}
+{{ $statefulsetSelector := include "prometheus-alerts.statefulsetSelector" . }}
+
+{{- if .Values.containerRules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -8,6 +15,8 @@ metadata:
   annotations:
     nextdoor.com/chart: {{ .Values.chart_name }}
     nextdoor.com/source: {{ .Values.chart_source }}
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Name }}.{{ .Release.Namespace }}.containerRules
@@ -24,7 +33,11 @@ spec:
       expr: |-
         sum by (container, instance, namespace, pod, reason) (
           sum_over_time(
-            kube_pod_container_status_terminated_reason{reason=~"{{ join "|" .reasons }}", namespace="{{ $targetNamespace }}"}[{{ .over }}]
+            kube_pod_container_status_terminated_reason{
+              reason=~"{{ join "|" .reasons }}",
+              {{ $podSelector }},
+              {{ $namespaceSelector }}
+            }[{{ .over }}]
           )
         ) > {{ .threshold }}
       for: {{ .for }}
@@ -47,7 +60,11 @@ spec:
       expr: |-
         sum by (container, instance, namespace, pod, reason) (
           sum_over_time(
-            kube_pod_container_status_terminated_reason{reason=~"OOMKilled", namespace="{{ $targetNamespace }}"}[{{ .over }}]
+            kube_pod_container_status_terminated_reason{
+              reason=~"OOMKilled",
+              {{ $podSelector }},
+              {{ $namespaceSelector }}
+            }[{{ .over }}]
           )
         ) > {{ .threshold }}
       for: {{ .for }}
@@ -68,7 +85,7 @@ spec:
           namespace {{ $labels.namespace }} for container {{ $labels.container
           }} in pod {{ $labels.pod }}.`}}
       expr: |-
-        sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace=~"{{ $targetNamespace }}"}[5m])) by (container, pod, namespace)
+        sum(increase(container_cpu_cfs_throttled_periods_total{container!="", {{ $namespaceSelector }}"}[5m])) by (container, pod, namespace)
           /
         sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
           > ( {{ .threshold }} / 100 )
@@ -100,7 +117,14 @@ spec:
           Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
           ({{`{{`}} $labels.container {{`}}`}}) is restarting {{`{{`}} printf
           "%.2f" $value {{`}}`}} times / 5 minutes.
-      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[5m]) * 60 * 5 > 0
+      expr: |-
+        rate(
+          kube_pod_container_status_restarts_total{
+            job="kube-state-metrics",
+            {{ $podSelector }},
+            {{ $namespaceSelector }}
+          }[5m]
+        ) * 60 * 5 > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -120,9 +144,19 @@ spec:
       expr: |-
         sum by (namespace, pod) (
           max by(namespace, pod) (
-            kube_pod_status_phase{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", phase=~"Pending|Unknown"}
-          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
-            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+            kube_pod_status_phase{
+              job="kube-state-metrics",
+              phase=~"Pending|Unknown",
+              {{ $podSelector }},
+              {{ $namespaceSelector }}
+            }
+          )
+            *
+          on(namespace, pod)
+          group_left(owner_kind)
+          topk by(namespace, pod) (
+            1,
+            max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
           )
         ) > 0
       for: {{ .for }}
@@ -144,9 +178,9 @@ spec:
           indicates that the Deployment has failed but has not been rolled
           back.
       expr: |-
-        kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        kube_deployment_status_observed_generation{ {{- $deploymentSelector -}} }
           !=
-        kube_deployment_metadata_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        kube_deployment_metadata_generation{ {{- $deploymentSelector -}} }
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -166,11 +200,11 @@ spec:
           replicas for longer than {{ .for }}.
       expr: |-
         (
-          kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+          kube_deployment_spec_replicas{ {{- $deploymentSelector -}} }
             !=
-          kube_deployment_status_replicas_available{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+          kube_deployment_status_replicas_available{ {{- $deploymentSelector -}} }
         ) and (
-          changes(kube_deployment_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[5m])
+          changes(kube_deployment_status_replicas_updated{ {{- $deploymentSelector -}} }[5m])
             ==
           0
         )
@@ -193,11 +227,11 @@ spec:
           replicas for longer than 15 minutes.
       expr: |-
         (
-          kube_statefulset_status_replicas_ready{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+          kube_statefulset_status_replicas_ready{ {{- $statefulsetSelector -}} }
             !=
-          kube_statefulset_status_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+          kube_statefulset_status_replicas{ {{- $statefulsetSelector -}} }
         ) and (
-          changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[5m])
+          changes(kube_statefulset_status_replicas_updated{ {{- $statefulsetSelector -}} }[5m])
             ==
           0
         )
@@ -220,9 +254,9 @@ spec:
           indicates that the StatefulSet has failed but has not been rolled
           back.
       expr: |-
-        kube_statefulset_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        kube_statefulset_status_observed_generation{ {{- $statefulsetSelector -}} }
           !=
-        kube_statefulset_metadata_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        kube_statefulset_metadata_generation{ {{- $statefulsetSelector -}} }
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -242,18 +276,18 @@ spec:
       expr: |-
         (
           max without (revision) (
-            kube_statefulset_status_current_revision{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_statefulset_status_current_revision{ {{- $statefulsetSelector -}} }
               unless
-            kube_statefulset_status_update_revision{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_statefulset_status_update_revision{ {{- $statefulsetSelector -}} }
           )
             *
           (
-            kube_statefulset_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_statefulset_replicas{ {{- $statefulsetSelector -}} }
               !=
-            kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_statefulset_status_replicas_updated{ {{- $statefulsetSelector -}} }
           )
         )  and (
-          changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[5m])
+          changes(kube_statefulset_status_replicas_updated{ {{- $statefulsetSelector -}} }[5m])
             ==
           0
         )
@@ -277,24 +311,24 @@ spec:
       expr: |-
         (
           (
-            kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_daemonset_status_current_number_scheduled{ {{- $daemonsetSelector -}} }
              !=
-            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_daemonset_status_desired_number_scheduled{ {{- $daemonsetSelector -}} }
           ) or (
-            kube_daemonset_status_number_misscheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_daemonset_status_number_misscheduled{ {{- $daemonsetSelector -}} }
              !=
             0
           ) or (
-            kube_daemonset_updated_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_daemonset_updated_number_scheduled{ {{- $daemonsetSelector -}} }
              !=
-            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_daemonset_status_desired_number_scheduled{ {{- $daemonsetSelector -}} }
           ) or (
-            kube_daemonset_status_number_available{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_daemonset_status_number_available{ {{- $daemonsetSelector -}} }
              !=
-            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+            kube_daemonset_status_desired_number_scheduled{ {{- $daemonsetSelector -}} }
           )
         ) and (
-          changes(kube_daemonset_updated_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[5m])
+          changes(kube_daemonset_updated_number_scheduled{ {{- $daemonsetSelector -}} }[5m])
             ==
           0
         )
@@ -315,7 +349,10 @@ spec:
           Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
           container {{`{{`}} $labels.container{{`}}`}} has been in waiting
           state for longer than 1 hour.
-      expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
+      expr: |-
+        sum by (namespace, pod, container) (
+          kube_pod_container_status_waiting_reason{ {{- $daemonsetSelector -}} }
+        ) > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -334,9 +371,9 @@ spec:
           $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are
           not scheduled.'
       expr: |-
-        kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        kube_daemonset_status_desired_number_scheduled{ {{- $daemonsetSelector -}} }
           -
-        kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0
+        kube_daemonset_status_current_number_scheduled{ {{- $daemonsetSelector -}} } > 0
       for: 10m
       labels:
         severity: {{ .severity }}
@@ -354,7 +391,7 @@ spec:
           '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}}
           $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are
           running where they are not supposed to run.'
-      expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0
+      expr: kube_daemonset_status_number_misscheduled{ {{- $daemonsetSelector -}} } > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -371,7 +408,11 @@ spec:
         description: >-
           Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name
           {{`}}`}} is taking more than 12 hours to complete.
-      expr: kube_job_spec_completions{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} - kube_job_status_succeeded{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}  > 0
+      expr: |-
+        kube_job_spec_completions{ {{- $jobSelector -}} }
+          -
+        kube_job_status_succeeded{ {{- $jobSelector -}} }
+          > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -389,7 +430,7 @@ spec:
           Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name
           {{`}}`}} failed to complete. Removing failed job after investigation
           should clear this alert.
-      expr: kube_job_failed{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}  > 0
+      expr: kube_job_failed{ {{- $jobSelector -}} }  > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -408,19 +449,31 @@ spec:
           has not matched the desired number of replicas for longer than 15
           minutes.
       expr: |-
-        (kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        (
+         kube_horizontalpodautoscaler_status_desired_replicas{ {{- $hpaSelector -}} }
           !=
-        kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"})
+         kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
+        )
           and
-        (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+
+        (
+         kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
           >
-        kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"})
+         kube_horizontalpodautoscaler_spec_min_replicas{ {{- $hpaSelector -}} }
+        )
+
           and
-        (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+
+        (
+         kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
           <
-        kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"})
+         kube_horizontalpodautoscaler_spec_max_replicas{ {{- $hpaSelector -}} }
+        )
+
           and
+
         changes(kube_horizontalpodautoscaler_status_current_replicas[15m]) == 0
+
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -438,9 +491,9 @@ spec:
           HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}}
           has been running at max replicas for longer than 15 minutes.
       expr: |-
-        kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
           ==
-        kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        kube_horizontalpodautoscaler_spec_max_replicas{ {{- $hpaSelector -}} }
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -67,10 +67,48 @@ alertManager:
 
 # Defaults applied to all Prometheus Rules
 defaults:
-  # -- The prefix URL to the runbook_urls that will be applied to each PrometheusRule
+  # -- (`string`) The prefix URL to the runbook_urls that will be applied to each PrometheusRule
   runbookUrl: https://github.com/Nextdoor/k8s-charts/blob/main/charts/prometheus-alerts/runbook.md
-  # -- Additional custom labels attached to every PrometheusRule
+
+  # -- (`map`) Additional custom labels attached to every PrometheusRule
   additionalRuleLabels: {}
+
+  # -- (`string`) Pattern used to scope down the alerts to only Pods that are
+  # part of this general application. Set to `None` if you want to disable this
+  # selector and apply the rules to all Pods in the namespace. This string is
+  # run through the `tpl` function.
+  podNameSelector: '{{ .Release.Name }}-.*'
+
+  # -- (`string`) Pattern used to scope down the alerts to only Jobs that are
+  # part of this general application. Set to `None` if you want to disable this
+  # selector and apply the rules to all Jobs in the namespace. This string is
+  # run through the `tpl` function.
+  jobNameSelector: '{{ .Release.Name }}-.*'
+
+  # -- (`string`) Pattern used to scope down the Deployment alerts to pods that
+  # are part of this general application. Set to `None` if you want to disable
+  # this selector and apply the rules to all the Deployments in the namespace.
+  # This string is run through the `tpl` function.
+  deploymentNameSelector: '{{ .Release.Name }}'
+
+  # -- (`string`) Pattern used to scope down the StatefulSet alerts to pods that
+  # are part of this general application. Set to `None` if you want to disable
+  # this selector and apply the rules to all the StatefulSets in the namespace.
+  # This string is run through the `tpl` function.
+  statefulsetNameSelector: '{{ .Release.Name }}'
+
+  # -- (`string`) Pattern used to scope down the DaemonSet alerts to pods that
+  # are part of this general application. Set to `None` if you want to disable
+  # this selector and apply the rules to all the DaemonSets in the namespace.
+  # This string is run through the `tpl` function.
+  daemonsetNameSelector: '{{ .Release.Name }}'
+
+  # -- (`string`) Pattern used to scope down the HorizontalPodAutoscaler alerts
+  # to pods that are part of this general application. Set to `None` if you
+  # want to disable this selector and apply the rules to all the
+  # HorizontalPodAutoscalers in the namespace. This string is run through the
+  # `tpl` function.
+  hpaNameSelector: '{{ .Release.Name }}'
 
 # Container Alerting Rules
 #

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.22.0
+version: 0.22.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.13
+    version: 0.0.14
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.22.1](https://img.shields.io/badge/Version-0.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -186,7 +186,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.13 |
+| file://../nd-common | nd-common | 0.0.14 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,6 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.13
-    # Temporary while we're under active development of this dependency chart.
+    version: 0.0.14
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -171,7 +171,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.13 |
+| file://../nd-common | nd-common | 0.0.14 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.3 |
 
 ## Values


### PR DESCRIPTION
The prometheus-alerts chart was too widely scoped. This would make it
difficult to run multiple Applications within a single Namespace that
each define their own prometheus-alerts charts.

This change significantly breaks backwards compatibility - hence the
major version upgrade. The new code narrowly scopes the alerts by
default, and provides overrides to let a developer widen their scope.