### PR TITLE
feat(charts/simple-workflow): Workflow Janitor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.5.0
+          version: v3.12.2
 
       - uses: actions/setup-python@v4
         with:

--- a/charts/simple-workflow/Chart.yaml
+++ b/charts/simple-workflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-workflow
 description: Default Argo Workflow Helm Chart
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: latest
 maintainers:
   - name: masterginger

--- a/charts/simple-workflow/README.md
+++ b/charts/simple-workflow/README.md
@@ -2,7 +2,7 @@
 
 Default Argo Workflow Helm Chart
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Values
 

--- a/charts/simple-workflow/templates/workflow-janitor.yaml
+++ b/charts/simple-workflow/templates/workflow-janitor.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.workflowJanitor .Values.workflowJanitor.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-keep-recent-n-workflows
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        mesh.nextdoor.com/dropMetrics: 'true'
+      annotations:
+        sidecar.istio.io/inject: 'false'
+    spec:
+      serviceAccountName: {{ .Values.workflow.serviceAccount.name }}
+      restartPolicy: Never
+      activeDeadlineSeconds: 120
+      containers:
+        - name: workflow-janitor
+          image: bitnami/kubectl:1.28.4
+          command: ["/bin/bash"]
+          args:
+            - -c
+            - >-
+              kubectl get workflow --sort-by=.metadata.creationTimestamp &&
+              echo "Total workflows: $(kubectl get workflow --sort-by=.metadata.creationTimestamp -o go-template --template {{ "'{{" }}range .items}}{{ "{{" }}.metadata.name}}{{ "{{" }}"\n"}}{{ "{{" }}end}}' | wc -l)" &&
+              echo "Keeping {{ .Values.workflowJanitor.keepRecent | default 30 }}" &&
+              while [[ $(kubectl get workflow --sort-by=.metadata.creationTimestamp -o go-template --template {{ "'{{" }}range .items}}{{ "{{" }}.metadata.name}}{{ "{{" }}"\n"}}{{ "{{" }}end}}' | wc -l) -gt {{ .Values.workflowJanitor.keepRecent | default 30 }} ]];
+              do
+              sleep 3;
+              kubectl delete workflow $(kubectl get workflow --sort-by=.metadata.creationTimestamp -o go-template --template {{ "'{{" }}range .items}}{{ "{{" }}.metadata.name}}{{ "{{" }}"\n"}}{{ "{{" }}end}}' | head -n 1);
+              kubectl get workflow --sort-by=.metadata.creationTimestamp;
+              done
+{{- end }}

--- a/charts/simple-workflow/templates/workflow-pipeline.yaml
+++ b/charts/simple-workflow/templates/workflow-pipeline.yaml
@@ -11,7 +11,13 @@ metadata:
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .Values.workflow.ttlStrategy }}
+  {{- if and .Values.workflowJanitor .Values.workflowJanitor.enabled }}
+  # Set a 30-day ttl because workflow janitor is enabled
+  ttlStrategy:
+    secondsAfterCompletion: 2592000
+    secondsAfterFailure: 2592000
+    secondsAfterSuccess: 2592000
+  {{- else if .Values.workflow.ttlStrategy }}
   ttlStrategy:
     {{- with $.Values.workflow.ttlStrategy }}
     {{- tpl (toYaml .) $ | nindent 4 }}


### PR DESCRIPTION
This PR adds a component to `simple-workflow` which only keeps the last N recent workflow instances.
This solves the problem when an Argo Workflow is deployed as part of an Argo Application sync and the latest workflow instance is deleted due to `ttlStrategy` or `retentionPolicy`, the Argo Application is marked as Missing/OutOfSync, and the alert (e.g. PagerDuty) is triggered.

If `.Values.workflowJanitor.enabled` is not specified or `false`, the component is a no-op.

This PR also updates the Helm version to 3.12.2 to support `and` operator in the Helm template.