### PR TITLE
[prometheus-alerts] Use the wildcard selector by default

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -3,7 +3,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -84,13 +84,13 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
 | defaults.additionalRuleLabels | object | `{}` | (`map`) Additional custom labels attached to every PrometheusRule |
-| defaults.daemonsetNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |
-| defaults.deploymentNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the Deployment alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the Deployments in the namespace. This string is run through the `tpl` function. |
-| defaults.hpaNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the HorizontalPodAutoscaler alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the HorizontalPodAutoscalers in the namespace. This string is run through the `tpl` function. |
+| defaults.daemonsetNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |
+| defaults.deploymentNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the Deployment alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the Deployments in the namespace. This string is run through the `tpl` function. |
+| defaults.hpaNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the HorizontalPodAutoscaler alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the HorizontalPodAutoscalers in the namespace. This string is run through the `tpl` function. |
 | defaults.jobNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the alerts to only Jobs that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all Jobs in the namespace. This string is run through the `tpl` function. |
 | defaults.podNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the alerts to only Pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all Pods in the namespace. This string is run through the `tpl` function. |
 | defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/prometheus-alerts/runbook.md"` | (`string`) The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
-| defaults.statefulsetNameSelector | string | `"{{ .Release.Name }}"` | (`string`) Pattern used to scope down the StatefulSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the StatefulSets in the namespace. This string is run through the `tpl` function. |
+| defaults.statefulsetNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the StatefulSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the StatefulSets in the namespace. This string is run through the `tpl` function. |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -89,26 +89,26 @@ defaults:
   # are part of this general application. Set to `None` if you want to disable
   # this selector and apply the rules to all the Deployments in the namespace.
   # This string is run through the `tpl` function.
-  deploymentNameSelector: '{{ .Release.Name }}'
+  deploymentNameSelector: '{{ .Release.Name }}-.*'
 
   # -- (`string`) Pattern used to scope down the StatefulSet alerts to pods that
   # are part of this general application. Set to `None` if you want to disable
   # this selector and apply the rules to all the StatefulSets in the namespace.
   # This string is run through the `tpl` function.
-  statefulsetNameSelector: '{{ .Release.Name }}'
+  statefulsetNameSelector: '{{ .Release.Name }}-.*'
 
   # -- (`string`) Pattern used to scope down the DaemonSet alerts to pods that
   # are part of this general application. Set to `None` if you want to disable
   # this selector and apply the rules to all the DaemonSets in the namespace.
   # This string is run through the `tpl` function.
-  daemonsetNameSelector: '{{ .Release.Name }}'
+  daemonsetNameSelector: '{{ .Release.Name }}-.*'
 
   # -- (`string`) Pattern used to scope down the HorizontalPodAutoscaler alerts
   # to pods that are part of this general application. Set to `None` if you
   # want to disable this selector and apply the rules to all the
   # HorizontalPodAutoscalers in the namespace. This string is run through the
   # `tpl` function.
-  hpaNameSelector: '{{ .Release.Name }}'
+  hpaNameSelector: '{{ .Release.Name }}-.*'
 
 # Container Alerting Rules
 #


### PR DESCRIPTION
I forgot that the various resource names are going to be `{{ .Release.Name}-{{ .Chart.Name }}`
in most cases, which means that we need to use the `-.*` wildcard selector.