### PR TITLE
feat(charts/rollout-app): Support EKS 1.26 changes to `autoscaling` API group

### DIFF
--- a/charts/rollout-app/templates/hpa.yaml
+++ b/charts/rollout-app/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "nd-common.fullname" . }}


### PR DESCRIPTION
The deprecated v2beta2 HorizontalPodAutoscaler API is removed in EKS 1.26 and replaced with v2.