### PR TITLE
fix(charts/simple-app): fix the liveness/readinessprobe checks

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,13 @@ in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
+
+### 1.1.1 -> 1.1.2
+
+The `livenessProbe` and `readinessProbe` changes made in
+https://github.com/Nextdoor/k8s-charts/pull/212 were invalid. In the `1.1.2`
+release I fix these checks. Going forward `livenessProbe` is optional, but
+`readinessProbe` is a required field.
 
 ### 1.0.x -> 1.1.x
 
@@ -359,7 +366,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | istio.metricsMerging | `bool` | `false` | If set to "True", then the Istio Metrics Merging system will be turned on and Envoy will attempt to scrape metrics from the application pod and merge them with its own. This defaults to False beacuse in most environments we want to explicitly split up the metrics and collect Istio metrics separate from Application metrics. |
 | istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down.  eg: preStopCommand: [ /bin/sleep, "30" ] |
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
-| livenessProbe | string | `nil` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. This is **required**. |
+| livenessProbe | string | `nil` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
 | minReadySeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds |
 | monitor.annotations | `map` | `{}` | ServiceMonitor annotations. |
 | monitor.enabled | `bool` | `true` | If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -12,6 +12,13 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
+### 1.1.1 -> 1.1.2
+
+The `livenessProbe` and `readinessProbe` changes made in
+https://github.com/Nextdoor/k8s-charts/pull/212 were invalid. In the `1.1.2`
+release I fix these checks. Going forward `livenessProbe` is optional, but
+`readinessProbe` is a required field.
+
 ### 1.0.x -> 1.1.x
 
 **BREAKING: `.Values.virtualService.gateways` syntax changed**

--- a/charts/simple-app/ci/datadog-with-env-values.yaml
+++ b/charts/simple-app/ci/datadog-with-env-values.yaml
@@ -20,6 +20,11 @@ ingress:
   # ALB-ingress controllers.
   sslRedirect: false
 
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
 replicaCount: 2
 minReadySeconds: 2
 progressDeadlineSeconds: 90

--- a/charts/simple-app/ci/datadog-without-env-values.yaml
+++ b/charts/simple-app/ci/datadog-without-env-values.yaml
@@ -4,6 +4,11 @@ datadog:
   scrapeLogs:
     enabled: true
 
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
 # For local development, we turn on the Ingress controller and set up a simple
 # local ingress.
 ingress:

--- a/charts/simple-app/ci/proxy-values.yaml
+++ b/charts/simple-app/ci/proxy-values.yaml
@@ -8,10 +8,25 @@ ingress:
   # ALB-ingress controllers.
   sslRedirect: false
 
+livenessProbe:
+  httpGet:
+    path: /
+    port: 80
+
 readinessProbe:
   httpGet:
     path: /
-    port: http
+    port: 80
+
+command:
+  - /bin/sleep
+  - infinity
+
+proxySidecar:
+  enabled: true
+  image:
+    repository: nginx
+    tag: stable
 
 replicaCount: 2
 minReadySeconds: 2

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -21,6 +21,10 @@ through $deploymentZones
 */}}
 {{- $fullName            := include "nd-common.fullname" . }}
 
+{{- /*
+Verify that some required inputs are supplied
+*/}}
+{{- $readinessProbe := required "readinessProbe is required" .Values.readinessProbe }}
 
 {{- /*
 By default, we do run the topology spread function - letting it decide
@@ -203,15 +207,14 @@ spec:
           {{- end }}
           {{- with $.Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml tpl (required "livenessProbe is required" .) $ | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- with $.Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml tpl (required "readinessProbe is required" .) $ | nindent 12 }}
-          {{- end }}
+            {{- tpl (toYaml $.Values.readinessProbe) $ | nindent 12 }}
           resources:
             {{- toYaml $.Values.proxySidecar.resources | nindent 12 }}
         {{- end }}
+
         - name: {{ include "nd-common.containerName" $ }}
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
@@ -284,12 +287,10 @@ spec:
           {{- end }}
           {{- with $.Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- with $.Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- tpl (toYaml $.Values.readinessProbe) $ | nindent 12 }}
 
 ---
 

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -8,12 +8,25 @@ ingress:
   # ALB-ingress controllers.
   sslRedirect: false
 
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+targetArchitecture: ~
+
 ports:
   - name: http
     containerPort: 80
     protocol: TCP
     # Optional flag to override the client-facing port for service requests.
     port:
+
   - name: https
     containerPort: 8443
     protocol: TCP

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -104,17 +104,17 @@ proxySidecar:
 # -- A PodSpec container "startupProbe" configuration object. Note that this
 # startupProbe will be applied to the proxySidecar container instead if that
 # is enabled.
-startupProbe:
+startupProbe: null
 
 # -- A PodSpec container "livenessProbe" configuration object. Note that this
 # livenessProbe will be applied to the proxySidecar container instead if that
-# is enabled. This is **required**.
-livenessProbe:
+# is enabled.
+livenessProbe: null
 
 # -- A PodSpec container "readinessProbe" configuration object. Note that this
 # readinessProbe will be applied to the proxySidecar container instead if that
 # is enabled. This is **required**.
-readinessProbe:
+readinessProbe: null
 
 # -- (`ContainerPort[]`) A list of Port objects that are exposed by the
 # service. These ports are applied to the main container, or the proxySidecar


### PR DESCRIPTION
The `livenessProbe` and `readinessProbe` changes made in
https://github.com/Nextdoor/k8s-charts/pull/212 were invalid. In the `1.1.2`
release I fix these checks. Going forward `livenessProbe` is optional, but
`readinessProbe` is a required field.
