### PR TITLE
fix(all): use service.name in virtualservice route if supplied

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
           python-version: 3.9
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.24
+version: 0.0.25
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.24](https://img.shields.io/badge/Version-0.0.24-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.25](https://img.shields.io/badge/Version-0.0.25-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_service.tpl
+++ b/charts/nd-common/templates/_service.tpl
@@ -11,11 +11,15 @@ https://github.com/istio/istio/issues/39792#issuecomment-1189669761 for
 details.
 */}}
 
+{{- define "nd-common.serviceName" }}
+{{- default (include "nd-common.fullname" $) .Values.service.name }}
+{{- end }}
+
 {{- define "nd-common.service" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ default (include "nd-common.fullname" $) .Values.service.name }}
+  name: {{ include "nd-common.serviceName" $ }}
   labels:
     {{- include "nd-common.labels" $ | nindent 4 }}
   annotations:

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.24
+    version: 0.0.25
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -167,7 +167,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.24 |
+| file://../nd-common | nd-common | 0.0.25 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/rollout-app/templates/istio/virtualservice.yaml
+++ b/charts/rollout-app/templates/istio/virtualservice.yaml
@@ -4,7 +4,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ include "nd-common.fullname" . }}
+  name: {{ include "nd-common.fullname" $ }}
   labels:
     {{- include "nd-common.labels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
@@ -63,7 +63,7 @@ spec:
         Rollouts will override it during rollout sessions.
         */}}
         - destination:
-            host: {{ include "nd-common.fullname" . }}
+            host: {{ include "nd-common.serviceName" $ }}
             port:
               number: {{ .Values.virtualService.port }}
           weight: 100
@@ -76,7 +76,7 @@ spec:
         */}}
         {{- if eq .Values.strategy "canary" }}
         - destination:
-            host: {{ include "nd-common.fullname" . }}-canary
+            host: {{ include "nd-common.serviceName" $ }}-canary
             port:
               number: {{ .Values.virtualService.port }}
           weight: 0

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.24
+    version: 0.0.25
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -312,7 +312,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.24 |
+| file://../nd-common | nd-common | 0.0.25 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/istio/virtualservice.yaml
+++ b/charts/simple-app/templates/istio/virtualservice.yaml
@@ -55,7 +55,7 @@ spec:
       {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRouteDestination */}}
       route:
         - destination:
-            host: {{ include "nd-common.fullname" . }}
+            host: {{ include "nd-common.serviceName" $ }}
             port:
               number: {{ .Values.virtualService.port }}
   {{- with .Values.virtualService.tls }}

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.24
+    version: 0.0.25
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -253,7 +253,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.24 |
+| file://../nd-common | nd-common | 0.0.25 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/stateful-app/templates/istio/virtualservice.yaml
+++ b/charts/stateful-app/templates/istio/virtualservice.yaml
@@ -4,7 +4,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ include "nd-common.fullname" . }}
+  name: {{ include "nd-common.fullname" $ }}
   labels:
     {{- include "nd-common.labels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
@@ -55,7 +55,7 @@ spec:
       {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRouteDestination */}}
       route:
         - destination:
-            host: {{ include "nd-common.fullname" . }}
+            host: {{ include "nd-common.serviceName" $ }}
             port:
               number: {{ .Values.virtualService.port }}
   {{- with .Values.virtualService.tls }}

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,7 +2,8 @@
 remote: origin
 chart-dirs:
   - charts
-helm-extra-args: --timeout 600s
+# https://github.com/helm/chart-testing-action/issues/135
+# helm-extra-args: --timeout 600s
 target-branch: main
 validate-maintainers: false
 chart-repos:


### PR DESCRIPTION
If the chart sets `.Values.service.name=xxx`, then we need to use that value in the `VirtualService` route - otherwise we create a route to a non-existent destination.