### PR TITLE
[charts/nd-common] Remove unused PrometheusRule

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.20
+version: 0.0.21
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.20](https://img.shields.io/badge/Version-0.0.20-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.21](https://img.shields.io/badge/Version-0.0.21-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_monitors.tpl
+++ b/charts/nd-common/templates/_monitors.tpl
@@ -173,35 +173,10 @@ spec:
 
 {{/*
 
-This function creates Prometheus recording rules that are useful to include in
-other queries about the configuration of this chart.
+This is currently a no-op function maintained for backwards compatibility. We
+can use this in the future to create Prometheus recording rules that may one day
+be useful to include in other queries about the configuration of this chart.
 
 */}}
 
-{{- define "nd-common.monitorRules" }}
-{{- if .Values.monitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: {{ include "nd-common.fullname" . }}-monitor-rules
-  {{- with .Values.monitor.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
-    {{- with .Values.monitor.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  groups:
-  - name: {{ include "nd-common.fullname" . }}.monitorRules
-    rules:
-      - record: pod_monitor_sample_limit
-        expr: {{ (include "nd-common.monitorSampleLimit" .) | quote }}
-        labels:
-          namespace: {{ .Release.Namespace }}
-          name: {{ include "nd-common.name" . }}
-          instance: {{ .Release.Name }}
-{{- end }}
-{{- end }}
+{{- define "nd-common.monitorRules" }}{{- end }}


### PR DESCRIPTION
This rule was originally created to approximate behavior that we now officially have through the built-in `scrape_sample_limit` metric. We can't remove this function (it would be a breaking change to other charts outside this repo) so turn it into a no-op, reserved for a future date where we need to create other Prom rules like this.