### PR TITLE
[simple/daemon/stateful] Revert to using in-template prometheusrules

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,17 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.6.1
+version: 0.7.0
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
-  - name: prometheus-alerts
-    alias: alerts
-    version: 1.0.2
-    repository: https://k8s-charts.nextdoor.com
-    condition: alerts.enabled
   - name: nd-common
     version: 0.0.15
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,14 @@ in Kubernetes][statefulsets]. The chart provides all of the common pieces like
 ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
+
+### 0.6.x -> 0.7.x
+
+**BREAKING: Rolled back to Values.prometheusRules**
+
+The use of nested charts within nested charts is problematic, and we have
+rolled it back. Please use `Values.prometheusRules` to configure alarms. We
+will deprecate the `prometheus-alerts` chart.
 
 ### 0.5.0 -> 0.6.0
 

--- a/charts/daemonset-app/README.md.gotmpl
+++ b/charts/daemonset-app/README.md.gotmpl
@@ -12,6 +12,14 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
+### 0.6.x -> 0.7.x
+
+**BREAKING: Rolled back to Values.prometheusRules**
+
+The use of nested charts within nested charts is problematic, and we have
+rolled it back. Please use `Values.prometheusRules` to configure alarms. We
+will deprecate the `prometheus-alerts` chart.
+
 ### 0.5.0 -> 0.6.0
 
 **NEW: PrometheusRules are enabled by default!!**

--- a/charts/daemonset-app/templates/prometheusrules.yaml
+++ b/charts/daemonset-app/templates/prometheusrules.yaml
@@ -1,0 +1,267 @@
+{{- $values          := .Values }}
+{{- $global          := . }}
+{{- $targetNamespace := .Release.Namespace }}
+{{- $runbookUrl      := required "Values.runbookUrl can not be blank!" .Values.runbookUrl }}
+{{- $appName         := include "nd-common.fullname" . }}
+{{- $podName         := trunc 56 $appName | printf "%s.*" }}
+{{- if .Values.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  groups:
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules
+    rules:
+
+    {{- with .Values.prometheusRules.PodContainerTerminated }}
+    - alert: PodContainerTerminated
+      annotations:
+        summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
+        runbook_url: {{ $runbookUrl }}#kube-pod-container-terminated
+        description: >-
+          Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
+          has a container that has been terminated ({{`{{ $value }}`}} times) due to
+          {{`{{$labels.reason}}`}} in the last {{ .for }}.
+      expr: |-
+        sum by (container, namespace, pod, reason) (
+          sum_over_time(
+            kube_pod_container_status_terminated_reason{
+              reason=~"{{ join "|" .reasons }}",
+              namespace="{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[{{ .over }}]
+          )
+        ) > {{ .threshold }}
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodCrashLooping }}
+    - alert: PodCrashLooping
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} is crash looping.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod
+          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+      expr: |-
+        rate(
+          kube_pod_container_status_restarts_total{
+            job="kube-state-metrics",
+            namespace=~"{{ $targetNamespace }}",
+            pod=~"{{ $podName }}"
+          }[5m]
+        ) * 60 * 5 > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodNotReady }}
+    - alert: PodNotReady
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} has been in a non-ready state for more than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          Pod {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          has been in a non-ready state for longer than {{ .for }}.
+      expr: |-
+        sum by (namespace, pod) (
+          max by(namespace, pod) (
+            kube_pod_status_phase{
+              job="kube-state-metrics",
+              namespace=~"{{ $targetNamespace }}",
+              phase=~"Pending|Unknown",
+              pod=~"{{ $podName }}"
+            }
+          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.ContainerRules
+    rules:
+
+    {{- with .Values.prometheusRules.CPUThrottlingHigh }}
+    - alert: CPUThrottlingHigh
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} processes are experiencing elevated CPU throttling
+        runbook_url: {{ $runbookUrl }}#CPUThrottlingHigh
+        description: >-
+          {{`{{ $value | humanizePercentage }}`}} throttling of CPU in
+          namespace {{`{{ $labels.namespace }}`}} for container
+          {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}.
+      expr: |-
+        sum(
+          increase(
+            container_cpu_cfs_throttled_periods_total{
+              container!="",
+              namespace=~"{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[5m]
+          )
+        ) by (container, pod, namespace)
+
+          /
+
+        sum(
+          increase(
+            container_cpu_cfs_periods_total{}[5m]
+          )
+        ) by (container, pod, namespace)
+
+        > ( {{ .threshold }} / 100 )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.ContainerWaiting }}
+    - alert: ContainerWaiting
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} container ({{`{{ $labels.container }}`}}) waiting longer than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#containerwaiting
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}
+          (namespace: {{`{{ $labels.namespace }}`}} has been in a waiting
+          state for longer than 1 hour.
+      expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.DaemonsetRules
+    rules:
+
+    {{ with .Values.prometheusRules.KubeDaemonSetRolloutStuck -}}
+    - alert: KubeDaemonSetRolloutStuck
+      annotations:
+        summary: DaemonSet rollout is stuck.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubedaemonsetrolloutstuck
+        description: >-
+          DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}}
+          $labels.daemonset {{`}}`}} has not finished or progressed for at
+          least {{ .for }}.
+      expr: |-
+        (
+          (
+            kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+             !=
+            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+          ) or (
+            kube_daemonset_status_number_misscheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+             !=
+            0
+          ) or (
+            kube_daemonset_updated_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+             !=
+            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+          ) or (
+            kube_daemonset_status_number_available{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+             !=
+            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+          )
+        ) and (
+          changes(kube_daemonset_updated_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}[5m])
+            ==
+          0
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml $values.prometheusRules.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{ with .Values.prometheusRules.KubeContainerWaiting -}}
+    - alert: KubeContainerWaiting
+      annotations:
+        summary: Pod container waiting longer than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#alert-name-kubecontainerwaiting
+        description: >-
+          Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
+          container {{`{{`}} $labels.container{{`}}`}} has been in waiting
+          state for longer than 1 hour.
+      expr: |-
+        sum by (namespace, pod, container) (
+          kube_pod_container_status_waiting_reason{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml $values.prometheusRules.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{ with .Values.prometheusRules.KubeDaemonSetNotScheduled -}}
+    - alert: KubeDaemonSetNotScheduled
+      annotations:
+        summary: DaemonSet pods are not scheduled.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubedaemonsetnotscheduled
+        description: >-
+          '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}}
+          $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are
+          not scheduled.'
+      expr: |-
+        kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"}
+          -
+        kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"} > 0
+      for: 10m
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml $values.prometheusRules.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{ with .Values.prometheusRules.KubeDaemonSetMisScheduled -}}
+    - alert: KubeDaemonSetMisScheduled
+      annotations:
+        summary: DaemonSet pods are misscheduled.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubedaemonsetmisscheduled
+        description: >-
+          '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}}
+          $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are
+          running where they are not supposed to run.'
+      expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics", daemonset="{{ $appName }}", namespace=~"{{ $targetNamespace }}"} > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml $values.prometheusRules.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+{{- end }}
+

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -1,3 +1,6 @@
+# -- The URL of the runbook for this service.
+runbookUrl: https://github.com/Nextdoor/k8s-charts/blob/main/charts/daemonset-app/README.md
+
 verticalAutoscaling:
   # -- (`bool`) Controls whether or not an VerticalPodAutoscaler resource is created.
   enabled: false
@@ -425,26 +428,66 @@ datadog:
     # https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
     processingRules: []
 
-# Configures alerts for all the pods managed by this application chart by
-# default. This chart can be overridden and reconfigured, but the default
-# behavior is generally correct for most workloads.
-alerts:
+# Container Alerting Rules
+#
+# These rules are designed to provide very basic but critical monitoring for
+# the health of your containers and pods. More specific alerts can be created
+# by you - but these apply to the pods and resources managed by this chart.
+prometheusRules:
   # -- (`bool`) Whether or not to enable the prometheus-alerts chart.
   enabled: true
 
-  # -- (`map`) Configure the specific Container rules that we want
-  containerRules:
-    # These rules are disabled because they do not match the resources this
-    # chart can create.
-    KubeDeploymentGenerationMismatch: false
-    KubeDeploymentReplicasMismatch: false
-    KubeHpaMaxedOut: false
-    KubeHpaReplicasMismatch: false
-    KubeJobCompletion: false
-    KubeJobFailed: false
-    KubeStatefulSetGenerationMismatch: false
-    KubeStatefulSetReplicasMismatch: false
-    KubeStatefulSetUpdateNotRolledOut: false
+  # -- (`map`) Additional custom labels attached to every PrometheusRule
+  additionalRuleLabels: {}
+
+  # -- Monitors Pods for Containers that are terminated either for unexpected
+  # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
+  # for $for (1m), then it will alert.
+  PodContainerTerminated:
+    severity: warning
+    threshold: 0
+    over: 10m
+    for: 1m
+    reasons:
+      # - Error  < when a container is evicted gracefully, the "error" state is used.
+      - ContainerCannotRun
+      - DeadlineExceeded
+
+  # -- Pod is crash looping
+  PodCrashLooping:
+    severity: warning
+    for: 15m
+
+  # -- Pod has been in a non-ready state for more than a specific threshold
+  PodNotReady:
+    severity: warning
+    for: 15m
+
+  # -- Container is being throttled by the CGroup - needs more resources.
+  CPUThrottlingHigh:
+    severity: warning
+    threshold: 65
+    for: 15m
+
+  # -- Pod container waiting longer than threshold
+  ContainerWaiting:
+    severity: warning
+    for: 1h
+
+  # -- DaemonSet pods are not scheduled
+  KubeDaemonSetNotScheduled:
+    severity: warning
+    for: 10m
+
+  # -- DaemonSet pods are misscheduled
+  KubeDaemonSetMisScheduled:
+    severity: warning
+    for: 15m
+
+  # -- DaemonSet rollout is stuck
+  KubeDaemonSetRolloutStuck:
+    severity: warning
+    for: 15m
 
 tests:
   connection:

--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: 0.0.1
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.14
+    version: 0.0.15
     repository: file://../nd-common

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -3,7 +3,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -11,6 +11,12 @@ Helm Chart that provisions a series of common Prometheus Alerts
 This chart provides a default deployment for a simple application that operates
 in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
+
+## Important Note on Changs to this chart!
+
+If you make changes to the queries in this chart, you must also go duplicate
+those changes in the `charts/simple-app`, `charts/daemonset-app` and
+`charts/stateful-app` charts.
 
 ## Upgrade Notes
 
@@ -36,7 +42,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.14 |
+| file://../nd-common | nd-common | 0.0.15 |
 
 ## Values
 

--- a/charts/prometheus-alerts/README.md.gotmpl
+++ b/charts/prometheus-alerts/README.md.gotmpl
@@ -11,6 +11,12 @@ This chart provides a default deployment for a simple application that operates
 in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
+## Important Note on Changs to this chart!
+
+If you make changes to the queries in this chart, you must also go duplicate
+those changes in the `charts/simple-app`, `charts/daemonset-app` and
+`charts/stateful-app` charts.
+
 ## Upgrade Notes
 
 ### 0.2.x -> 1.0.x

--- a/charts/prometheus-alerts/templates/_helpers.tpl
+++ b/charts/prometheus-alerts/templates/_helpers.tpl
@@ -1,3 +1,7 @@
+{{- define "prometheus-alerts.fullname" -}}
+{{ .Template.Name | replace ".yaml" "" | replace "/" "-" | trunc 63 }}
+{{- end }}
+
 {{- define "prometheus-alerts.namespaceSelector" -}}
 namespace="{{ .Release.Namespace }}"
 {{- end }}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -11,7 +11,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ .Release.Name }}-container-rules
+  name: {{ include "prometheus-alerts.fullname" . }}
   annotations:
     nextdoor.com/chart: {{ .Values.chart_name }}
     nextdoor.com/source: {{ .Values.chart_source }}

--- a/charts/prometheus-alerts/templates/pagerduty-alertmanagerconfig.yaml
+++ b/charts/prometheus-alerts/templates/pagerduty-alertmanagerconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
-  name: {{ .Release.Name }}-default-pagerduty
+  name: {{ include "prometheus-alerts.fullname" . }}
   labels:
     alertmanagerConfig: {{ .Values.alertManager.alertmanagerConfig }}
 spec:
@@ -19,6 +19,6 @@ spec:
         - sendResolved: true
           severity: '{{ .Files.Get "files/pagerduty_severity.tpl" | trimSuffix "\n" }}'
           routingKey:
-            name: {{ .Release.Name }}-default-pagerduty-routing-key
+            name: {{ include "prometheus-alerts.fullname" . }}
             key: routing_key
 {{ end -}}

--- a/charts/prometheus-alerts/templates/pagerduty-routing-key-externalsecret.yaml
+++ b/charts/prometheus-alerts/templates/pagerduty-routing-key-externalsecret.yaml
@@ -3,12 +3,12 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
-  name: {{ .Release.Name }}-default-pagerduty-routing-key
+  name: {{ include "prometheus-alerts.fullname" . }}
 spec:
   secretStoreRef:
     {{- toYaml .Values.alertManager.pagerduty.routing_key_store_ref | nindent 4 }}
   target:
-    name: {{ .Release.Name }}-default-pagerduty-routing-key
+    name: {{ include "prometheus-alerts.fullname" . }}
   data:
     - secretKey: routing_key
       remoteRef:
@@ -17,7 +17,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-default-pagerduty-routing-key
+  name: {{ include "prometheus-alerts.fullname" . }}
 type: Opaque
 data:
   routing_key: {{ .Values.alertManager.pagerduty.routing_key | b64enc }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.23.1
+version: 0.23.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.23.2
+version: 0.24.0
 appVersion: latest
 maintainers:
   - name: diranged
@@ -12,11 +12,6 @@ dependencies:
     version: 0.1.3
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
-  - name: prometheus-alerts
-    version: 1.0.2
-    alias: alerts
-    repository: https://k8s-charts.nextdoor.com
-    condition: alerts.enabled
   - name: nd-common
     version: 0.0.15
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.23.1](https://img.shields.io/badge/Version-0.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.23.2](https://img.shields.io/badge/Version-0.23.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -211,7 +211,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| alerts.containerRules | object | `{"KubeDaemonSetMisScheduled":false,"KubeDaemonSetNotScheduled":false,"KubeJobCompletion":false,"KubeJobFailed":false,"KubeStatefulSetGenerationMismatch":false,"KubeStatefulSetReplicasMismatch":false,"KubeStatefulSetUpdateNotRolledOut":false}` | (`map`) Configure the specific Container rules that we want |
+| alerts.containerRules | object | `{"KubeDaemonSetMisScheduled":false,"KubeDaemonSetNotScheduled":false,"KubeDaemonSetRolloutStuck":false,"KubeJobCompletion":false,"KubeJobFailed":false,"KubeStatefulSetGenerationMismatch":false,"KubeStatefulSetReplicasMismatch":false,"KubeStatefulSetUpdateNotRolledOut":false}` | (`map`) Configure the specific Container rules that we want |
 | alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the prometheus-alerts chart. |
 | args | list | `[]` | The arguments passed to the command. If unspecified the container defaults are used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
 | autoscaling.behavior | object | `{"scaleDown":{"policies":[{"periodSeconds":60,"type":"Pods","value":5},{"periodSeconds":60,"type":"Percent","value":25}],"selectPolicy":"Min","stabilizationWindowSeconds":300},"scaleUp":{"policies":[{"periodSeconds":60,"type":"Pods","value":4},{"periodSeconds":60,"type":"Percent","value":100}],"selectPolicy":"Max","stabilizationWindowSeconds":0}}` | (`map`) Controls the way that the AutoScaler scales up and down. We use this to control the speed in which the scaler responds to scaleUp and scaleDown events. Explicitly set this to `null` to let Kubernetes set its default policy. |

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -12,6 +12,14 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
+### 0.23.x -> 0.24.x
+
+**BREAKING: Rolled back to Values.prometheusRules**
+
+The use of nested charts within nested charts is problematic, and we have
+rolled it back. Please use `Values.prometheusRules` to configure alarms. We
+will deprecate the `prometheus-alerts` chart.
+
 ### 0.22.x -> 0.23.x
 
 **BREAKING: The HorizontalPodAutoscaler has been upgraded to `v2beta2`**

--- a/charts/simple-app/templates/prometheusrules.yaml
+++ b/charts/simple-app/templates/prometheusrules.yaml
@@ -1,0 +1,281 @@
+{{- $values          := .Values }}
+{{- $global          := . }}
+{{- $targetNamespace := .Release.Namespace }}
+{{- $runbookUrl      := required "Values.runbookUrl can not be blank!" .Values.runbookUrl }}
+{{- $appName         := include "nd-common.fullname" . }}
+{{- $podName         := trunc 56 $appName | printf "%s.*" }}
+{{- if .Values.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  groups:
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules
+    rules:
+
+    {{- with .Values.prometheusRules.PodContainerTerminated }}
+    - alert: PodContainerTerminated
+      annotations:
+        summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
+        runbook_url: {{ $runbookUrl }}#kube-pod-container-terminated
+        description: >-
+          Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
+          has a container that has been terminated ({{`{{ $value }}`}} times) due to
+          {{`{{$labels.reason}}`}} in the last {{ .for }}.
+      expr: |-
+        sum by (container, namespace, pod, reason) (
+          sum_over_time(
+            kube_pod_container_status_terminated_reason{
+              reason=~"{{ join "|" .reasons }}",
+              namespace="{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[{{ .over }}]
+          )
+        ) > {{ .threshold }}
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodCrashLooping }}
+    - alert: PodCrashLooping
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} is crash looping.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod
+          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+      expr: |-
+        rate(
+          kube_pod_container_status_restarts_total{
+            job="kube-state-metrics",
+            namespace=~"{{ $targetNamespace }}",
+            pod=~"{{ $podName }}"
+          }[5m]
+        ) * 60 * 5 > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodNotReady }}
+    - alert: PodNotReady
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} has been in a non-ready state for more than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          Pod {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          has been in a non-ready state for longer than {{ .for }}.
+      expr: |-
+        sum by (namespace, pod) (
+          max by(namespace, pod) (
+            kube_pod_status_phase{
+              job="kube-state-metrics",
+              namespace=~"{{ $targetNamespace }}",
+              phase=~"Pending|Unknown",
+              pod=~"{{ $podName }}"
+            }
+          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.ContainerRules
+    rules:
+
+    {{- with .Values.prometheusRules.CPUThrottlingHigh }}
+    - alert: CPUThrottlingHigh
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} processes are experiencing elevated CPU throttling
+        runbook_url: {{ $runbookUrl }}#CPUThrottlingHigh
+        description: >-
+          {{`{{ $value | humanizePercentage }}`}} throttling of CPU in
+          namespace {{`{{ $labels.namespace }}`}} for container
+          {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}.
+      expr: |-
+        sum(
+          increase(
+            container_cpu_cfs_throttled_periods_total{
+              container!="",
+              namespace=~"{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[5m]
+          )
+        ) by (container, pod, namespace)
+
+          /
+
+        sum(
+          increase(
+            container_cpu_cfs_periods_total{}[5m]
+          )
+        ) by (container, pod, namespace)
+
+        > ( {{ .threshold }} / 100 )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.ContainerWaiting }}
+    - alert: ContainerWaiting
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} container ({{`{{ $labels.container }}`}}) waiting longer than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#containerwaiting
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}
+          (namespace: {{`{{ $labels.namespace }}`}} has been in a waiting
+          state for longer than 1 hour.
+      expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.DeploymentRules
+    rules:
+
+    {{- with .Values.prometheusRules.DeploymentGenerationMismatch }}
+    - alert: DeploymentGenerationMismatch
+      annotations:
+        summary: >-
+          {{`{{ $labels.deployment }}`}} deployment generation mismatch due to possible roll-back
+        runbook_url: {{ $runbookUrl }}#deploymentgenerationmismatch
+        description: >-
+          Deployment generation for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment }}`}}
+          does not match, this indicates that the Deployment has failed but has not been rolled
+          back.
+      expr: |-
+        sum by(namespace, deployment) (
+          kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+            !=
+          kube_deployment_metadata_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.DeploymentReplicasMismatch }}
+    - alert: DeploymentReplicasMismatch
+      annotations:
+        summary: >-
+          {{`{{ $labels.deployment }}`}} deployment has not matched the expected number of replicas.
+        runbook_url: {{ $runbookUrl }}#deploymentreplicasmismatch
+        description: >-
+          Deployment {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment }}`}}
+          has not matched the expected number of replicas for longer than {{ .for }}.
+      expr: |-
+        sum by(namespace, deployment) (
+          (
+            kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+              !=
+            kube_deployment_status_replicas_available{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}
+          ) and (
+            changes(kube_deployment_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", deployment="{{ $appName }}"}[5m])
+              ==
+            0
+          )
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  {{- if .Values.autoscaling.enabled }}
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.HorizontalPodAutoscalerRules
+    rules:
+
+    {{- with .Values.prometheusRules.HpaReplicasMismatch }}
+    - alert: HpaReplicasMismatch
+      annotations:
+        summary: >-
+          {{`{{ $labels.horizontalpodautoscaler }}`}} HPA has not matched descired number of replicas.
+        runbook_url: {{ $runbookUrl }}#hpareplicasmismatch
+        description: >-
+          HPA {{`{{ $labels.namespace }}`}}/{{`{{ $labels.horizontalpodautoscaler }}`}}
+          has not matched the desired number of replicas for longer than 15
+          minutes.
+      expr: |-
+        sum by(namespace, horizontalpodautoscaler) (
+          (kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            !=
+          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"})
+            and
+          (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            >
+          kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"})
+            and
+          (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            <
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"})
+            and
+          changes(kube_horizontalpodautoscaler_status_current_replicas[15m]) == 0
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.HpaMaxedOut }}
+    - alert: HpaMaxedOut
+      annotations:
+        summary: >-
+          {{`{{ $labels.horizontalpodautoscaler }}`}} HPA is running at max replicas
+        runbook_url: {{ $runbookUrl }}#hpamaxedout
+        description: >-
+          HPA {{`{{ $labels.namespace }}`}}/{{`{{ $labels.horizontalpodautoscaler }}`}}
+          has been running at max replicas for longer than 15 minutes.
+      expr: |-
+        sum by(namespace, horizontalpodautoscaler) (
+          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+            ==
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", horizontalpodautoscaler="{{ $appName }}"}
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}
+

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -703,22 +703,69 @@ istio-alerts:
   # -- (`bool`) Whether or not to enable the istio-alerts chart.
   enabled: true
 
-# Configures alerts for all the pods managed by this application chart by
-# default. This chart can be overridden and reconfigured, but the default
-# behavior is generally correct for most workloads.
-alerts:
+# Container Alerting Rules
+#
+# These rules are designed to provide very basic but critical monitoring for
+# the health of your containers and pods. More specific alerts can be created
+# by you - but these apply to the pods and resources managed by this chart.
+prometheusRules:
   # -- (`bool`) Whether or not to enable the prometheus-alerts chart.
   enabled: true
 
-  # -- (`map`) Configure the specific Container rules that we want
-  containerRules:
-    # These rules are disabled because they do not match the resources this
-    # chart can create.
-    KubeDaemonSetMisScheduled: false
-    KubeDaemonSetNotScheduled: false
-    KubeDaemonSetRolloutStuck: false
-    KubeJobCompletion: false
-    KubeJobFailed: false
-    KubeStatefulSetGenerationMismatch: false
-    KubeStatefulSetReplicasMismatch: false
-    KubeStatefulSetUpdateNotRolledOut: false
+  # -- (`map`) Additional custom labels attached to every PrometheusRule
+  additionalRuleLabels: {}
+
+  # -- Monitors Pods for Containers that are terminated either for unexpected
+  # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
+  # for $for (1m), then it will alert.
+  PodContainerTerminated:
+    severity: warning
+    threshold: 0
+    over: 10m
+    for: 1m
+    reasons:
+      # - Error  < when a container is evicted gracefully, the "error" state is used.
+      - ContainerCannotRun
+      - DeadlineExceeded
+
+  # -- Pod is crash looping
+  PodCrashLooping:
+    severity: warning
+    for: 15m
+
+  # -- Pod has been in a non-ready state for more than a specific threshold
+  PodNotReady:
+    severity: warning
+    for: 15m
+
+  # -- Container is being throttled by the CGroup - needs more resources.
+  CPUThrottlingHigh:
+    severity: warning
+    threshold: 65
+    for: 15m
+
+  # -- Pod container waiting longer than threshold
+  ContainerWaiting:
+    severity: warning
+    for: 1h
+
+  # -- Deployment generation mismatch due to possible roll-back
+  DeploymentGenerationMismatch:
+    severity: warning
+    for: 15m
+
+  # -- Deployment has not matched the expected number of replicas
+  DeploymentReplicasMismatch:
+    severity: warning
+    for: 15m
+
+  # -- HPA has not matched descired number of replicas
+  HpaReplicasMismatch:
+    severity: warning
+    for: 15m
+
+  # -- HPA is running at max replicas
+  HpaMaxedOut:
+    severity: warning
+    for: 15m
+

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -716,6 +716,7 @@ alerts:
     # chart can create.
     KubeDaemonSetMisScheduled: false
     KubeDaemonSetNotScheduled: false
+    KubeDaemonSetRolloutStuck: false
     KubeJobCompletion: false
     KubeJobFailed: false
     KubeStatefulSetGenerationMismatch: false

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.7.2
+version: 0.8.0
 appVersion: latest
 maintainers:
   - name: diranged
@@ -12,11 +12,6 @@ dependencies:
     version: 0.1.3
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
-  - name: prometheus-alerts
-    alias: alerts
-    version: 1.0.2
-    repository: https://k8s-charts.nextdoor.com
-    condition: alerts.enabled
   - name: nd-common
     version: 0.0.15
     repository: file://../nd-common

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -190,7 +190,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| alerts.containerRules | object | `{"KubeDaemonSetMisScheduled":false,"KubeDaemonSetNotScheduled":false,"KubeDeploymentGenerationMismatch":false,"KubeDeploymentReplicasMismatch":false,"KubeJobCompletion":false,"KubeJobFailed":false}` | (`map`) Configure the specific Container rules that we want |
+| alerts.containerRules | object | `{"KubeDaemonSetMisScheduled":false,"KubeDaemonSetNotScheduled":false,"KubeDaemonSetRolloutStuck":false,"KubeDeploymentGenerationMismatch":false,"KubeDeploymentReplicasMismatch":false,"KubeJobCompletion":false,"KubeJobFailed":false}` | (`map`) Configure the specific Container rules that we want |
 | alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the prometheus-alerts chart. |
 | args | list | `[]` | The arguments passed to the command. If unspecified the container defaults are used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
 | command | list | `[]` | The command run by the container. This overrides `ENTRYPOINT`. If not specified, the container's default entrypoint is used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -12,6 +12,14 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
+### 0.7.x -> 0.8.x
+
+**BREAKING: Rolled back to Values.prometheusRules**
+
+The use of nested charts within nested charts is problematic, and we have
+rolled it back. Please use `Values.prometheusRules` to configure alarms. We
+will deprecate the `prometheus-alerts` chart.
+
 ### 0.6.x -> 0.7.x
 
 **NEW: PrometheusRules are enabled by default!!**

--- a/charts/stateful-app/templates/prometheusrules.yaml
+++ b/charts/stateful-app/templates/prometheusrules.yaml
@@ -1,0 +1,250 @@
+{{- $values          := .Values }}
+{{- $global          := . }}
+{{- $targetNamespace := .Release.Namespace }}
+{{- $runbookUrl      := required "Values.runbookUrl can not be blank!" .Values.runbookUrl }}
+{{- $appName         := include "nd-common.fullname" . }}
+{{- $podName         := trunc 56 $appName | printf "%s.*" }}
+
+{{- if .Values.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
+  labels:
+    {{- include "nd-common.labels" . | nindent 4 }}
+spec:
+  groups:
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules
+    rules:
+
+    {{- with .Values.prometheusRules.PodContainerTerminated }}
+    - alert: PodContainerTerminated
+      annotations:
+        summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
+        runbook_url: {{ $runbookUrl }}#kube-pod-container-terminated
+        description: >-
+          Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
+          has a container that has been terminated ({{`{{ $value }}`}} times) due to
+          {{`{{$labels.reason}}`}} in the last {{ .for }}.
+      expr: |-
+        sum by (container, namespace, pod, reason) (
+          sum_over_time(
+            kube_pod_container_status_terminated_reason{
+              reason=~"{{ join "|" .reasons }}",
+              namespace="{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[{{ .over }}]
+          )
+        ) > {{ .threshold }}
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodCrashLooping }}
+    - alert: PodCrashLooping
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} is crash looping.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod
+          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+      expr: |-
+        rate(
+          kube_pod_container_status_restarts_total{
+            job="kube-state-metrics",
+            namespace=~"{{ $targetNamespace }}",
+            pod=~"{{ $podName }}"
+          }[5m]
+        ) * 60 * 5 > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.PodNotReady }}
+    - alert: PodNotReady
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} has been in a non-ready state for more than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          Pod {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
+          has been in a non-ready state for longer than {{ .for }}.
+      expr: |-
+        sum by (namespace, pod) (
+          max by(namespace, pod) (
+            kube_pod_status_phase{
+              job="kube-state-metrics",
+              namespace=~"{{ $targetNamespace }}",
+              phase=~"Pending|Unknown",
+              pod=~"{{ $podName }}"
+            }
+          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.ContainerRules
+    rules:
+
+    {{- with .Values.prometheusRules.CPUThrottlingHigh }}
+    - alert: CPUThrottlingHigh
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} processes are experiencing elevated CPU throttling
+        runbook_url: {{ $runbookUrl }}#CPUThrottlingHigh
+        description: >-
+          {{`{{ $value | humanizePercentage }}`}} throttling of CPU in
+          namespace {{`{{ $labels.namespace }}`}} for container
+          {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}.
+      expr: |-
+        sum(
+          increase(
+            container_cpu_cfs_throttled_periods_total{
+              container!="",
+              namespace=~"{{ $targetNamespace }}",
+              pod=~"{{ $podName }}"
+            }[5m]
+          )
+        ) by (container, pod, namespace)
+
+          /
+
+        sum(
+          increase(
+            container_cpu_cfs_periods_total{}[5m]
+          )
+        ) by (container, pod, namespace)
+
+        > ( {{ .threshold }} / 100 )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{- with .Values.prometheusRules.ContainerWaiting }}
+    - alert: ContainerWaiting
+      annotations:
+        summary: >-
+          {{`{{ $labels.pod }}`}} container ({{`{{ $labels.container }}`}}) waiting longer than {{ .for }}
+        runbook_url: {{ $runbookUrl }}#containerwaiting
+        description: >-
+          Container {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}
+          (namespace: {{`{{ $labels.namespace }}`}} has been in a waiting
+          state for longer than 1 hour.
+      expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.StatefulSetRules
+    rules:
+
+    {{ with .Values.prometheusRules.KubeStatefulSetReplicasMismatch -}}
+    - alert: KubeStatefulSetReplicasMismatch
+      annotations:
+        summary: StatefulSet has not matched the expected number of replicas.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubestatefulsetreplicasmismatch
+        description: >-
+          StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}}
+          $labels.statefulset {{`}}`}} has not matched the expected number of
+          replicas for longer than 15 minutes.
+      expr: |-
+        (
+          kube_statefulset_status_replicas_ready{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+            !=
+          kube_statefulset_status_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+        ) and (
+          changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}[5m])
+            ==
+          0
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml $values.prometheusRules.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{ with .Values.prometheusRules.KubeStatefulSetGenerationMismatch -}}
+    - alert: KubeStatefulSetGenerationMismatch
+      annotations:
+        summary: StatefulSet generation mismatch due to possible roll-back
+        runbook_url: {{ $runbookUrl }}#alert-name-kubestatefulsetgenerationmismatch
+        description: >-
+          StatefulSet generation for {{`{{`}} $labels.namespace
+          {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} does not match, this
+          indicates that the StatefulSet has failed but has not been rolled
+          back.
+      expr: |-
+        kube_statefulset_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+          !=
+        kube_statefulset_metadata_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml $values.prometheusRules.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{ with .Values.prometheusRules.KubeStatefulSetUpdateNotRolledOut -}}
+    - alert: KubeStatefulSetUpdateNotRolledOut
+      annotations:
+        summary: StatefulSet update has not been rolled out.
+        runbook_url: {{ $runbookUrl }}#alert-name-kubestatefulsetupdatenotrolledout
+        description: >-
+          StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}}
+          $labels.statefulset {{`}}`}} update has not been rolled out.
+      expr: |-
+        (
+          max without (revision) (
+            kube_statefulset_status_current_revision{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+              unless
+            kube_statefulset_status_update_revision{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+          )
+            *
+          (
+            kube_statefulset_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+              !=
+            kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}
+          )
+        )  and (
+          changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", statefulset="{{ $appName }}"}[5m])
+            ==
+          0
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml $values.prometheusRules.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+{{- end }}
+

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -575,6 +575,9 @@ tests:
       # If this is left empty, the default is "latest"
       tag:
 
+# -- The URL of the runbook for this service.
+runbookUrl: https://github.com/Nextdoor/k8s-charts/blob/main/charts/simple-app/README.md
+
 # Configure alerts for all istio VirtualServices in the namespace this chart is launched in.
 # If you are launching a single copy of stateful-app in a namespace, just leave this enabled
 # to reproduce similar behavior to services launched on ECS with dedicated ALBs. For more
@@ -584,21 +587,63 @@ istio-alerts:
   # -- (`bool`) Whether or not to enable the istio-alerts chart.
   enabled: true
 
-# Configures alerts for all the pods managed by this application chart by
-# default. This chart can be overridden and reconfigured, but the default
-# behavior is generally correct for most workloads.
-alerts:
+# Container Alerting Rules
+#
+# These rules are designed to provide very basic but critical monitoring for
+# the health of your containers and pods. More specific alerts can be created
+# by you - but these apply to the pods and resources managed by this chart.
+prometheusRules:
   # -- (`bool`) Whether or not to enable the prometheus-alerts chart.
   enabled: true
 
-  # -- (`map`) Configure the specific Container rules that we want
-  containerRules:
-    # These rules are disabled because they do not match the resources this
-    # chart can create.
-    KubeDaemonSetMisScheduled: false
-    KubeDaemonSetNotScheduled: false
-    KubeDaemonSetRolloutStuck: false
-    KubeDeploymentGenerationMismatch: false
-    KubeDeploymentReplicasMismatch: false
-    KubeJobCompletion: false
-    KubeJobFailed: false
+  # -- (`map`) Additional custom labels attached to every PrometheusRule
+  additionalRuleLabels: {}
+
+  # -- Monitors Pods for Containers that are terminated either for unexpected
+  # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
+  # for $for (1m), then it will alert.
+  PodContainerTerminated:
+    severity: warning
+    threshold: 0
+    over: 10m
+    for: 1m
+    reasons:
+      # - Error  < when a container is evicted gracefully, the "error" state is used.
+      - ContainerCannotRun
+      - DeadlineExceeded
+
+  # -- Pod is crash looping
+  PodCrashLooping:
+    severity: warning
+    for: 15m
+
+  # -- Pod has been in a non-ready state for more than a specific threshold
+  PodNotReady:
+    severity: warning
+    for: 15m
+
+  # -- Container is being throttled by the CGroup - needs more resources.
+  CPUThrottlingHigh:
+    severity: warning
+    threshold: 65
+    for: 15m
+
+  # -- Pod container waiting longer than threshold
+  ContainerWaiting:
+    severity: warning
+    for: 1h
+
+  # -- Deployment has not matched the expected number of replicas
+  KubeStatefulSetReplicasMismatch:
+    severity: warning
+    for: 15m
+
+  # -- StatefulSet generation mismatch due to possible roll-back
+  KubeStatefulSetGenerationMismatch:
+    severity: warning
+    for: 15m
+
+  # -- StatefulSet update has not been rolled out
+  KubeStatefulSetUpdateNotRolledOut:
+    severity: warning
+    for: 15m

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -597,6 +597,7 @@ alerts:
     # chart can create.
     KubeDaemonSetMisScheduled: false
     KubeDaemonSetNotScheduled: false
+    KubeDaemonSetRolloutStuck: false
     KubeDeploymentGenerationMismatch: false
     KubeDeploymentReplicasMismatch: false
     KubeJobCompletion: false


### PR DESCRIPTION
**What did I want?**

Unfortunately the use of nested-nested helm charts (ie, `myapp -> simple-app -> prometheus-alerts`) is fine when you only do it once. .. but when you run multiple versions of those nested sub charts, Helm squashes them into a common namespace and it causes all kinds of conflicts. This was the original reason I pulled the `prometheusRules` into the `simple-app` chart to begin with.

**What did I do?**

I finished the job of migrating all the custom prometheusRules into each of the daemons/stateful/simple-app charts. There is some duplication of effort here, but not a lot.