### PR TITLE
just fix rollup time

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.0.1
 maintainers:
   - name: sabw8217

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -31,7 +31,7 @@ spec:
           /
 
         sum by (destination_service_name) (
-            increase(istio_requests_total{destination_service_namespace="{{ $release.Namespace }}"}[60s])
+            increase(istio_requests_total{destination_service_namespace="{{ $release.Namespace }}"}[5m])
         )
           > {{ .threshold }}
       for: {{ .for }}


### PR DESCRIPTION
We bucket in units of 1m, therefore this time must be greater. I greped for s] and 1m so I think this was the only case less than or equal to a minute in the repo