### PR TITLE
[simple-app] Allow PDB creation if replica count is null

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.27.2
+version: 0.27.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.27.2](https://img.shields.io/badge/Version-0.27.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.27.3](https://img.shields.io/badge/Version-0.27.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -337,8 +337,11 @@ spec:
 ---
 
 {{- if $.Values.podDisruptionBudget -}}
-{{- if lt ($.Values.replicaCount | int) 2 }}
+{{- if and $.Values.replicaCount (lt ($.Values.replicaCount | int) 2) }}
 {{- fail "Deployment replica count can not be less than 2 in order to configure PDB. Please configure Replica count greater than or equal to 2." }}
+{{- end }}
+{{- if and $.Values.autoscaling.enabled (lt ($.Values.autoscaling.minReplicas | int) 2) }}
+{{- fail "Deployment autoscaling minimum can not be less than 2 in order to configure PDB. Please configure a minimum replica count greater than or equal to 2." }}
 {{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -25,6 +25,7 @@ enableTopologySpread: true
 terminationGracePeriodSeconds: 30
 autoscaling:
   enabled: true
+  minReplicas: 2
 
 secrets:
   TEST_SECRET: junksecret


### PR DESCRIPTION
We assume that if somebody is explicitly setting the replica count to `null` and enabling PDBs, they know what they're doing and probably have custom autoscaling or something.