### PR TITLE
[daemonset-app] Use 'false' rather than 'null'

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -436,15 +436,15 @@ alerts:
   containerRules:
     # These rules are disabled because they do not match the resources this
     # chart can create.
-    KubeDeploymentGenerationMismatch: null
-    KubeDeploymentReplicasMismatch: null
-    KubeHpaMaxedOut: null
-    KubeHpaReplicasMismatch: null
-    KubeJobCompletion: null
-    KubeJobFailed: null
-    KubeStatefulSetGenerationMismatch: null
-    KubeStatefulSetReplicasMismatch: null
-    KubeStatefulSetUpdateNotRolledOut: null
+    KubeDeploymentGenerationMismatch: false
+    KubeDeploymentReplicasMismatch: false
+    KubeHpaMaxedOut: false
+    KubeHpaReplicasMismatch: false
+    KubeJobCompletion: false
+    KubeJobFailed: false
+    KubeStatefulSetGenerationMismatch: false
+    KubeStatefulSetReplicasMismatch: false
+    KubeStatefulSetUpdateNotRolledOut: false
 
 tests:
   connection:


### PR DESCRIPTION
When nested charts merge the Values, the 'null' values don't translate
causing them to be wiped out of the final chart.