### PR TITLE
[simple-app/rollout-app/stateful-app] Add AWS tags to ingress LB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ orig
 
 # MacOS file
 .DS_Store
+
+# IDEs
+.vscode

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/

--- a/charts/rollout-app/templates/ingress/ingress.yaml
+++ b/charts/rollout-app/templates/ingress/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
         }
       }
     {{- end }}
+    alb.ingress.kubernetes.io/tags: kubernetes_namespace={{ .Release.Name }}
 spec:
   rules:
     - host: {{ tpl .Values.ingress.host . | quote }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.25.2
+version: 0.25.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.25.2](https://img.shields.io/badge/Version-0.25.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.25.3](https://img.shields.io/badge/Version-0.25.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/ingress/ingress.yaml
+++ b/charts/simple-app/templates/ingress/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
         }
       }
     {{- end }}
+    alb.ingress.kubernetes.io/tags: kubernetes_namespace={{ .Release.Name }}
 spec:
   rules:
     - host: {{ tpl .Values.ingress.host . | quote }}

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.9.2
+version: 0.9.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/stateful-app/templates/ingress/ingress.yaml
+++ b/charts/stateful-app/templates/ingress/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
         }
       }
     {{- end }}
+    alb.ingress.kubernetes.io/tags: kubernetes_namespace={{ .Release.Name }}
 spec:
   rules:
     - host: {{ tpl .Values.ingress.host . | quote }}


### PR DESCRIPTION
I have no idea if this applies to our environment but I found this annotation we can add if we do use this controller. https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#resource-tags

This is the only real change: https://github.com/Nextdoor/k8s-charts/pull/163/files#diff-d8238429e8bf4db0c7df1c76b65983a05a6ced2407910a6f5aac1e4be3fe2eafR24