### PR TITLE
[nd-common] Support templated values in excluded Istio inbound ports

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.20
+version: 0.0.21
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.20](https://img.shields.io/badge/Version-0.0.20-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.21](https://img.shields.io/badge/Version-0.0.21-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`


### PR DESCRIPTION
Tested locally with various combinations of `istio.enabled`, `monitor.enabled`, and templated and non-templated values for the ports.

Ex:

```
  istio:
    enabled: true
    excludeInboundPorts:
      - '{{ .Values.database.port }}'
      - 1234

  monitor:
    enabled: true
    portNumber: 9090
```

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gnarfeed-read
  labels:
    helm.sh/chart: read-0.4.2
    app.kubernetes.io/version: "local"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: read
    app.kubernetes.io/instance: gnarfeed
spec:
  replicas: 1
  revisionHistoryLimit: 3
  selector:
    matchLabels:
      app.kubernetes.io/name: read
      app.kubernetes.io/instance: gnarfeed
  template:
    metadata:proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
traffic.sidecar.istio.io/excludeInboundPorts: "5432, 1234, 9090"
```