### PR TITLE
chore(simple-app): remove uppercase transform of secret engine keys

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.15.3
+version: 0.15.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.15.4](https://img.shields.io/badge/Version-0.15.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/daemonset-app/templates/kmssecret.yaml
+++ b/charts/daemonset-app/templates/kmssecret.yaml
@@ -7,6 +7,6 @@ spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- end }}

--- a/charts/daemonset-app/templates/sealedsecret.yaml
+++ b/charts/daemonset-app/templates/sealedsecret.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
   template:
     metadata:

--- a/charts/daemonset-app/templates/secret.yaml
+++ b/charts/daemonset-app/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
   name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
-  {{ $key | upper }}: {{ $value | b64enc }}
+  {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/

--- a/charts/rollout-app/templates/kmssecret.yaml
+++ b/charts/rollout-app/templates/kmssecret.yaml
@@ -7,6 +7,6 @@ spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- end }}

--- a/charts/rollout-app/templates/sealedsecret.yaml
+++ b/charts/rollout-app/templates/sealedsecret.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
   template:
     metadata:

--- a/charts/rollout-app/templates/secret.yaml
+++ b/charts/rollout-app/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
   name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
-  {{ $key | upper }}: {{ $value | b64enc }}
+  {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.6.3
+version: 1.6.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.4](https://img.shields.io/badge/Version-1.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/kmssecret.yaml
+++ b/charts/simple-app/templates/kmssecret.yaml
@@ -7,6 +7,6 @@ spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- end }}

--- a/charts/simple-app/templates/sealedsecret.yaml
+++ b/charts/simple-app/templates/sealedsecret.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
   template:
     metadata:

--- a/charts/simple-app/templates/secret.yaml
+++ b/charts/simple-app/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
   name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
-  {{ $key | upper }}: {{ $value | b64enc }}
+  {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 0.16.3
+version: 0.16.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 0.16.3](https://img.shields.io/badge/Version-0.16.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.16.4](https://img.shields.io/badge/Version-0.16.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/stateful-app/templates/kmssecret.yaml
+++ b/charts/stateful-app/templates/kmssecret.yaml
@@ -7,6 +7,6 @@ spec:
   region: {{ .Values.kmsSecretsRegion }}
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- end }}

--- a/charts/stateful-app/templates/sealedsecret.yaml
+++ b/charts/stateful-app/templates/sealedsecret.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   encryptedData:
     {{- range $key, $value := .Values.secrets }}
-    {{ $key | upper }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
   template:
     metadata:

--- a/charts/stateful-app/templates/secret.yaml
+++ b/charts/stateful-app/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
   name: {{ include "nd-common.fullname" . }}-secrets
 data:
   {{- range $key, $value := .Values.secrets }}
-  {{ $key | upper }}: {{ $value | b64enc }}
+  {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
After some private feedback (and I tend to agree), we want to _remove_ the `uppercase` transformation on secret property keys.

As the rest of the engines (`plaintext` and `kms`) are in abundant use, changing that would be BREAKING. 

I feel we can switch the `sealed` engine template only, as adoption of that is nil (and IMO a breaking change later for the rest of the secret engines).

I think the advantage of letting user explicitly set the key name (rather than doing a "behind-the-scenes" transformation) outweigh the cons (less friction finding/debugging secrets, some 3rd-party charts may require user to have a secret with a specifically styled key, etc)