### PR TITLE
[nd-common] Remove pod_name label, implement default filter for go/process metrics

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.22
+    version: 0.0.23
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -336,11 +336,17 @@ monitor:
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
 
-  # -- PodMonitor MetricRelabelConfigs to apply to samples before ingestion.
+  # -- ServiceMonitor MetricRelabelConfigs to apply to samples before ingestion.
   # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
-  metricRelabelings: []
+  metricRelabelings:
+    # By default, drop the go_.* and process_.* metrics. These metrics are
+    # usually not used, and cause a bunch of high cardinality data to be
+    # stored.
+    - sourceLabels: [__name__]
+      regex: (go|process)_.*
+      action: drop
 
-  # -- (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well
+  # -- (`enum: http, https`) ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
 
   # -- ServiceMonitor will use these tlsConfig settings to make the health check requests

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.22
+version: 0.0.23
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.22](https://img.shields.io/badge/Version-0.0.22-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.23](https://img.shields.io/badge/Version-0.0.23-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_monitors.tpl
+++ b/charts/nd-common/templates/_monitors.tpl
@@ -87,11 +87,6 @@ spec:
         - regex: __meta_kubernetes_pod_label_(tags_datadoghq_com_(service|version))
           replacement: $1
           action: labelmap
-
-        # Map the pod name into the pod_name label
-        - sourceLabels: [__meta_kubernetes_pod_name]
-          action: replace
-          targetLabel: pod_name
         {{- end }}
       {{- with .Values.monitor.metricRelabelings }}
       metricRelabelings:

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.22
+    version: 0.0.23
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -131,7 +131,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.22 |
+| file://../nd-common | nd-common | 0.0.23 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.4 |
 
 ## Values
@@ -202,7 +202,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
 | initContainers | list | `[]` |  |
 | istio-alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
-| istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `PodMonitor` object. |
+| istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `ServiceMonitor` object. |
 | istio.excludeInboundPorts | list | `[]` | (`list`) If supplied, this is a list of inbound TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. The `.Values.monitor.portNumber` is already included by default. The port values can either be integers or templatized strings. |
 | istio.excludeOutboundPorts | list | `[]` | (`list`) If supplied, this is a list of outbound TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. The port values can either be integers or templatized strings. |
 | istio.metricsMerging | bool | `false` | (`bool`) If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
@@ -210,19 +210,19 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
 | minReadySeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds |
-| monitor.annotations | object | `{}` | (`map`) PodMonitor annotations. |
-| monitor.enabled | bool | `true` | (`bool`) If enabled, PodMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
-| monitor.interval | string | `nil` | PodMonitor scrape interval |
-| monitor.labels | object | `{}` | Additional PodMonitor labels. |
-| monitor.metricRelabelings | list | `[]` | PodMonitor MetricRelabelConfigs to apply to samples before ingestion. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
+| monitor.annotations | object | `{}` | (`map`) ServiceMonitor annotations. |
+| monitor.enabled | bool | `true` | (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
+| monitor.interval | string | `nil` | ServiceMonitor scrape interval |
+| monitor.labels | object | `{}` | Additional ServiceMonitor labels. |
+| monitor.metricRelabelings | list | `[{"action":"drop","regex":"(go|process)_.*","sourceLabels":["__name__"]}]` | ServiceMonitor MetricRelabelConfigs to apply to samples before ingestion. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
 | monitor.path | string | `"/metrics"` | (`string`) Path to scrape metrics from within your Pod. |
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
-| monitor.relabelings | list | `[]` | PodMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| monitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | monitor.sampleLimit | int | `25000` | (`int`) The maximum number of metrics that can be scraped - if there are more than this, then scraping will fail entirely by Prometheus. This is used as a circuit breaker to avoid blowing up Prometheus memory footprints. |
-| monitor.scheme | string | `"http"` | (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well |
-| monitor.scrapeTimeout | string | `nil` | PodMonitor scrape timeout in Go duration format (e.g. 15s) |
-| monitor.tlsConfig | string | `nil` | PodMonitor will use these tlsConfig settings to make the health check requests |
+| monitor.scheme | string | `"http"` | (`enum: http, https`) ServiceMonitor will use http by default, but you can pick https as well |
+| monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
 | network.allowedNamespaces | list | `[]` | (`strings[]`) A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
 | nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -680,7 +680,7 @@ affinity: {}
 # Monitoring configuration for metric scraping against the Prometheus-style
 # metrics endpoint.
 monitor:
-  # -- (`bool`) If enabled, PodMonitor resources for Prometheus Operator
+  # -- (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator
   # are created or if `Values.istio.enabled` is `True`, then the appropriate
   # Pod Annotations will be added for the istio-proxy sidecar container to
   # scrape the metrics.
@@ -697,13 +697,13 @@ monitor:
   # -- (`string`) Path to scrape metrics from within your Pod.
   path: /metrics
 
-  # -- (`map`) PodMonitor annotations.
+  # -- (`map`) ServiceMonitor annotations.
   annotations: {}
 
-  # -- Additional PodMonitor labels.
+  # -- Additional ServiceMonitor labels.
   labels: {}
 
-  # -- PodMonitor scrape interval
+  # -- ServiceMonitor scrape interval
   interval: null
 
   # -- (`int`) The maximum number of metrics that can be scraped - if there are
@@ -711,21 +711,27 @@ monitor:
   # used as a circuit breaker to avoid blowing up Prometheus memory footprints.
   sampleLimit: 25000
 
-  # -- PodMonitor scrape timeout in Go duration format (e.g. 15s)
+  # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
 
-  # -- PodMonitor relabel configs to apply to samples before scraping
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
 
-  # -- PodMonitor MetricRelabelConfigs to apply to samples before ingestion.
+  # -- ServiceMonitor MetricRelabelConfigs to apply to samples before ingestion.
   # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
-  metricRelabelings: []
+  metricRelabelings:
+    # By default, drop the go_.* and process_.* metrics. These metrics are
+    # usually not used, and cause a bunch of high cardinality data to be
+    # stored.
+    - sourceLabels: [__name__]
+      regex: (go|process)_.*
+      action: drop
 
-  # -- (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well
+  # -- (`enum: http, https`) ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
 
-  # -- PodMonitor will use these tlsConfig settings to make the health check requests
+  # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
   tlsConfig: null
 
 # Configuration that lets the chart know that it's operating inside of an Istio
@@ -735,7 +741,7 @@ istio:
   # -- (`bool`) Whether or not the service should be part of an Istio Service
   # Mesh. If this is turned on and `Values.monitor.enabled=true`, then the
   # Istio Sidecar containers will be configured to pull and merge the metrics
-  # from the application, rather than creating a new `PodMonitor` object.
+  # from the application, rather than creating a new `ServiceMonitor` object.
   enabled: true
 
   # -- (`list`) If supplied, this is a list of inbound TCP ports that are excluded

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 0.27.1
+version: 0.27.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.22
+    version: 0.0.23
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.27.2](https://img.shields.io/badge/Version-0.27.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -260,7 +260,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.22 |
+| file://../nd-common | nd-common | 0.0.23 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.4 |
 
 ## Values
@@ -316,7 +316,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
 | initContainers | list | `[]` |  |
 | istio-alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
-| istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `PodMonitor` object. |
+| istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `ServiceMonitor` object. |
 | istio.excludeInboundPorts | list | `[]` | (`list`) If supplied, this is a list of inbound TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. The `.Values.monitor.portNumber` is already included by default. The port values can either be integers or templatized strings. |
 | istio.excludeOutboundPorts | list | `[]` | (`list`) If supplied, this is a list of outbound TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. The port values can either be integers or templatized strings. |
 | istio.metricsMerging | bool | `false` | (`bool`) If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
@@ -324,19 +324,19 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
 | minReadySeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds |
-| monitor.annotations | object | `{}` | (`map`) PodMonitor annotations. |
-| monitor.enabled | bool | `true` | (`bool`) If enabled, PodMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
-| monitor.interval | string | `nil` | PodMonitor scrape interval |
-| monitor.labels | object | `{}` | Additional PodMonitor labels. |
-| monitor.metricRelabelings | list | `[]` | PodMonitor MetricRelabelConfigs to apply to samples before ingestion. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
+| monitor.annotations | object | `{}` | (`map`) ServiceMonitor annotations. |
+| monitor.enabled | bool | `true` | (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
+| monitor.interval | string | `nil` | ServiceMonitor scrape interval |
+| monitor.labels | object | `{}` | Additional ServiceMonitor labels. |
+| monitor.metricRelabelings | list | `[{"action":"drop","regex":"(go|process)_.*","sourceLabels":["__name__"]}]` | ServiceMonitor MetricRelabelConfigs to apply to samples before ingestion. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
 | monitor.path | string | `"/metrics"` | (`string`) Path to scrape metrics from within your Pod. |
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
-| monitor.relabelings | list | `[]` | PodMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| monitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | monitor.sampleLimit | int | `25000` | (`int`) The maximum number of metrics that can be scraped - if there are more than this, then scraping will fail entirely by Prometheus. This is used as a circuit breaker to avoid blowing up Prometheus memory footprints. |
-| monitor.scheme | string | `"http"` | (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well |
-| monitor.scrapeTimeout | string | `nil` | PodMonitor scrape timeout in Go duration format (e.g. 15s) |
-| monitor.tlsConfig | string | `nil` | PodMonitor will use these tlsConfig settings to make the health check requests |
+| monitor.scheme | string | `"http"` | (`enum: http, https`) ServiceMonitor will use http by default, but you can pick https as well |
+| monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
 | network.allowedNamespaces | list | `[]` | (`strings[]`) A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
 | nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -553,7 +553,7 @@ affinity: {}
 # Monitoring configuration for metric scraping against the Prometheus-style
 # metrics endpoint.
 monitor:
-  # -- (`bool`) If enabled, PodMonitor resources for Prometheus Operator
+  # -- (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator
   # are created or if `Values.istio.enabled` is `True`, then the appropriate
   # Pod Annotations will be added for the istio-proxy sidecar container to
   # scrape the metrics.
@@ -570,13 +570,13 @@ monitor:
   # -- (`string`) Path to scrape metrics from within your Pod.
   path: /metrics
 
-  # -- (`map`) PodMonitor annotations.
+  # -- (`map`) ServiceMonitor annotations.
   annotations: {}
 
-  # -- Additional PodMonitor labels.
+  # -- Additional ServiceMonitor labels.
   labels: {}
 
-  # -- PodMonitor scrape interval
+  # -- ServiceMonitor scrape interval
   interval: null
 
   # -- (`int`) The maximum number of metrics that can be scraped - if there are
@@ -584,21 +584,27 @@ monitor:
   # used as a circuit breaker to avoid blowing up Prometheus memory footprints.
   sampleLimit: 25000
 
-  # -- PodMonitor scrape timeout in Go duration format (e.g. 15s)
+  # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
 
-  # -- PodMonitor relabel configs to apply to samples before scraping
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
 
-  # -- PodMonitor MetricRelabelConfigs to apply to samples before ingestion.
+  # -- ServiceMonitor MetricRelabelConfigs to apply to samples before ingestion.
   # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
-  metricRelabelings: []
+  metricRelabelings:
+    # By default, drop the go_.* and process_.* metrics. These metrics are
+    # usually not used, and cause a bunch of high cardinality data to be
+    # stored.
+    - sourceLabels: [__name__]
+      regex: (go|process)_.*
+      action: drop
 
-  # -- (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well
+  # -- (`enum: http, https`) ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
 
-  # -- PodMonitor will use these tlsConfig settings to make the health check requests
+  # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
   tlsConfig: null
 
 # Configuration that lets the chart know that it's operating inside of an Istio
@@ -608,7 +614,7 @@ istio:
   # -- (`bool`) Whether or not the service should be part of an Istio Service
   # Mesh. If this is turned on and `Values.monitor.enabled=true`, then the
   # Istio Sidecar containers will be configured to pull and merge the metrics
-  # from the application, rather than creating a new `PodMonitor` object.
+  # from the application, rather than creating a new `ServiceMonitor` object.
   enabled: true
 
   # -- (`list`) If supplied, this is a list of inbound TCP ports that are excluded

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.22
+    version: 0.0.23
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -217,7 +217,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.22 |
+| file://../nd-common | nd-common | 0.0.23 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.1.4 |
 
 ## Values
@@ -258,26 +258,26 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | ingress.sslRedirect | bool | `true` | If `true`, then this will annotate the Ingress with a special AWS ALB Ingress Controller annotation that configures an SSL-redirect at the ALB level. |
 | initContainers | list | `[]` |  |
 | istio-alerts.enabled | bool | `true` | (`bool`) Whether or not to enable the istio-alerts chart. |
-| istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `PodMonitor` object. |
+| istio.enabled | bool | `true` | (`bool`) Whether or not the service should be part of an Istio Service Mesh. If this is turned on and `Values.monitor.enabled=true`, then the Istio Sidecar containers will be configured to pull and merge the metrics from the application, rather than creating a new `ServiceMonitor` object. |
 | istio.excludeInboundPorts | list | `[]` | (`list`) If supplied, this is a list of inbound TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. The `.Values.monitor.portNumber` is already included by default. The port values can either be integers or templatized strings. |
 | istio.excludeOutboundPorts | list | `[]` | (`list`) If supplied, this is a list of outbound TCP ports that are excluded from being proxied by the Istio-proxy Envoy sidecar process. The port values can either be integers or templatized strings. |
 | istio.metricsMerging | bool | `false` | (`bool`) If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
 | istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down. eg: preStopCommand: [ /bin/sleep, "30" ] |
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
-| monitor.annotations | object | `{}` | (`map`) PodMonitor annotations. |
-| monitor.enabled | bool | `true` | (`bool`) If enabled, PodMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
-| monitor.interval | string | `nil` | PodMonitor scrape interval |
-| monitor.labels | object | `{}` | Additional PodMonitor labels. |
-| monitor.metricRelabelings | list | `[]` | PodMonitor MetricRelabelConfigs to apply to samples before ingestion. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
+| monitor.annotations | object | `{}` | (`map`) ServiceMonitor annotations. |
+| monitor.enabled | bool | `true` | (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |
+| monitor.interval | string | `nil` | ServiceMonitor scrape interval |
+| monitor.labels | object | `{}` | Additional ServiceMonitor labels. |
+| monitor.metricRelabelings | list | `[{"action":"drop","regex":"(go|process)_.*","sourceLabels":["__name__"]}]` | ServiceMonitor MetricRelabelConfigs to apply to samples before ingestion. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig |
 | monitor.path | string | `"/metrics"` | (`string`) Path to scrape metrics from within your Pod. |
 | monitor.portName | string | `"metrics"` | (`string`) Name of the port to scrape for metrics - this is the name of the port that will be exposed in your `PodSpec` for scraping purposes. |
 | monitor.portNumber | int | `9090` | (`int`) Number of the port to scrape for metrics - this port will be exposed in your `PodSpec` to ensure it can be scraped. |
-| monitor.relabelings | list | `[]` | PodMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
+| monitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig |
 | monitor.sampleLimit | int | `25000` | (`int`) The maximum number of metrics that can be scraped - if there are more than this, then scraping will fail entirely by Prometheus. This is used as a circuit breaker to avoid blowing up Prometheus memory footprints. |
-| monitor.scheme | string | `"http"` | (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well |
-| monitor.scrapeTimeout | string | `nil` | PodMonitor scrape timeout in Go duration format (e.g. 15s) |
-| monitor.tlsConfig | string | `nil` | PodMonitor will use these tlsConfig settings to make the health check requests |
+| monitor.scheme | string | `"http"` | (`enum: http, https`) ServiceMonitor will use http by default, but you can pick https as well |
+| monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
 | network.allowedNamespaces | list | `[]` | (`strings[]`) A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
 | nodeSelector | object | `{}` | (`map`) A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -424,7 +424,7 @@ affinity: {}
 # Monitoring configuration for metric scraping against the Prometheus-style
 # metrics endpoint.
 monitor:
-  # -- (`bool`) If enabled, PodMonitor resources for Prometheus Operator
+  # -- (`bool`) If enabled, ServiceMonitor resources for Prometheus Operator
   # are created or if `Values.istio.enabled` is `True`, then the appropriate
   # Pod Annotations will be added for the istio-proxy sidecar container to
   # scrape the metrics.
@@ -441,13 +441,13 @@ monitor:
   # -- (`string`) Path to scrape metrics from within your Pod.
   path: /metrics
 
-  # -- (`map`) PodMonitor annotations.
+  # -- (`map`) ServiceMonitor annotations.
   annotations: {}
 
-  # -- Additional PodMonitor labels.
+  # -- Additional ServiceMonitor labels.
   labels: {}
 
-  # -- PodMonitor scrape interval
+  # -- ServiceMonitor scrape interval
   interval: null
 
   # -- (`int`) The maximum number of metrics that can be scraped - if there are
@@ -455,21 +455,27 @@ monitor:
   # used as a circuit breaker to avoid blowing up Prometheus memory footprints.
   sampleLimit: 25000
 
-  # -- PodMonitor scrape timeout in Go duration format (e.g. 15s)
+  # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
   scrapeTimeout: null
 
-  # -- PodMonitor relabel configs to apply to samples before scraping
+  # -- ServiceMonitor relabel configs to apply to samples before scraping
   # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   relabelings: []
 
-  # -- PodMonitor MetricRelabelConfigs to apply to samples before ingestion.
+  # -- ServiceMonitor MetricRelabelConfigs to apply to samples before ingestion.
   # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
-  metricRelabelings: []
+  metricRelabelings:
+    # By default, drop the go_.* and process_.* metrics. These metrics are
+    # usually not used, and cause a bunch of high cardinality data to be
+    # stored.
+    - sourceLabels: [__name__]
+      regex: (go|process)_.*
+      action: drop
 
-  # -- (`enum: http, https`) PodMonitor will use http by default, but you can pick https as well
+  # -- (`enum: http, https`) ServiceMonitor will use http by default, but you can pick https as well
   scheme: http
 
-  # -- PodMonitor will use these tlsConfig settings to make the health check requests
+  # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
   tlsConfig: null
 
 # Configuration that lets the chart know that it's operating inside of an Istio
@@ -479,7 +485,7 @@ istio:
   # -- (`bool`) Whether or not the service should be part of an Istio Service
   # Mesh. If this is turned on and `Values.monitor.enabled=true`, then the
   # Istio Sidecar containers will be configured to pull and merge the metrics
-  # from the application, rather than creating a new `PodMonitor` object.
+  # from the application, rather than creating a new `ServiceMonitor` object.
   enabled: true
 
   # -- (`list`) If supplied, this is a list of inbound TCP ports that are excluded


### PR DESCRIPTION
These filters can be overridden - but by setting some default ones, we can avoid bringing a bunch of high cardinality and noisy metrics that are mostly not being used.