### PR TITLE
fix(charts/istio-alerts): use federated rolled up metrics

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.1.5
+version: 0.2.0
 appVersion: 0.0.1
 maintainers:
-  - name: sabw8217
-    email: aaron@nextdoor.com
+  - name: diranged
+    email: matt@nextdoor.com

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 
@@ -8,7 +8,7 @@ A Helm chart that provisions a series of alerts for istio VirtualServices
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| sabw8217 | <aaron@nextdoor.com> |  |
+| diranged | <matt@nextdoor.com> |  |
 
 ## Values
 
@@ -24,11 +24,13 @@ A Helm chart that provisions a series of alerts for istio VirtualServices
 | chart_source | string | `"https://github.com/Nextdoor/k8s-charts"` |  |
 | defaults.additionalRuleLabels | object | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/istio-alerts/runbook.md"` | The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
+| serviceRules.destinationServiceName | string | `".*"` | Narrow down the alerts to a particular Destination Service if there are multiple services that require different thresholds within the same namespace. |
 | serviceRules.enabled | bool | `true` | Whether to enable the service rules template |
 | serviceRules.highRequestLatency.enabled | bool | `true` | Whether to enable the monitor on latency returned by the VirtualService. |
 | serviceRules.highRequestLatency.for | string | `"15m"` | How long to evaluate the latency of services. |
+| serviceRules.highRequestLatency.percentile | float | `0.95` | Which percentile to monitor - should be between 0 and 1. Default is 95th percentile. |
 | serviceRules.highRequestLatency.severity | string | `"warning"` | Severity of the latency monitor |
-| serviceRules.highRequestLatency.threshold | float | `0.5` | The threshold for considering the latency monitor to be alarming. |
+| serviceRules.highRequestLatency.threshold | float | `0.5` | The threshold for considering the latency monitor to be alarming. This is in seconds. |
 | serviceRules.http5XXMonitor | object | `{"enabled":true,"for":"5m","severity":"critical","threshold":0.0005}` | Configuration related to the 5xx monitor for the VirtualService. |
 | serviceRules.http5XXMonitor.enabled | bool | `true` | Whether to enable the monitor on 5xxs returned by the VirtualService. |
 | serviceRules.http5XXMonitor.for | string | `"5m"` | How long to evaluate the rate of 5xxs over. |

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -23,15 +23,20 @@ spec:
           High rate of 5xx responses from the {{`{{$labels.destination_service_name}}`}} VirtualService
           in namespace {{`{{$labels.namespace}}`}}.
 
-      expr: >-
-        sum by (destination_service_name) (
-            increase(istio_requests_total{response_code=~"5.*", destination_service_namespace="{{ $release.Namespace }}"}[5m])
+      expr: >
+        sum by (destination_service_name, reporter, source_workload) (
+          istio_requests:increase5m{
+            response_code=~"5.*",
+            destination_service_namespace="{{ $release.Namespace }}",
+            destination_service_name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+          }
         )
-
           /
-
-        sum by (destination_service_name) (
-            increase(istio_requests_total{destination_service_namespace="{{ $release.Namespace }}"}[5m])
+        sum by (destination_service_name, reporter, source_workload) (
+          istio_requests:increase5m{
+            destination_service_namespace="{{ $release.Namespace }}",
+            destination_service_name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+          }
         )
           > {{ .threshold }}
       for: {{ .for }}
@@ -56,12 +61,22 @@ spec:
           Average request latency of {{`{{ $value | humanizePercentage }}`}} is above threshold ({{ .threshold }}s)
           in namespace {{`{{ $labels.namespace }}`}} for pod {{`{{ $labels.pod }}`}} (container: {{`{{ $labels.container }}`}}).
       expr: |-
-        avg by (destination_service_name) (
-          irate(
-            istio_request_duration_milliseconds_bucket{reporter=~"destination",destination_service_namespace="{{ $release.Namespace }}"}[5m]
-          ) / 1000
+        histogram_quantile(
+          {{ .percentile }},
+          sum(irate(
+            istio_request_duration_milliseconds_bucket{
+              destination_service_namespace="{{ $release.Namespace }}",
+              destination_service_name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+            }[5m]
+          )) by (
+            destination_service_name,
+            reporter,
+            source_canonical_service,
+            le
+          )
         )
-          > {{ .threshold }}
+        / 1000
+        > {{ .threshold }}
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/istio-alerts/values.yaml
+++ b/charts/istio-alerts/values.yaml
@@ -79,23 +79,41 @@ serviceRules:
   # -- Whether to enable the service rules template
   enabled: true
 
+  # -- Narrow down the alerts to a particular Destination Service if there
+  # are multiple services that require different thresholds within the same
+  # namespace.
+  destinationServiceName: .*
+
   # -- Configuration related to the 5xx monitor for the VirtualService.
   http5XXMonitor:
     # -- Whether to enable the monitor on 5xxs returned by the VirtualService.
     enabled: true
+
     # -- How long to evaluate the rate of 5xxs over.
     for: 5m
-    # -- The threshold for considering the 5xx monitor to be alarming. Default is 0.05% error rate, i.e 99.95% reliability.
+
+    # -- The threshold for considering the 5xx monitor to be alarming. Default
+    # is 0.05% error rate, i.e 99.95% reliability.
     threshold: 0.0005
+
     # -- Severity of the 5xx monitor
     severity: critical
 
   highRequestLatency:
-    # -- Whether to enable the monitor on latency returned by the VirtualService.
+    # -- Whether to enable the monitor on latency returned by the
+    # VirtualService.
     enabled: true
+
+    # -- Which percentile to monitor - should be between 0 and 1. Default is
+    # 95th percentile.
+    percentile: 0.95
+
     # -- Severity of the latency monitor
     severity: warning
-    # -- The threshold for considering the latency monitor to be alarming.
+
+    # -- The threshold for considering the latency monitor to be alarming. This
+    # is in seconds.
     threshold: 0.5
+
     # -- How long to evaluate the latency of services.
     for: 15m


### PR DESCRIPTION
We switched to using federated metric collection so the `istio_requests_total` metric no longer exists. We need to be using `istio_requests:increase5m` to count the actual 5xx's.

Additionally, this chart needed some more flexibility to be able to be launched multiple times in a single namespace targeting different `destination_service_names` with different thresholds.

Finally, the alerts need to be split out across `reporter=source` and `reporter=destination` so that the application owners are alerted both if their own `istio-proxy` sidecar is reporting errors (thus definitely happening in their own app), and also if the `istio-ingressgateway` pods are reporting errors (which could be network problems, no healthy upstream issues, etc).

**Proof: `istio_requests:total5m`**

Here is an updated image with an example of the query working.. we also happen to have a service throwing errors here at a high rate, which helps illustrate the labels that the alert would be sent out with:

![Screenshot 2023-08-31 at 4 15 20 PM](https://github.com/Nextdoor/k8s-charts/assets/768067/272a725b-7b1f-46f4-8e1e-ec5477c87d63)


**Proof:  Percentile-based Latency Alarm**

Rather than alerting on the plain average, I've refactored the alarm to alert on a given percentile.. this allows the operator to decide how sensitive they want to be. The alert is also now broken out on `destination_service_name`, `reporter` and `source_canonical_service` to help them identify the source of the latency and traffic.

![Screenshot 2023-08-31 at 4 27 44 PM](https://github.com/Nextdoor/k8s-charts/assets/768067/c6387c0d-c8cd-4cae-a610-f816df2c6a60)