### PR TITLE
feat(charts/nd-common): Adding support for istio sidecar resource override

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.2.1
+    version: 0.3.0
     repository: file://../nd-common

--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.15.0
+version: 0.15.1
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.2.0
+    version: 0.2.1
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.2.0
+version: 0.2.1
 appVersion: latest

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.2.1
+version: 0.3.0
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_istio.tpl
+++ b/charts/nd-common/templates/_istio.tpl
@@ -79,7 +79,7 @@ proxy.istio.io/overrides: >-
   } 
 {{- end }}
 
-{{/*
+{{- /*
 
 Prepare the set of resource annotations for the istio-sidecar.
 Motivation: Due to an incident, we found out that once one of the values is set through annotation. It overides the other values which is what led to the incident.
@@ -100,7 +100,7 @@ Usage: To setup the values follow the regular k8s resources structure under the 
        memory: 10Mi
      limits:
        memory: 60Mi
-*/}}
+*/ -}}
 {{- with .Values.istio.resources }}
 sidecar.istio.io/proxyCPU: {{ .requests.cpu | default "100m" | quote }}
 sidecar.istio.io/proxyCPULimit: {{ .limits.cpu | default "2" | quote }}

--- a/charts/nd-common/templates/_istio.tpl
+++ b/charts/nd-common/templates/_istio.tpl
@@ -82,20 +82,30 @@ proxy.istio.io/overrides: >-
 {{/*
 
 Prepare the set of resource annotations for the istio-sidecar.
-Fallbacking to the current implemented default resources:
-    Limits:
-      cpu:                2
-      memory:             1Gi
-    Requests:
-      cpu:                100m
-      memory:             128Mi
-
+Motivation: Due to an incident, we found out that once one of the values is set through annotation. It overides the other values which is what led to the incident.
+            This behaviour is not documents nor it makes sense in any ways.
+Description: Once a value is set to any of the istio.(proxyCPU, proxyCPULimit, proxyMemory, proxyMemoryLimit), all the 4 annotations will get created.
+             Fallbacking to the current implemented default resources for any annotation that is not specifically set:
+                Limits:
+                  cpu:                2
+                  memory:             1Gi
+                Requests:
+                  cpu:                100m
+                  memory:             128Mi
+Usage: To setup the values follow the regular k8s resources structure under the istio key, like the bellow example:
+  istio:
+   resources:
+     requests:
+       cpu: 10m
+       memory: 10Mi
+     limits:
+       memory: 60Mi
 */}}
-{{- if or (or .Values.istio.proxyCPU .Values.istio.proxyMemory) (or .Values.istio.proxyCPULimit .Values.istio.proxyMemoryLimit) }}
-sidecar.istio.io/proxyCPU: {{ .Values.istio.proxyCPU | default "100m" | quote }}
-sidecar.istio.io/proxyCPULimit: {{ .Values.istio.proxyCPULimit | default "2" | quote }}
-sidecar.istio.io/proxyMemory: {{ .Values.istio.proxyMemory | default "128Mi" | quote }}
-sidecar.istio.io/proxyMemoryLimit: {{ .Values.istio.proxyMemoryLimit | default "1Gi" | quote }}
+{{- with .Values.istio.resources }}
+sidecar.istio.io/proxyCPU: {{ .requests.cpu | default "100m" | quote }}
+sidecar.istio.io/proxyCPULimit: {{ .limits.cpu | default "2" | quote }}
+sidecar.istio.io/proxyMemory: {{ .requests.memory | default "128Mi" | quote }}
+sidecar.istio.io/proxyMemoryLimit: {{ .limits.memory | default "1Gi" | quote }}
 {{- end }}
 
 {{- end }}

--- a/charts/nd-common/templates/_istio.tpl
+++ b/charts/nd-common/templates/_istio.tpl
@@ -138,25 +138,6 @@ Build a comma-separated list of outbound ports to exclude from Istio routing.
 
 {{/*
 
-Prepare the set of resource annotations for the istio-sidecar.
-Fallbacking to the current implemented default resources:
-    Limits:
-      cpu:                2
-      memory:             1Gi
-    Requests:
-      cpu:                100m
-      memory:             128Mi
-
-*/}}
-{{- if or (or .Values.istio.proxyCPU .Values.istio.proxyMemory) (or .Values.istio.proxyCPULimit .Values.istio.proxyMemoryLimit) }}
-sidecar.istio.io/proxyCPU: {{ .Values.istio.proxyCPU | default "100m" | quote }}
-sidecar.istio.io/proxyCPULimit: {{ .Values.istio.proxyCPULimit | default "2" | quote }}
-sidecar.istio.io/proxyMemory: {{ .Values.istio.proxyMemory | default "128Mi" | quote }}
-sidecar.istio.io/proxyMemoryLimit: {{ .Values.istio.proxyMemoryLimit | default "1Gi" | quote }}
-{{- end }}
-
-{{/*
-
 The "istioLabels" function creates a few common labels that the Istio team (and
 Kiali teams) have decided make sense for tracking applications inside of a
 mesh.

--- a/charts/nd-common/templates/_istio.tpl
+++ b/charts/nd-common/templates/_istio.tpl
@@ -79,6 +79,25 @@ proxy.istio.io/overrides: >-
   } 
 {{- end }}
 
+{{/*
+
+Prepare the set of resource annotations for the istio-sidecar.
+Fallbacking to the current implemented default resources:
+    Limits:
+      cpu:                2
+      memory:             1Gi
+    Requests:
+      cpu:                100m
+      memory:             128Mi
+
+*/}}
+{{- if or (or .Values.istio.proxyCPU .Values.istio.proxyMemory) (or .Values.istio.proxyCPULimit .Values.istio.proxyMemoryLimit) }}
+sidecar.istio.io/proxyCPU: {{ .Values.istio.proxyCPU | default "100m" | quote }}
+sidecar.istio.io/proxyCPULimit: {{ .Values.istio.proxyCPULimit | default "2" | quote }}
+sidecar.istio.io/proxyMemory: {{ .Values.istio.proxyMemory | default "128Mi" | quote }}
+sidecar.istio.io/proxyMemoryLimit: {{ .Values.istio.proxyMemoryLimit | default "1Gi" | quote }}
+{{- end }}
+
 {{- end }}
 {{- end }}
 
@@ -115,6 +134,25 @@ Build a comma-separated list of outbound ports to exclude from Istio routing.
 {{- end }}
 {{- end }}
 {{- join ", " $ports }}
+{{- end }}
+
+{{/*
+
+Prepare the set of resource annotations for the istio-sidecar.
+Fallbacking to the current implemented default resources:
+    Limits:
+      cpu:                2
+      memory:             1Gi
+    Requests:
+      cpu:                100m
+      memory:             128Mi
+
+*/}}
+{{- if or (or .Values.istio.proxyCPU .Values.istio.proxyMemory) (or .Values.istio.proxyCPULimit .Values.istio.proxyMemoryLimit) }}
+sidecar.istio.io/proxyCPU: {{ .Values.istio.proxyCPU | default "100m" | quote }}
+sidecar.istio.io/proxyCPULimit: {{ .Values.istio.proxyCPULimit | default "2" | quote }}
+sidecar.istio.io/proxyMemory: {{ .Values.istio.proxyMemory | default "128Mi" | quote }}
+sidecar.istio.io/proxyMemoryLimit: {{ .Values.istio.proxyMemoryLimit | default "1Gi" | quote }}
 {{- end }}
 
 {{/*

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.2.1
+    version: 0.3.0
     repository: file://../nd-common

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.2.0
+    version: 0.2.1
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -167,7 +167,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.0 |
+| file://../nd-common | nd-common | 0.2.1 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -167,7 +167,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.1 |
+| file://../nd-common | nd-common | 0.3.0 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.2.1
+    version: 0.3.0
     repository: file://../nd-common

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.2.0
+    version: 0.2.1
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -312,7 +312,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.1 |
+| file://../nd-common | nd-common | 0.3.0 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -312,7 +312,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.0 |
+| file://../nd-common | nd-common | 0.2.1 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.2.1
+    version: 0.3.0
     repository: file://../nd-common

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.16.0
+version: 0.16.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.2.0
+    version: 0.2.1
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -259,7 +259,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.0 |
+| file://../nd-common | nd-common | 0.2.1 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -259,7 +259,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.1 |
+| file://../nd-common | nd-common | 0.3.0 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
 
 ## Values


### PR DESCRIPTION
**Motivation**
Due to an incident, we found out that once one of the values is set through annotation. It overides the other values which is what led to the incident.
This behaviour is not documents nor it makes sense in any ways.
**Description**
Once a value is set to any of the istio.(proxyCPU, proxyCPULimit, proxyMemory, proxyMemoryLimit), all the 4 annotations will get created.
Fallbacking to the current implemented default resources for any annotation that is not specifically set:
    Limits:
      cpu:                2
      memory:             1Gi
    Requests:
      cpu:                100m
      memory:             128Mi

The PR includes:
- Adding support for istio sidecar resource override in nd-common istio-annotations.
- Updating dependant charts to use the new nd-common.