### PR TITLE
feat(charts/simple-workflow): Update helm, path and repoURL when updating an Argo App in simple-workflow

### DIFF
--- a/charts/simple-workflow/Chart.yaml
+++ b/charts/simple-workflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-workflow
 description: Default Argo Workflow Helm Chart
 type: application
-version: 0.0.13
+version: 0.0.14
 appVersion: latest
 maintainers:
   - name: masterginger

--- a/charts/simple-workflow/README.md
+++ b/charts/simple-workflow/README.md
@@ -2,7 +2,7 @@
 
 Default Argo Workflow Helm Chart
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Values
 

--- a/charts/simple-workflow/templates/workflow-pipeline.yaml
+++ b/charts/simple-workflow/templates/workflow-pipeline.yaml
@@ -119,6 +119,23 @@ spec:
             {{- end }}
         spec:
           source:
+            helm:
+              valueFiles:
+                - values.yaml
+                {{- if $.Values.global.additionalValueFiles }}
+                {{- range $.Values.global.additionalValueFiles }}
+                - {{ . }}
+                {{- end }}
+                {{- end }}
+                - values.{{ $.Values.global.appGroup }}.yaml
+              {{- if $config.helmParameters }}
+              parameters:
+              {{- with $config.helmParameters }}
+              {{- tpl (toYaml .) $ | nindent 16 }}
+              {{- end }}
+              {{- end }}
+            path: {{ $config.chartPath }}
+            repoURL: {{ $config.repoURL }}
             targetRevision: {{ $.Values.app.targetRevision }}
           {{- if and ($config.specOverride) ($config.specOverride.update) }}
           {{- with $config.specOverride.update }}


### PR DESCRIPTION
Once an Argo App is created, the current simple-workflow chart cannot update the helm, path and repoURL fields, this prevents us from migrating the Argo App's Helm chart to a different directory or a different repo.

This PR sets the helm, path and repoURL when updating the Argo App in simple-workflow.