### PR TITLE
fix(charts): make sure to name the secrets uniquely

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -101,7 +101,7 @@ spec:
           envFrom:
             {{- if .Values.secrets }}
             - secretRef:
-                name:  {{ .Release.Name }}-secrets
+                name: {{ include "nd-common.fullname" . }}-secrets
             {{- end }}
             {{- with .Values.envFrom}}
             {{- range $env := index .}}

--- a/charts/daemonset-app/templates/kmssecret.yaml
+++ b/charts/daemonset-app/templates/kmssecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: secret.h3poteto.dev/v1beta1
 kind: KMSSecret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:

--- a/charts/daemonset-app/templates/secret.yaml
+++ b/charts/daemonset-app/templates/secret.yaml
@@ -5,7 +5,7 @@ This template is used for local development.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
   {{ $key | upper }}: {{ $value | b64enc }}

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/

--- a/charts/rollout-app/templates/kmssecret.yaml
+++ b/charts/rollout-app/templates/kmssecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: secret.h3poteto.dev/v1beta1
 kind: KMSSecret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -63,7 +63,7 @@ spec:
       {{- with .Values.blueGreen.antiAffinity }}
       antiAffinity:
         {{- toYaml . | nindent 8 }}
-      {{- end }} 
+      {{- end }}
 
     {{- else if (eq .Values.strategy "canary") }}
     canary:
@@ -118,7 +118,7 @@ spec:
       {{- with .Values.canary.antiAffinity }}
       antiAffinity:
         {{- toYaml . | nindent 8 }}
-      {{- end }} 
+      {{- end }}
 
       {{- with .Values.canary.steps }}
       steps:
@@ -272,7 +272,7 @@ spec:
           envFrom:
             {{- if .Values.secrets }}
             - secretRef:
-                name:  {{ .Release.Name }}-secrets
+                name: {{ include "nd-common.fullname" . }}-secrets
             {{- end }}
             {{- with .Values.envFrom}}
             {{- range $env := index .}}

--- a/charts/rollout-app/templates/secret.yaml
+++ b/charts/rollout-app/templates/secret.yaml
@@ -5,7 +5,7 @@ This template is used for local development.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
   {{ $key | upper }}: {{ $value | b64enc }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -239,7 +239,7 @@ spec:
           envFrom:
             {{- if $.Values.secrets }}
             - secretRef:
-                name:  {{ $.Release.Name }}-secrets
+                name: {{ include "nd-common.fullname" $ }}-secrets
             {{- end }}
             {{- with $.Values.envFrom}}
             {{- range $env := index .}}

--- a/charts/simple-app/templates/kmssecret.yaml
+++ b/charts/simple-app/templates/kmssecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: secret.h3poteto.dev/v1beta1
 kind: KMSSecret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:

--- a/charts/simple-app/templates/secret.yaml
+++ b/charts/simple-app/templates/secret.yaml
@@ -5,7 +5,7 @@ This template is used for local development.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
   {{ $key | upper }}: {{ $value | b64enc }}

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/stateful-app/templates/kmssecret.yaml
+++ b/charts/stateful-app/templates/kmssecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: secret.h3poteto.dev/v1beta1
 kind: KMSSecret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:

--- a/charts/stateful-app/templates/secret.yaml
+++ b/charts/stateful-app/templates/secret.yaml
@@ -5,7 +5,7 @@ This template is used for local development.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
   {{ $key | upper }}: {{ $value | b64enc }}

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -170,7 +170,7 @@ spec:
           envFrom:
             {{- if .Values.secrets }}
             - secretRef:
-                name:  {{ .Release.Name }}-secrets
+                name: {{ include "nd-common.fullname" . }}-secrets
             {{- end }}
             {{- with .Values.envFrom}}
             {{- range $env := index .}}


### PR DESCRIPTION
When using multiple `simple-app` charts as a dependency in a single parent chart, it turns out that the `KMSSecret/Secret` resources were conflicting in name because they were not using our standard naming template function.