### PR TITLE
[Flink operator] Rename pod monitor label from cluster to flink-cluster

### DIFF
--- a/charts/flink-operator/Chart.yaml
+++ b/charts/flink-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Intalls the Spotify-version of the Flink-on-K8S-Operator
 name: flink-operator
-version: 0.0.1
+version: 0.1.0
 appVersion: v0.3.0
 sources:
   - https://github.com/spotify/flink-on-k8s-operator/releases

--- a/charts/flink-operator/README.md
+++ b/charts/flink-operator/README.md
@@ -1,6 +1,6 @@
 # flink-operator
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
 Intalls the Spotify-version of the Flink-on-K8S-Operator
 

--- a/charts/flink-operator/templates/podmonitor.yaml
+++ b/charts/flink-operator/templates/podmonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   podTargetLabels:
-    - cluster
     - component
   selector:
     matchLabels:
@@ -14,4 +13,8 @@ spec:
   # Specify the port name of the exposed metric port
   podMetricsEndpoints:
     - port: prom
+      relabelings:
+        - action: replace
+          sourceLabels: [ __meta_kubernetes_pod_label_cluster ]
+          targetLabel: flink_cluster
 {{ end -}}


### PR DESCRIPTION
Changing pod monitor label from `cluster` to `flink-cluster` for flonk-operator, per [this](https://nextdoor.slack.com/archives/CM6EWSYH4/p1710968293931579) discussion. 