### PR TITLE
Adding support for batch job/s in simple-workflow

### DIFF
--- a/charts/simple-workflow/Chart.yaml
+++ b/charts/simple-workflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-workflow
 description: Default Argo Workflow Helm Chart
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: latest
 maintainers:
   - name: masterginger

--- a/charts/simple-workflow/README.md
+++ b/charts/simple-workflow/README.md
@@ -2,7 +2,7 @@
 
 Default Argo Workflow Helm Chart
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Values
 

--- a/charts/simple-workflow/templates/workflow-pipeline.yaml
+++ b/charts/simple-workflow/templates/workflow-pipeline.yaml
@@ -195,7 +195,7 @@ spec:
               {{- end }}
        {{- range $jobName, $jobConfig := $config.jobs }}
         - name: verify-job-synced-and-healthy-{{ $name }}
-          depends: verify-app-synced-and-healthy-{{ $name }}.Succeeded
+          depends: verify-job-healthy-{{ $name }}.Succeeded
           template: verify-job-{{ $jobName }}
           arguments:
             parameters:

--- a/charts/simple-workflow/templates/workflow-pipeline.yaml
+++ b/charts/simple-workflow/templates/workflow-pipeline.yaml
@@ -195,7 +195,7 @@ spec:
               {{- end }}
        {{- range $jobName, $jobConfig := $config.jobs }}
         - name: verify-job-synced-and-healthy-{{ $name }}
-          depends: verify-job-healthy-{{ $name }}.Succeeded
+          depends: verify-app-synced-and-healthy-{{ $name }}.Succeeded
           template: verify-job-{{ $jobName }}
           arguments:
             parameters:

--- a/charts/simple-workflow/templates/workflow-pipeline.yaml
+++ b/charts/simple-workflow/templates/workflow-pipeline.yaml
@@ -129,6 +129,23 @@ spec:
           {{- with $config.metadata }}
           {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
+  {{- range $jobName, $jobConfig := $config.jobs }}
+  - name: verify-job-{{ $jobName }}
+    timeout: {{ $jobConfig.timeout }}
+    inputs:
+      parameters:
+        - name: successCondition
+    resource:
+      action: get
+      successCondition: "{{`{{inputs.parameters.successCondition}}`}}"
+      manifest: |
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          {{- with $jobConfig.metadata }}
+          {{- tpl (toYaml .) $ | nindent 10 }}
+          {{- end }}
+  {{- end}}
   {{- end }}
   {{- end }}
 
@@ -176,6 +193,16 @@ spec:
               {{- else }}
               value: status.sync.status == Synced, status.health.status == Healthy, status.sync.comparedTo.source.targetRevision == {{ $.Values.app.targetRevision }}
               {{- end }}
+       {{- range $jobName, $jobConfig := $config.jobs }}
+        - name: verify-job-synced-and-healthy-{{ $name }}
+          depends: verify-app-synced-and-healthy-{{ $name }}.Succeeded
+          template: verify-job-{{ $jobName }}
+          arguments:
+            parameters:
+              - name: successCondition
+                value: status.health.status == Healthy
+        {{- end }}
+
       {{- end }}
       {{- end }}
 

--- a/charts/simple-workflow/values.yaml
+++ b/charts/simple-workflow/values.yaml
@@ -66,4 +66,15 @@ argocd:
   #       create: {}
   #       # -- (Dictionary) customized sync spec for the "update" action, optional
   #       update: {}
+  #     # -- (Dictionary) metadata of the argocd application
+  #     metadata: {}
+  #     # -- (Dictionary) Batch jobs to be verified if successful, optional.
+  #     jobs:
+  #       # -- (String) name of the job
+  #       name:
+  #       # -- (String) The timeout for verifying the batch job
+  #       timeout: 600s
+  #       # -- (Dictionary) metadata of the batch job
+  #       metadata: {}
+
   applications: {}


### PR DESCRIPTION
What is this ?
- This PR adds on to the  existing simple-workflow that checks on argocd app health to also look for one or many `kind: job` 's health within the same argocd app.

Why do we need this ?
- Currently, simple-workflow requires a `kind: Job` to not be an [argo hook](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/).
- Having a job as hook is beneficial because we can decide if we want to run is Pre, Post or During sync.
- This change will enable argocd applications to have hooks that can run as part of their sync and ensure they are healthy too.