### PR TITLE
[simple-app]: Add minimum replica count check for PDB configuration

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.25.8
+version: 0.25.9
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.25.8](https://img.shields.io/badge/Version-0.25.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.25.9](https://img.shields.io/badge/Version-0.25.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/poddisruptionbudget.yaml
+++ b/charts/simple-app/templates/poddisruptionbudget.yaml
@@ -1,7 +1,7 @@
+{{- if .Values.podDisruptionBudget -}}
 {{- if lt (.Values.replicaCount | int) 2 }}
 {{- fail "Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greater than 2." }}
 {{- end }}
-{{- if .Values.podDisruptionBudget -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/simple-app/templates/poddisruptionbudget.yaml
+++ b/charts/simple-app/templates/poddisruptionbudget.yaml
@@ -1,3 +1,6 @@
+{{- if lt (.Values.replicaCount | int) 2 }}
+{{- fail "Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greather than 2." }}
+{{- end }}
 {{- if .Values.podDisruptionBudget -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/simple-app/templates/poddisruptionbudget.yaml
+++ b/charts/simple-app/templates/poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.podDisruptionBudget -}}
 {{- if lt (.Values.replicaCount | int) 2 }}
-{{- fail "Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greater than 2." }}
+{{- fail "Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greater than or equal to 2." }}
 {{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/simple-app/templates/poddisruptionbudget.yaml
+++ b/charts/simple-app/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if lt (.Values.replicaCount | int) 2 }}
-{{- fail "Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greather than 2." }}
+{{- fail "Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greater than 2." }}
 {{- end }}
 {{- if .Values.podDisruptionBudget -}}
 apiVersion: policy/v1


### PR DESCRIPTION
We have seen few times that replica count for deployment and pdb is configured as 1. It causes issue while scaling and draining the node. In order to configure PDB, deployment replica count should be set to minimum of 2. This PR adds that check. If replica count is less than 2, then helm will throw error. 

Proof it works

```
saansh45 ~/Code/k8s-charts/charts/simple-app (pdb_replica_count_check) $ make template
Pulling dependencies in...
helm dependency update .
walk.go:74: found symbolic link in path: /Users/angadpatil/Code/k8s-charts/charts/simple-app/ci/local-values.yaml resolves to /Users/angadpatil/Code/k8s-charts/charts/simple-app/values.local.yaml
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://k8s-charts.nextdoor.com" chart repository
Saving 2 charts
Downloading istio-alerts from repo https://k8s-charts.nextdoor.com
Deleting outdated charts
helm template --debug --values values.yaml --values values.local.yaml --namespace simple-app simple-app .
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /Users/angadpatil/Code/k8s-charts/charts/simple-app

walk.go:74: found symbolic link in path: /Users/angadpatil/Code/k8s-charts/charts/simple-app/ci/local-values.yaml resolves to /Users/angadpatil/Code/k8s-charts/charts/simple-app/values.local.yaml

Error: execution error at (simple-app/templates/poddisruptionbudget.yaml:2:4): Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greater than 2.
helm.go:84: [debug] execution error at (simple-app/templates/poddisruptionbudget.yaml:2:4): Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greater than 2.
make: *** [template] Error 1
```