### PR TITLE
feat(prometheus-alerts): add PodReadyReplicaDrop alerts

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.2.0
+    version: 0.3.1
     repository: file://../nd-common

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -3,7 +3,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -54,7 +54,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.0 |
+| file://../nd-common | nd-common | 0.3.1 |
 
 ## Values
 
@@ -96,6 +96,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | containerRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | containerRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| containerRules.PodReadyReplicaCountDrop | object | `{"compareToOffset":"1m","enabled":false,"for":"0m","severity":"warning","threshold":0.35}` | Number of ready pods in ReplicaSet has fallen |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
 | defaults.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.daemonsetNameSelector | `string` | `"{{ .Release.Name }}-.*"` | Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -193,6 +193,80 @@ spec:
         {{- end }}
     {{- end }}
 
+    {{ with .Values.containerRules.PodReadyReplicaCountDrop -}}
+    {{- if .enabled }}
+    - alert: PodReadyReplicaCountDrop
+      annotations:
+        summary: Number of ready pods in ReplicaSet has fallen
+        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          The number of ready pods for {{`{{`}} $labels.namespace
+          {{`}}`}}/{{`{{`}} $labels.rs_type {{`}}`}} has dropped significantly, this
+          indicates that readiness checks are failing for a large portion of the replicas.
+          Please debug immediately and/or manuallly scale out.
+      expr: |-
+        (
+          (
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{ {{ $namespaceSelector }}  } offset {{ .compareToOffset }},
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+
+            -
+
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{ {{ $namespaceSelector }} },
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+          )
+
+          /
+
+          sum by (namespace, rs_type) (
+            label_replace(
+              kube_replicaset_status_ready_replicas{ {{ $namespaceSelector }} } offset {{ .compareToOffset }},
+              "rs_type",
+              "$1",
+              "replicaset",
+              "(.*)-.*"
+            )
+          )
+
+          > {{ .threshold }}
+
+        )
+
+        and
+
+        sum by (namespace, rs_type) (
+          label_replace(
+            kube_replicaset_status_ready_replicas{ {{ $namespaceSelector }} } offset {{ .compareToOffset }},
+            "rs_type",
+            "$1",
+            "replicaset",
+            "(.*)-.*"
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
+
     {{ with .Values.containerRules.KubeDeploymentGenerationMismatch -}}
     - alert: KubeDeploymentGenerationMismatch
       annotations:

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -160,6 +160,14 @@ containerRules:
     severity: warning
     for: 15m
 
+  # -- Number of ready pods in ReplicaSet has fallen
+  PodReadyReplicaCountDrop:
+    enabled: false
+    severity: warning
+    threshold: 0.35
+    comparteToOffset: 1m
+    for: 0m
+
   # Pod container waiting longer than threshold
   ContainerWaiting:
     severity: warning

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -165,7 +165,7 @@ containerRules:
     enabled: false
     severity: warning
     threshold: 0.35
-    comparteToOffset: 1m
+    compareToOffset: 1m
     for: 0m
 
   # Pod container waiting longer than threshold

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -276,6 +276,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | prometheusRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | prometheusRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | prometheusRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| prometheusRules.PodReadyReplicaCountDrop | object | `{"compareToOffset":"1m","enabled":false,"for":"0m","severity":"warning","threshold":0.35}` | Number of ready pods in ReplicaSet has fallen |
 | prometheusRules.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | prometheusRules.enabled | `bool` | `true` | Whether or not to enable the container rules template |
 | proxySidecar.enabled | Boolean | `false` | Enables injecting a pre-defined reverse proxy sidecar container into the Pod containers list. |

--- a/charts/rollout-app/templates/prometheusrules.yaml
+++ b/charts/rollout-app/templates/prometheusrules.yaml
@@ -100,6 +100,90 @@ spec:
         {{- end }}
     {{- end }}
 
+    {{- with .Values.prometheusRules.PodReadyReplicaCountDrop }}
+    {{- if .enabled }}
+    - alert: PodReadyReplicaCountDrop
+      annotations:
+        summary: Number of ready pods in ReplicaSet has fallen
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          The number of ready pods for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.rs_type }}`}}
+          has dropped significantly, this indicates that readiness checks are failing for a large
+          portion of the replicas. Please debug immediately and/or manuallly scale out.
+      expr: |-
+        sum by (namespace, pod) (
+          max by(namespace, pod) (
+            kube_pod_status_phase{
+              job="kube-state-metrics",
+              namespace=~"{{ $targetNamespace }}",
+              phase=~"Pending|Unknown",
+              pod=~"{{ $podName }}"
+            }
+          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
+            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+          )
+        ) > 0
+        (
+          (
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+
+            -
+
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}},
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+          )
+
+          /
+
+          sum by (namespace, rs_type) (
+            label_replace(
+              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+              "rs_type",
+              "$1",
+              "replicaset",
+              "(.*)-.*"
+            )
+          )
+
+          > {{ .threshold }}
+
+        )
+
+        and
+
+        sum by (namespace, rs_type) (
+          label_replace(
+            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+            "rs_type",
+            "$1",
+            "replicaset",
+            "(.*)-.*"
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.ContainerRules
     rules:
 

--- a/charts/rollout-app/templates/prometheusrules.yaml
+++ b/charts/rollout-app/templates/prometheusrules.yaml
@@ -111,23 +111,11 @@ spec:
           has dropped significantly, this indicates that readiness checks are failing for a large
           portion of the replicas. Please debug immediately and/or manuallly scale out.
       expr: |-
-        sum by (namespace, pod) (
-          max by(namespace, pod) (
-            kube_pod_status_phase{
-              job="kube-state-metrics",
-              namespace=~"{{ $targetNamespace }}",
-              phase=~"Pending|Unknown",
-              pod=~"{{ $podName }}"
-            }
-          ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
-            1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
-          )
-        ) > 0
         (
           (
             sum by (namespace, rs_type) (
               label_replace(
-                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
                 "rs_type",
                 "$1",
                 "replicaset",
@@ -139,7 +127,7 @@ spec:
 
             sum by (namespace, rs_type) (
               label_replace(
-                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}},
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"},
                 "rs_type",
                 "$1",
                 "replicaset",
@@ -152,7 +140,7 @@ spec:
 
           sum by (namespace, rs_type) (
             label_replace(
-              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
               "rs_type",
               "$1",
               "replicaset",
@@ -168,7 +156,7 @@ spec:
 
         sum by (namespace, rs_type) (
           label_replace(
-            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
             "rs_type",
             "$1",
             "replicaset",

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -900,6 +900,14 @@ prometheusRules:
     severity: warning
     for: 15m
 
+  # -- Number of ready pods in ReplicaSet has fallen
+  PodReadyReplicaCountDrop:
+    enabled: false
+    severity: warning
+    threshold: 0.35
+    comparteToOffset: 1m
+    for: 0m
+
   # -- Container is being throttled by the CGroup - needs more resources.
   # This value is appropriate for applications that are highly sensitive to
   # request latency. Insensitive workloads might need to raise this percentage

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -905,7 +905,7 @@ prometheusRules:
     enabled: false
     severity: warning
     threshold: 0.35
-    comparteToOffset: 1m
+    compareToOffset: 1m
     for: 0m
 
   # -- Container is being throttled by the CGroup - needs more resources.

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -407,6 +407,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | prometheusRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | prometheusRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | prometheusRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| prometheusRules.PodReadyReplicaCountDrop | object | `{"compareToOffset":"1m","enabled":false,"for":"0m","severity":"warning","threshold":0.35}` | Number of ready pods in ReplicaSet has fallen |
 | prometheusRules.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | prometheusRules.enabled | `bool` | `true` | Whether or not to enable the prometheus-alerts chart. |
 | proxySidecar.enabled | Boolean | `false` | Enables injecting a pre-defined reverse proxy sidecar container into the Pod containers list. |

--- a/charts/simple-app/templates/prometheusrules.yaml
+++ b/charts/simple-app/templates/prometheusrules.yaml
@@ -115,7 +115,7 @@ spec:
           (
             sum by (namespace, rs_type) (
               label_replace(
-                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
                 "rs_type",
                 "$1",
                 "replicaset",
@@ -127,7 +127,7 @@ spec:
 
             sum by (namespace, rs_type) (
               label_replace(
-                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}},
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"},
                 "rs_type",
                 "$1",
                 "replicaset",
@@ -140,7 +140,7 @@ spec:
 
           sum by (namespace, rs_type) (
             label_replace(
-              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
               "rs_type",
               "$1",
               "replicaset",
@@ -156,7 +156,7 @@ spec:
 
         sum by (namespace, rs_type) (
           label_replace(
-            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
             "rs_type",
             "$1",
             "replicaset",

--- a/charts/simple-app/templates/prometheusrules.yaml
+++ b/charts/simple-app/templates/prometheusrules.yaml
@@ -100,6 +100,78 @@ spec:
         {{- end }}
     {{- end }}
 
+    {{- with .Values.prometheusRules.PodReadyReplicaCountDrop }}
+    {{- if .enabled }}
+    - alert: PodReadyReplicaCountDrop
+      annotations:
+        summary: Number of ready pods in ReplicaSet has fallen
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          The number of ready pods for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.rs_type }}`}}
+          has dropped significantly, this indicates that readiness checks are failing for a large
+          portion of the replicas. Please debug immediately and/or manuallly scale out.
+      expr: |-
+        (
+          (
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+
+            -
+
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}},
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+          )
+
+          /
+
+          sum by (namespace, rs_type) (
+            label_replace(
+              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+              "rs_type",
+              "$1",
+              "replicaset",
+              "(.*)-.*"
+            )
+          )
+
+          > {{ .threshold }}
+
+        )
+
+        and
+
+        sum by (namespace, rs_type) (
+          label_replace(
+            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+            "rs_type",
+            "$1",
+            "replicaset",
+            "(.*)-.*"
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.ContainerRules
     rules:
 

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -767,6 +767,14 @@ prometheusRules:
     severity: warning
     for: 15m
 
+  # -- Number of ready pods in ReplicaSet has fallen
+  PodReadyReplicaCountDrop:
+    enabled: false
+    severity: warning
+    threshold: 0.35
+    comparteToOffset: 1m
+    for: 0m
+
   # -- Container is being throttled by the CGroup - needs more resources.
   # This value is appropriate for applications that are highly sensitive to
   # request latency. Insensitive workloads might need to raise this percentage

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -772,7 +772,7 @@ prometheusRules:
     enabled: false
     severity: warning
     threshold: 0.35
-    comparteToOffset: 1m
+    compareToOffset: 1m
     for: 0m
 
   # -- Container is being throttled by the CGroup - needs more resources.

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.16.2
+version: 0.16.3
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.16.3](https://img.shields.io/badge/Version-0.16.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -338,6 +338,7 @@ kmsSecretsRegion: us-west-2 (AWS region where the KMS key is located)
 | prometheusRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | prometheusRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | prometheusRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| prometheusRules.PodReadyReplicaCountDrop | object | `{"compareToOffset":"1m","enabled":false,"for":"0m","severity":"warning","threshold":0.35}` | Number of ready pods in ReplicaSet has fallen |
 | prometheusRules.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | prometheusRules.enabled | `bool` | `true` | Whether or not to enable the prometheus-alerts chart. |
 | proxySidecar.enabled | Boolean | `false` | Enables injecting a pre-defined reverse proxy sidecar container into the Pod containers list. |

--- a/charts/stateful-app/templates/prometheusrules.yaml
+++ b/charts/stateful-app/templates/prometheusrules.yaml
@@ -116,7 +116,7 @@ spec:
           (
             sum by (namespace, rs_type) (
               label_replace(
-                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
                 "rs_type",
                 "$1",
                 "replicaset",
@@ -128,7 +128,7 @@ spec:
 
             sum by (namespace, rs_type) (
               label_replace(
-                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}},
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"},
                 "rs_type",
                 "$1",
                 "replicaset",
@@ -141,7 +141,7 @@ spec:
 
           sum by (namespace, rs_type) (
             label_replace(
-              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
               "rs_type",
               "$1",
               "replicaset",
@@ -157,7 +157,7 @@ spec:
 
         sum by (namespace, rs_type) (
           label_replace(
-            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}"} offset {{ .compareToOffset }},
             "rs_type",
             "$1",
             "replicaset",

--- a/charts/stateful-app/templates/prometheusrules.yaml
+++ b/charts/stateful-app/templates/prometheusrules.yaml
@@ -101,6 +101,78 @@ spec:
         {{- end }}
     {{- end }}
 
+    {{- with .Values.prometheusRules.PodReadyReplicaCountDrop }}
+    {{- if .enabled }}
+    - alert: PodReadyReplicaCountDrop
+      annotations:
+        summary: Number of ready pods in ReplicaSet has fallen
+        runbook_url: {{ $runbookUrl }}#alert-name-kubepodnotready
+        description: >-
+          The number of ready pods for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.rs_type }}`}}
+          has dropped significantly, this indicates that readiness checks are failing for a large
+          portion of the replicas. Please debug immediately and/or manuallly scale out.
+      expr: |-
+        (
+          (
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+
+            -
+
+            sum by (namespace, rs_type) (
+              label_replace(
+                kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}},
+                "rs_type",
+                "$1",
+                "replicaset",
+                "(.*)-.*"
+              )
+            )
+          )
+
+          /
+
+          sum by (namespace, rs_type) (
+            label_replace(
+              kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+              "rs_type",
+              "$1",
+              "replicaset",
+              "(.*)-.*"
+            )
+          )
+
+          > {{ .threshold }}
+
+        )
+
+        and
+
+        sum by (namespace, rs_type) (
+          label_replace(
+            kube_replicaset_status_ready_replicas{namespace=~"{{ $targetNamespace }}} offset {{ .compareToOffset }},
+            "rs_type",
+            "$1",
+            "replicaset",
+            "(.*)-.*"
+          )
+        ) > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- with $values.prometheusRules.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.ContainerRules
     rules:
 

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -645,7 +645,7 @@ prometheusRules:
     enabled: false
     severity: warning
     threshold: 0.35
-    comparteToOffset: 1m
+    compareToOffset: 1m
     for: 0m
 
   # -- Container is being throttled by the CGroup - needs more resources.

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -640,6 +640,14 @@ prometheusRules:
     severity: warning
     for: 15m
 
+  # -- Number of ready pods in ReplicaSet has fallen
+  PodReadyReplicaCountDrop:
+    enabled: false
+    severity: warning
+    threshold: 0.35
+    comparteToOffset: 1m
+    for: 0m
+
   # -- Container is being throttled by the CGroup - needs more resources.
   # This value is appropriate for applications that are highly sensitive to
   # request latency. Insensitive workloads might need to raise this percentage


### PR DESCRIPTION
A configurable alarm (disabled by default) that says _"Compared to the previous {{ .compareToOffset}}, more than {{ .threshold} } ratio of your pods are now not ready"_

Tested by rendering the template and running against a timeframe of data for which I would've liked to be alerted:

<img width="1705" alt="Screenshot 2024-01-19 at 1 37 41 PM" src="https://github.com/Nextdoor/k8s-charts/assets/831526/79bd8182-da88-4b0b-8b91-a63d603414d1">

The raw patterns this would've alerted against:

<img width="1705" alt="Screenshot 2024-01-19 at 1 59 53 PM" src="https://github.com/Nextdoor/k8s-charts/assets/831526/91029292-f8e6-48ac-8739-9daf02764a4a">
