### PR TITLE
feat(all): refactor service creation for application and monitoring

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.11.5
+version: 0.12.0
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.24
+    version: 0.1.0
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.11.5](https://img.shields.io/badge/Version-0.11.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.0.25
+version: 0.1.0
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.0.25](https://img.shields.io/badge/Version-0.0.25-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.0.24
+    version: 0.1.0
     repository: file://../nd-common

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -3,7 +3,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -54,7 +54,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.24 |
+| file://../nd-common | nd-common | 0.1.0 |
 
 ## Values
 

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.25
+    version: 0.1.0
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -167,7 +167,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.25 |
+| file://../nd-common | nd-common | 0.1.0 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.25
+    version: 0.1.0
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -312,7 +312,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.25 |
+| file://../nd-common | nd-common | 0.1.0 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.12.1
+version: 0.13.0
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.0.25
+    version: 0.1.0
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -253,7 +253,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.0.25 |
+| file://../nd-common | nd-common | 0.1.0 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values


### PR DESCRIPTION
Currently we create single service which includes service monitoring port. Istiod processes all these service ports. We use Prometheus Operator which uses ServiceMonitor and PodMonitor objects to determine endpoints to scrape.  So within service mesh, we don't care about service monitoring ports being exposed to envoy sidecar config. This PR simplifies the process of creating these services as 

In all of our k8s-charts repos we break out the Service objects into two objects. $serviceName and $serviceName-metrics.

The $serviceName Service only exposes the application ports, not the monitoring ports.

The $serviceName-metrics Service exposes only the Metrics port (and is only created if we are creating a ServiceMonitor).

The $serviceName-metrics service gets the networking.istio.io/exportTo: . annotation to expose the service only to other Istio pods within the same namespace

This pattern simplifies our template actually, and at the same time will significantly reduce the number of service ports that our Istiod processes are monitoring.

*diff*

```
saansh45 ~/Code/k8s-charts/charts/simple-app (refactor_services) $  (⎈|kind-default:malone)$ diff -b -u orig new
--- orig	2023-11-07 10:53:47
+++ new	2023-11-07 11:38:54
@@ -3,8 +3,8 @@
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "flink-operator" chart repository
 ...Successfully got an update from the "strimzi" chart repository
-...Successfully got an update from the "jetstack" chart repository
 ...Successfully got an update from the "k8s-charts" chart repository
+...Successfully got an update from the "jetstack" chart repository
 Update Complete. ⎈Happy Helming!⎈
 Saving 2 charts
 Downloading istio-alerts from repo https://k8s-charts.nextdoor.com
@@ -132,6 +132,26 @@
       protocol: TCP
       name: https

+  selector:
+    app.kubernetes.io/name: simple-app
+    app.kubernetes.io/instance: simple-app
+---
+# Source: simple-app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple-app-metrics
+  labels:
+    helm.sh/chart: simple-app-1.2.1
+    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: simple-app
+    app.kubernetes.io/instance: simple-app
+  annotations:
+    networking.istio.io/exportTo: nullnullnull
+spec:
+  type: ClusterIP
+  ports:
     - port: 9090
       targetPort: 9090
       name: http-metrics
```

*Actual Service Objects*

```
# Source: simple-app/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: simple-app
  labels:
    helm.sh/chart: simple-app-1.2.1
    app.kubernetes.io/version: "latest"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: simple-app
    app.kubernetes.io/instance: simple-app
  annotations:

    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: kubernetes_namespace=simple-app
spec:
  type: ClusterIP
  ports:

    - port: 80
      targetPort: http
      protocol: TCP
      name: http
    - port: 443
      targetPort: https
      protocol: TCP
      name: https

  selector:
    app.kubernetes.io/name: simple-app
    app.kubernetes.io/instance: simple-app
```

```
# Source: simple-app/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: simple-app-metrics
  labels:
    helm.sh/chart: simple-app-1.2.1
    app.kubernetes.io/version: "latest"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: simple-app
    app.kubernetes.io/instance: simple-app
  annotations:
    networking.istio.io/exportTo: nullnullnull
spec:
  type: ClusterIP
  ports:
    - port: 9090
      targetPort: 9090
      name: http-metrics
  selector:
    app.kubernetes.io/name: simple-app
    app.kubernetes.io/instance: simple-app
```