### PR TITLE
[all charts] Fix some bad ContainerWaiting/CrashLoop Rules

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.9.4
+version: 0.9.5
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.9.5](https://img.shields.io/badge/Version-0.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/daemonset-app/templates/prometheusrules.yaml
+++ b/charts/daemonset-app/templates/prometheusrules.yaml
@@ -43,24 +43,25 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .Values.prometheusRules.PodCrashLooping }}
-    - alert: PodCrashLooping
+    {{- with .Values.prometheusRules.PodCrashLoopBackOff }}
+    - alert: PodCrashLoopBackOff
       annotations:
         summary: >-
-          {{`{{ $labels.pod }}`}} is crash looping.
+          {{`Container inside pod {{ $labels.pod }} is crash looping`}}
         runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
         description: >-
-          Container {{`{{ $labels.container }}`}} in pod
-          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
-          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+          {{`Container {{ $labels.container }} within pod {{ $labels.pod }} is in
+          a {{ $labels.reason }} state. Investigate because it indicates that
+          the Pod is unable to become fully healthy.`}}
       expr: |-
-        rate(
-          kube_pod_container_status_restarts_total{
+        sum by(namespace, pod, container, reason) (
+          kube_pod_container_status_waiting_reason{
             job="kube-state-metrics",
+            reason="CrashLoopBackOff",
             namespace=~"{{ $targetNamespace }}",
             pod=~"{{ $podName }}"
-          }[5m]
-        ) * 60 * 5 > 0
+          }
+        ) > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -459,10 +459,10 @@ prometheusRules:
       - ContainerCannotRun
       - DeadlineExceeded
 
-  # -- Pod is crash looping
-  PodCrashLooping:
+  # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
+  PodCrashLoopBackOff:
     severity: warning
-    for: 15m
+    for: 10m
 
   # -- Pod has been in a non-ready state for more than a specific threshold
   PodNotReady:

--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.0.6
+version: 1.1.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -3,7 +3,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -59,8 +59,8 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.CPUThrottlingHigh.for | string | `"15m"` |  |
 | containerRules.CPUThrottlingHigh.severity | string | `"warning"` |  |
 | containerRules.CPUThrottlingHigh.threshold | int | `65` |  |
-| containerRules.KubeContainerWaiting.for | string | `"1h"` |  |
-| containerRules.KubeContainerWaiting.severity | string | `"warning"` |  |
+| containerRules.ContainerWaiting.for | string | `"1h"` |  |
+| containerRules.ContainerWaiting.severity | string | `"warning"` |  |
 | containerRules.KubeDaemonSetMisScheduled.for | string | `"15m"` |  |
 | containerRules.KubeDaemonSetMisScheduled.severity | string | `"warning"` |  |
 | containerRules.KubeDaemonSetNotScheduled.for | string | `"10m"` |  |
@@ -78,8 +78,6 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.KubeJobCompletion.severity | string | `"warning"` |  |
 | containerRules.KubeJobFailed.for | string | `"15m"` |  |
 | containerRules.KubeJobFailed.severity | string | `"warning"` |  |
-| containerRules.KubePodCrashLooping | object | `{"for":"15m","severity":"warning"}` | Pod is crash looping |
-| containerRules.KubePodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
 | containerRules.KubeStatefulSetGenerationMismatch.for | string | `"15m"` |  |
 | containerRules.KubeStatefulSetGenerationMismatch.severity | string | `"warning"` |  |
 | containerRules.KubeStatefulSetReplicasMismatch.for | string | `"15m"` |  |
@@ -88,6 +86,8 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.KubeStatefulSetUpdateNotRolledOut.severity | string | `"warning"` |  |
 | containerRules.PodContainerOOMKilled | object | `{"for":"1m","over":"60m","severity":"warning","threshold":0}` | Sums up all of the OOMKilled events per pod over the $over time (60m). If that number breaches the $threshold (0) for $for (1m), then it will alert. |
 | containerRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
+| containerRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
+| containerRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
 | defaults.additionalRuleLabels | object | `{}` | (`map`) Additional custom labels attached to every PrometheusRule |
 | defaults.daemonsetNameSelector | string | `"{{ .Release.Name }}-.*"` | (`string`) Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -75,6 +75,27 @@ spec:
         {{- end }}
     {{ end -}}
 
+    {{ with .Values.containerRules.ContainerWaiting -}}
+    - alert: ContainerWaiting
+      annotations:
+        summary: Pod container waiting longer than {{ .for }}
+        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubecontainerwaiting
+        description: >-
+          Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
+          container {{`{{`}} $labels.container{{`}}`}} has been in waiting
+          state for longer than 1 hour.
+      expr: |-
+        sum by (namespace, pod, container) (
+          kube_pod_container_status_waiting_reason{ {{- $podSelector -}} }
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
     {{- with .Values.containerRules.CPUThrottlingHigh }}
     - alert: CPUThrottlingHigh
       annotations:
@@ -112,23 +133,24 @@ spec:
   - name: {{ .Release.Name }}.{{ .Release.Namespace }}.kubernetesAppsRules
     rules:
 
-    {{ with .Values.containerRules.KubePodCrashLooping -}}
-    - alert: KubePodCrashLooping
+    {{ with .Values.containerRules.PodCrashLoopBackOff -}}
+    - alert: PodCrashLoopBackOff
       annotations:
-        summary: Pod is crash looping.
+        summary: {{`Container inside pod {{ $labels.pod }} is crash looping`}}
         runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubepodcrashlooping
         description: >-
-          Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
-          ({{`{{`}} $labels.container {{`}}`}}) is restarting {{`{{`}} printf
-          "%.2f" $value {{`}}`}} times / 5 minutes.
+          {{`Container {{ $labels.container }} within pod {{ $labels.pod }} is in
+          a {{ $labels.reason }} state. Investigate because it indicates that
+          the Pod is unable to become fully healthy.`}}
       expr: |-
-        rate(
-          kube_pod_container_status_restarts_total{
+        sum by(namespace, pod, container, reason) (
+          kube_pod_container_status_waiting_reason{
             job="kube-state-metrics",
+            reason="CrashLoopBackOff",
             {{ $podSelector }},
             {{ $namespaceSelector }}
-          }[5m]
-        ) * 60 * 5 > 0
+          }
+        ) > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -137,8 +159,8 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubePodNotReady -}}
-    - alert: KubePodNotReady
+    {{ with .Values.containerRules.PodNotReady -}}
+    - alert: PodNotReady
       annotations:
         summary: Pod has been in a non-ready state for more than {{ .for }}
         runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubepodnotready
@@ -336,27 +358,6 @@ spec:
             ==
           0
         )
-      for: {{ .for }}
-      labels:
-        severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
-        {{- end }}
-    {{- end }}
-
-    {{ with .Values.containerRules.KubeContainerWaiting -}}
-    - alert: KubeContainerWaiting
-      annotations:
-        summary: Pod container waiting longer than {{ .for }}
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubecontainerwaiting
-        description: >-
-          Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
-          container {{`{{`}} $labels.container{{`}}`}} has been in waiting
-          state for longer than 1 hour.
-      expr: |-
-        sum by (namespace, pod, container) (
-          kube_pod_container_status_waiting_reason{ {{- $daemonsetSelector -}} }
-        ) > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -141,15 +141,20 @@ containerRules:
     over: 60m
     for: 1m
 
-  # -- Pod is crash looping
-  KubePodCrashLooping:
+  # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
+  PodCrashLoopBackOff:
+    severity: warning
+    for: 10m
+
+  # -- Pod has been in a non-ready state for more than a specific threshold
+  PodNotReady:
     severity: warning
     for: 15m
 
-  # -- Pod has been in a non-ready state for more than a specific threshold
-  KubePodNotReady:
+  # Pod container waiting longer than threshold
+  ContainerWaiting:
     severity: warning
-    for: 15m
+    for: 1h
 
   # -- Deployment generation mismatch due to possible roll-back
   KubeDeploymentGenerationMismatch:
@@ -180,11 +185,6 @@ containerRules:
   KubeDaemonSetRolloutStuck:
     severity: warning
     for: 15m
-
-  # Pod container waiting longer than threshold
-  KubeContainerWaiting:
-    severity: warning
-    for: 1h
 
   # DaemonSet pods are not scheduled
   KubeDaemonSetNotScheduled:

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -224,7 +224,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | prometheusRules.HpaMaxedOut | object | `{"for":"15m","severity":"warning"}` | HPA is running at max replicas |
 | prometheusRules.HpaReplicasMismatch | object | `{"for":"15m","severity":"warning"}` | HPA has not matched descired number of replicas |
 | prometheusRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
-| prometheusRules.PodCrashLooping | object | `{"for":"15m","severity":"warning"}` | Pod is crash looping |
+| prometheusRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | prometheusRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
 | prometheusRules.additionalRuleLabels | object | `{}` | (`map`) Additional custom labels attached to every PrometheusRule |
 | prometheusRules.enabled | bool | `true` | (`bool`) Whether or not to enable the container rules template |

--- a/charts/rollout-app/templates/prometheusrules.yaml
+++ b/charts/rollout-app/templates/prometheusrules.yaml
@@ -43,24 +43,25 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .Values.prometheusRules.PodCrashLooping }}
-    - alert: PodCrashLooping
+    {{- with .Values.prometheusRules.PodCrashLoopBackOff }}
+    - alert: PodCrashLoopBackOff
       annotations:
         summary: >-
-          {{`{{ $labels.pod }}`}} is crash looping.
+          {{`Container inside pod {{ $labels.pod }} is crash looping`}}
         runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
         description: >-
-          Container {{`{{ $labels.container }}`}} in pod
-          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
-          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+          {{`Container {{ $labels.container }} within pod {{ $labels.pod }} is in
+          a {{ $labels.reason }} state. Investigate because it indicates that
+          the Pod is unable to become fully healthy.`}}
       expr: |-
-        rate(
-          kube_pod_container_status_restarts_total{
+        sum by(namespace, pod, container, reason) (
+          kube_pod_container_status_waiting_reason{
             job="kube-state-metrics",
+            reason="CrashLoopBackOff",
             namespace=~"{{ $targetNamespace }}",
             pod=~"{{ $podName }}"
-          }[5m]
-        ) * 60 * 5 > 0
+          }
+        ) > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -875,10 +875,10 @@ prometheusRules:
       - ContainerCannotRun
       - DeadlineExceeded
 
-  # -- Pod is crash looping
-  PodCrashLooping:
+  # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
+  PodCrashLoopBackOff:
     severity: warning
-    for: 15m
+    for: 10m
 
   # -- Pod has been in a non-ready state for more than a specific threshold
   PodNotReady:

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.25.7
+version: 0.25.8
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.25.7](https://img.shields.io/badge/Version-0.25.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.25.8](https://img.shields.io/badge/Version-0.25.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -316,7 +316,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | prometheusRules.HpaMaxedOut | object | `{"for":"15m","severity":"warning"}` | HPA is running at max replicas |
 | prometheusRules.HpaReplicasMismatch | object | `{"for":"15m","severity":"warning"}` | HPA has not matched descired number of replicas |
 | prometheusRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
-| prometheusRules.PodCrashLooping | object | `{"for":"15m","severity":"warning"}` | Pod is crash looping |
+| prometheusRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | prometheusRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
 | prometheusRules.additionalRuleLabels | object | `{}` | (`map`) Additional custom labels attached to every PrometheusRule |
 | prometheusRules.enabled | bool | `true` | (`bool`) Whether or not to enable the prometheus-alerts chart. |

--- a/charts/simple-app/templates/prometheusrules.yaml
+++ b/charts/simple-app/templates/prometheusrules.yaml
@@ -43,24 +43,25 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .Values.prometheusRules.PodCrashLooping }}
-    - alert: PodCrashLooping
+    {{- with .Values.prometheusRules.PodCrashLoopBackOff }}
+    - alert: PodCrashLoopBackOff
       annotations:
         summary: >-
-          {{`{{ $labels.pod }}`}} is crash looping.
+          {{`Container inside pod {{ $labels.pod }} is crash looping`}}
         runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
         description: >-
-          Container {{`{{ $labels.container }}`}} in pod
-          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
-          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+          {{`Container {{ $labels.container }} within pod {{ $labels.pod }} is in
+          a {{ $labels.reason }} state. Investigate because it indicates that
+          the Pod is unable to become fully healthy.`}}
       expr: |-
-        rate(
-          kube_pod_container_status_restarts_total{
+        sum by(namespace, pod, container, reason) (
+          kube_pod_container_status_waiting_reason{
             job="kube-state-metrics",
+            reason="CrashLoopBackOff",
             namespace=~"{{ $targetNamespace }}",
             pod=~"{{ $podName }}"
-          }[5m]
-        ) * 60 * 5 > 0
+          }
+        ) > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/simple-app/templates/tests/test-connection.yaml
+++ b/charts/simple-app/templates/tests/test-connection.yaml
@@ -21,5 +21,5 @@ spec:
       args:
         {{- $global := . }}
         {{- range $arg := index .Values.tests.connection.args }}
-        - {{ tpl $arg $global }}
+        - {{ tpl $arg $global | quote }}
         {{- end }}

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -733,10 +733,10 @@ prometheusRules:
       - ContainerCannotRun
       - DeadlineExceeded
 
-  # -- Pod is crash looping
-  PodCrashLooping:
+  # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
+  PodCrashLoopBackOff:
     severity: warning
-    for: 15m
+    for: 10m
 
   # -- Pod has been in a non-ready state for more than a specific threshold
   PodNotReady:

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.9.7
+version: 0.9.8
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.9.7](https://img.shields.io/badge/Version-0.9.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.9.8](https://img.shields.io/badge/Version-0.9.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -280,7 +280,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | prometheusRules.KubeStatefulSetReplicasMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment has not matched the expected number of replicas |
 | prometheusRules.KubeStatefulSetUpdateNotRolledOut | object | `{"for":"15m","severity":"warning"}` | StatefulSet update has not been rolled out |
 | prometheusRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
-| prometheusRules.PodCrashLooping | object | `{"for":"15m","severity":"warning"}` | Pod is crash looping |
+| prometheusRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | prometheusRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
 | prometheusRules.additionalRuleLabels | object | `{}` | (`map`) Additional custom labels attached to every PrometheusRule |
 | prometheusRules.enabled | bool | `true` | (`bool`) Whether or not to enable the prometheus-alerts chart. |

--- a/charts/stateful-app/templates/prometheusrules.yaml
+++ b/charts/stateful-app/templates/prometheusrules.yaml
@@ -44,24 +44,25 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .Values.prometheusRules.PodCrashLooping }}
-    - alert: PodCrashLooping
+    {{- with .Values.prometheusRules.PodCrashLoopBackOff }}
+    - alert: PodCrashLoopBackOff
       annotations:
         summary: >-
-          {{`{{ $labels.pod }}`}} is crash looping.
+          {{`Container inside pod {{ $labels.pod }} is crash looping`}}
         runbook_url: {{ $runbookUrl }}#alert-name-kubepodcrashlooping
         description: >-
-          Container {{`{{ $labels.container }}`}} in pod
-          {{`{{ $labels.pod }}`}} (namespace: {{`{{ $labels.namespace }}`}})
-          is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
+          {{`Container {{ $labels.container }} within pod {{ $labels.pod }} is in
+          a {{ $labels.reason }} state. Investigate because it indicates that
+          the Pod is unable to become fully healthy.`}}
       expr: |-
-        rate(
-          kube_pod_container_status_restarts_total{
+        sum by(namespace, pod, container, reason) (
+          kube_pod_container_status_waiting_reason{
             job="kube-state-metrics",
+            reason="CrashLoopBackOff",
             namespace=~"{{ $targetNamespace }}",
             pod=~"{{ $podName }}"
-          }[5m]
-        ) * 60 * 5 > 0
+          }
+        ) > 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -617,10 +617,10 @@ prometheusRules:
       - ContainerCannotRun
       - DeadlineExceeded
 
-  # -- Pod is crash looping
-  PodCrashLooping:
+  # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
+  PodCrashLoopBackOff:
     severity: warning
-    for: 15m
+    for: 10m
 
   # -- Pod has been in a non-ready state for more than a specific threshold
   PodNotReady:


### PR DESCRIPTION
The rules we had in place to catch Pods in a CrashLoopBackoff state were
too complicated and easily missed pods depending on the situation. A
much cleaner metric exists with a very clear selector for
`CrashLoopBackOff`, so I am rewriting the rules to use that.

https://www.circonus.com/2021/01/guide-to-monitoring-kubernetes-part-2-which-metrics-and-health-conditions-you-should-be-monitoring/