### PR TITLE
feat(simple-app): Support optional different probes for proxySidecar

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.6.4
+version: 1.6.5
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.6.4](https://img.shields.io/badge/Version-1.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.5](https://img.shields.io/badge/Version-1.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -421,8 +421,11 @@ secretsEngine: sealed
 | proxySidecar.image.pullPolicy | String | `"IfNotPresent"` | Always, Never or IfNotPresent |
 | proxySidecar.image.repository | String | `"nginx"` | The Docker image name and repository for the sidecar |
 | proxySidecar.image.tag | String | `"latest"` | The Docker tag for the sidecar |
+| proxySidecar.livenessProbe | string | `nil` | A PodSpec container "livenessProbe" configuration object. Takes precedence (overrides) whatever is set at the root-level probe |
 | proxySidecar.name | String | `"proxy"` | The name of the proxy sidecar container |
+| proxySidecar.readinessProbe | string | `nil` | A PodSpec container "readinessProbe" configuration object. Takes precedence (overrides) whatever is set at the root-level probe |
 | proxySidecar.resources | object | `{}` | A PodSpec "Resources" object for the proxy container |
+| proxySidecar.startupProbe | string | `nil` | A PodSpec container "startupProbe" configuration object. Takes precedence (overrides) whatever is set at the root-level probe |
 | proxySidecar.volumeMounts | list | `[]` | List of VolumeMounts that are applied to the proxySidecar container - these must refer to volumes set in the `Values.volumes` parameter. |
 | readinessProbe | string | `nil` | A PodSpec container "readinessProbe" configuration object. Note that this readinessProbe will be applied to the proxySidecar container instead if that is enabled. This is **required**. |
 | replicaCount | `int` | `2` | The number of Pods to start up by default. If the `autoscaling.enabled` parameter is set, then this serves as the "start scale" for an application. Setting this to `null` prevents the setting from being applied at all in the PodSpec, leaving it to Kubernetes to use the default value (1). https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas |

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -200,16 +200,22 @@ spec:
           ports:
             {{- include "nd-common.containerPorts" $ | nindent 12 }}
           {{- end }}
-          {{- with $.Values.startupProbe }}
+          {{- $pxyStrtpPrb := $.Values.proxySidecar.startupProbe | default $.Values.startupProbe }}
+          {{- with $pxyStrtpPrb }}
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with $.Values.livenessProbe }}
+          {{- $pxyLivePrb := $.Values.proxySidecar.livenessProbe | default $.Values.livenessProbe }}
+          {{- with $pxyLivePrb }}
           livenessProbe:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           readinessProbe:
+            {{- if $.Values.proxySidecar.readinessProbe }}
+            {{- tpl (toYaml $.Values.proxySidecar.readinessProbe) $ | nindent 12 }}
+            {{- else }}
             {{- tpl (toYaml $.Values.readinessProbe) $ | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml $.Values.proxySidecar.resources | nindent 12 }}
         {{- end }}

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -101,6 +101,18 @@ proxySidecar:
   # -- A PodSpec "Resources" object for the proxy container
   resources: {}
 
+  # -- A PodSpec container "startupProbe" configuration object. Takes
+  # precedence (overrides) whatever is set at the root-level probe
+  startupProbe: null
+
+  # -- A PodSpec container "livenessProbe" configuration object. Takes
+  # precedence (overrides) whatever is set at the root-level probe
+  livenessProbe: null
+
+  # -- A PodSpec container "readinessProbe" configuration object. Takes
+  # precedence (overrides) whatever is set at the root-level probe
+  readinessProbe: null
+
 # -- A PodSpec container "startupProbe" configuration object. Note that this
 # startupProbe will be applied to the proxySidecar container instead if that
 # is enabled.


### PR DESCRIPTION
## The Problem We're Trying To Solve

Right now the main "app" container and the "proxySidecar" container share the same probes.

As each container may be different, this can result in health check issues and we have no way of customizing a probe for each of the containers.

## This Change

To maintain backwards compatibility, this will set the proxy sidecar's probes to whatever is set in `proxySidecar.*Probe` (and if it's not set, default to the current behavior of using the probe from the root.