### PR TITLE
set cluster lb policy so envoy understands the redis cluster topology

### DIFF
--- a/charts/istio-endpoints/Chart.yaml
+++ b/charts/istio-endpoints/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-endpoints
 description: Per-Namespace Istio Configuration Chart
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/istio-endpoints/README.md
+++ b/charts/istio-endpoints/README.md
@@ -2,7 +2,7 @@
 
 Per-Namespace Istio Configuration Chart
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [elasticache]: https://aws.amazon.com/elasticache/
 [serviceentry]: https://istio.io/latest/docs/reference/config/networking/service-entry/
@@ -60,7 +60,7 @@ plugin, then you must also be running Istio 1.11+.
 + dependencies:
 +   - name: istio-endpoints
 +     repository: https://k8s-charts.nextdoor.com
-+     version: 0.3.0
++     version: 0.3.1
   maintainers:
     - name: diranged
       email: matt@nextdoor.com

--- a/charts/istio-endpoints/templates/elasticache.yaml
+++ b/charts/istio-endpoints/templates/elasticache.yaml
@@ -84,6 +84,13 @@ spec:
       patch:
         operation: MERGE
         value:
+          {{- /*
+          Ensure Envoy uses the Redis cluster aware loadbalancer so that it understand the
+          cluster topology and can route requests to a node responsible for the target
+          key's hash slot.
+          */}}
+          lb_policy: CLUSTER_PROVIDED
+
           cluster_type:
             name: envoy.clusters.redis
             typed_config:


### PR DESCRIPTION
Ensure Envoy uses the Redis cluster aware loadbalancer so that it understand the cluster topology and can route requests to a node responsible for the target key's hash slot.