### PR TITLE
feat(charts/simple-workflow): Support 'verifyOnly' and 'revision'

### DIFF
--- a/charts/simple-workflow/Chart.yaml
+++ b/charts/simple-workflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-workflow
 description: Default Argo Workflow Helm Chart
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: latest
 maintainers:
   - name: masterginger

--- a/charts/simple-workflow/README.md
+++ b/charts/simple-workflow/README.md
@@ -2,7 +2,7 @@
 
 Default Argo Workflow Helm Chart
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Values
 

--- a/charts/simple-workflow/templates/workflow-pipeline.yaml
+++ b/charts/simple-workflow/templates/workflow-pipeline.yaml
@@ -28,6 +28,7 @@ spec:
   templates:
   {{- range $name, $config := .Values.argocd.applications }}
   {{- if or (not $config.disabled) (eq $config.disabled "false") }}
+  {{- if or (not $config.verifyOnly) (eq $config.verifyOnly "false") }}
   - name: check-existing-app-{{ $name }}
     resource:
       action: get
@@ -106,6 +107,7 @@ spec:
           {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
           {{- end }}
+  {{- end }}
   - name: verify-app-{{ $name }}
     timeout: {{ $config.timeout }}
     inputs:
@@ -134,6 +136,7 @@ spec:
       {{- end }}
       {{- range $name, $config := .Values.argocd.applications }}
       {{- if or (not $config.disabled) (eq $config.disabled "false") }}
+      {{- if or (not $config.verifyOnly) (eq $config.verifyOnly "false") }}
       - name: check-existing-app-{{ $name }}
         {{- if $config.depends }}
         {{- $depends := list -}}
@@ -154,20 +157,31 @@ spec:
       - name: update-app-{{ $name }}
         template: update-app-{{ $name }}
         depends: check-existing-app-{{ $name }}.Succeeded
+      {{- end }}
       - name: verify-app-synced-{{ $name }}
+        {{- if or (not $config.verifyOnly) (eq $config.verifyOnly "false") }}
         depends: create-app-{{ $name }}.Succeeded || update-app-{{ $name }}.Succeeded
+        {{- end }}
         template: verify-app-{{ $name }}
         arguments:
           parameters:
             - name: successCondition
+              {{- if $.Values.app.revision }}
+              value: status.sync.status == Synced, status.sync.revision == {{ $.Values.app.revision }}
+              {{- else }}
               value: status.sync.status == Synced, status.sync.comparedTo.source.targetRevision == {{ $.Values.app.targetRevision }}
+              {{- end }}
       - name: verify-app-healthy-{{ $name }}
         depends: verify-app-synced-{{ $name }}.Succeeded
         template: verify-app-{{ $name }}
         arguments:
           parameters:
             - name: successCondition
+              {{- if $.Values.app.revision }}
+              value: status.health.status == Healthy, status.sync.revision == {{ $.Values.app.revision }}
+              {{- else }}
               value: status.health.status == Healthy, status.sync.comparedTo.source.targetRevision == {{ $.Values.app.targetRevision }}
+              {{- end }}
       {{- end }}
       {{- end }}
 

--- a/charts/simple-workflow/values.yaml
+++ b/charts/simple-workflow/values.yaml
@@ -8,6 +8,8 @@ global:
 app:
   # -- (String) Target revision which the Argo Apps in the workflow will deploy from, usually a Git tag
   targetRevision: placeholder-target-revision
+  # -- (String) The Git revision (Git sha) which the Argo Apps in the workflow will deploy from, optional. When specified, the verification steps will check revision instead of targetRevision.
+  # revision: placeholder-revision
   # -- (String) Name of the workflow
   workflowName: workflow-name
 
@@ -52,6 +54,8 @@ argocd:
   #       - another-app
   #     # -- (String boolean) whether the app should be skipped in the workflow dag, optional.
   #     disabled: "false"
+  #     # -- (String boolean) whether the workflow should just verify the app states, optional.
+  #     verifyOnly: "false"
   #     # -- (Dictionary) customized sync spec (e.g. syncPolicy, ignoreDifferences), optional
   #     specOverride:
   #       # -- (Dictionary) customized sync spec for the "create" action, optional


### PR DESCRIPTION
This PR introduced two new functionalities to `simple-workflow` chart:
* `verifyOnly` which allows `simple-workflow` to only perform verification on an Argo App which is deployed by other pipelines, without trying to create/update the app itself.
* `revision` which allows `simple-workflow` to verify the Argo App based on the revision the app is synced with, instead of the `targetRevision` field.