### PR TITLE
feat(prometheus-alerts): Add alerts to check that selectors actually select valid data

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 
@@ -25,6 +25,8 @@ A Helm chart that provisions a series of alerts for istio VirtualServices
 | defaults.additionalRuleLabels | object | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/istio-alerts/runbook.md"` | The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
 | serviceRules.destinationServiceName | string | `".*"` | Narrow down the alerts to a particular Destination Service if there are multiple services that require different thresholds within the same namespace. |
+| serviceRules.destinationServiceSelectorValidity.for | string | `"1h"` |  |
+| serviceRules.destinationServiceSelectorValidity.sevarity | string | `"warning"` |  |
 | serviceRules.enabled | bool | `true` | Whether to enable the service rules template |
 | serviceRules.highRequestLatency.enabled | bool | `true` | Whether to enable the monitor on latency returned by the VirtualService. |
 | serviceRules.highRequestLatency.for | string | `"15m"` | How long to evaluate the latency of services. |

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -25,9 +25,9 @@ A Helm chart that provisions a series of alerts for istio VirtualServices
 | defaults.additionalRuleLabels | object | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/istio-alerts/runbook.md"` | The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
 | serviceRules.destinationServiceName | string | `".*"` | Narrow down the alerts to a particular Destination Service if there are multiple services that require different thresholds within the same namespace. |
-| serviceRules.destinationServiceSelectorValidity | object | `{"for":"1h","sevarity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| serviceRules.destinationServiceSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | serviceRules.destinationServiceSelectorValidity.for | string | `"1h"` | How long to evaluate. |
-| serviceRules.destinationServiceSelectorValidity.sevarity | string | `"warning"` | Severity of the monitor |
+| serviceRules.destinationServiceSelectorValidity.severity | string | `"warning"` | Severity of the monitor |
 | serviceRules.enabled | bool | `true` | Whether to enable the service rules template |
 | serviceRules.highRequestLatency.enabled | bool | `true` | Whether to enable the monitor on latency returned by the VirtualService. |
 | serviceRules.highRequestLatency.for | string | `"15m"` | How long to evaluate the latency of services. |

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -25,8 +25,9 @@ A Helm chart that provisions a series of alerts for istio VirtualServices
 | defaults.additionalRuleLabels | object | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/istio-alerts/runbook.md"` | The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
 | serviceRules.destinationServiceName | string | `".*"` | Narrow down the alerts to a particular Destination Service if there are multiple services that require different thresholds within the same namespace. |
-| serviceRules.destinationServiceSelectorValidity.for | string | `"1h"` |  |
-| serviceRules.destinationServiceSelectorValidity.sevarity | string | `"warning"` |  |
+| serviceRules.destinationServiceSelectorValidity | object | `{"for":"1h","sevarity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| serviceRules.destinationServiceSelectorValidity.for | string | `"1h"` | How long to evaluate. |
+| serviceRules.destinationServiceSelectorValidity.sevarity | string | `"warning"` | Severity of the monitor |
 | serviceRules.enabled | bool | `true` | Whether to enable the service rules template |
 | serviceRules.highRequestLatency.enabled | bool | `true` | Whether to enable the monitor on latency returned by the VirtualService. |
 | serviceRules.highRequestLatency.for | string | `"15m"` | How long to evaluate the latency of services. |

--- a/charts/istio-alerts/runbook.md
+++ b/charts/istio-alerts/runbook.md
@@ -9,3 +9,15 @@ to the grafana deployment for the correct EKS cluster and select the relevant
 service. Many services have custom dashboards in DataDog as well which may help
 investigate this alert further, and most service also produce logs of requests
 which may provide more context into what errors are being returned and why.
+
+## Alert-Rules-Selectors-Validity
+
+This alert fires when there may be an error in setting the proper selectors used
+by the other alerts in this chart. It attempts to read a basic metric using the
+selector you provided. For instance, if you have a pod selector that looks for
+`pod=~"foo-bar-.*"` but your pods are actually named `baz-.*`, this alert will
+notify you of the misconfiguration. Read the alert description to see exactly
+which selector is having an issue. Also note that you need to collect the
+metrics that this alert uses. For instance, to test pod selectors, we use the
+`kube_pod_info` metric. If you do not collect this metric, this alert will
+continiously fire.

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -56,7 +56,7 @@ spec:
       annotations:
         summary: >-
           {{`{{$labels.destination_service_name}}`}} avg request latencies are above {{ .threshold }}s!
-        runbook_url: {{ $values.defaults.runbookUrl}} #HighRequestLatency
+        runbook_url: {{ $values.defaults.runbookUrl}}#HighRequestLatency
         description: >-
           Average request latency of {{`{{ $value | humanizePercentage }}`}} is above threshold ({{ .threshold }}s)
           in namespace {{`{{ $labels.namespace }}`}} for pod {{`{{ $labels.pod }}`}} (container: {{`{{ $labels.container }}`}}).
@@ -85,5 +85,37 @@ spec:
         {{ toYaml . | nindent 8}}
         {{- end }}
     {{- end }}
-  {{- end }}
+    {{- end }}
+
+  - name: {{ .Release.Name }}.{{ .Release.Namespace }}.{{ .Chart.Name }}.alertRulesSelectorsValidity
+    rules:
+    {{- with .Values.serviceRules.destinationServiceSelectorValidity }}
+    - alert: DestinationServiceSelectorValidity
+      annotations:
+        summary: >-
+          DestinationServiceSelector for istio-alerts is invalid
+        runbook_url: {{ $values.defaults.runbookUrl}}#Alert-Rules-Selectors-Validity
+        description: >-
+          The DaemonsetSelector used for daemonset level alerts did not return any data.
+          Please check the DaemonsetSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your daemonsets so that you
+          will be alerted for daemonset issues. The current selector is
+          `{destination_service_namespace="{{ $release.Namespace }}", destination_service_name="{{ $.Values.serviceRules.destinationServiceName }}"}`.
+      expr: |-
+        (
+          count(
+            istio_request_duration_milliseconds_bucket{
+              destination_service_namespace="{{ $release.Namespace }}",
+              destination_service_name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        namespace: {{ $release.Namespace }}
+        {{- with $values.defaults.additionalRuleLabels}}
+        {{ toYaml . | nindent 8}}
+        {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/istio-alerts/values.yaml
+++ b/charts/istio-alerts/values.yaml
@@ -117,3 +117,7 @@ serviceRules:
 
     # -- How long to evaluate the latency of services.
     for: 15m
+  
+  destinationServiceSelectorValidity:
+    sevarity: warning
+    for: 1h

--- a/charts/istio-alerts/values.yaml
+++ b/charts/istio-alerts/values.yaml
@@ -118,6 +118,13 @@ serviceRules:
     # -- How long to evaluate the latency of services.
     for: 15m
 
+  # -- Does a basic lookup using the defined selectors to see if we can see any
+  # info for a given selector. This is the "watcher for the watcher". If we get
+  # alerted by this, we likely have a bad selector and our alerts are not going
+  # to ever fire.
   destinationServiceSelectorValidity:
+    # -- Severity of the monitor
     sevarity: warning
+
+    # -- How long to evaluate.
     for: 1h

--- a/charts/istio-alerts/values.yaml
+++ b/charts/istio-alerts/values.yaml
@@ -117,7 +117,7 @@ serviceRules:
 
     # -- How long to evaluate the latency of services.
     for: 15m
-  
+
   destinationServiceSelectorValidity:
     sevarity: warning
     for: 1h

--- a/charts/istio-alerts/values.yaml
+++ b/charts/istio-alerts/values.yaml
@@ -124,7 +124,7 @@ serviceRules:
   # to ever fire.
   destinationServiceSelectorValidity:
     # -- Severity of the monitor
-    sevarity: warning
+    severity: warning
 
     # -- How long to evaluate.
     for: 1h

--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.2.0
+    version: 0.3.1
     repository: file://../nd-common

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -3,7 +3,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -54,7 +54,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.2.0 |
+| file://../nd-common | nd-common | 0.3.1 |
 
 ## Values
 
@@ -68,6 +68,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | alertManager.repeatInterval | string | `"1h"` | How long to wait before sending a notification again if it has already been sent successfully for an alert. (Usually ~3h or more). |
 | chart_name | string | `"prometheus-rules"` |  |
 | chart_source | string | `"https://github.com/Nextdoor/k8s-charts"` |  |
+| containerRules.AlertRulesSelectorsValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.CPUThrottlingHigh | object | `{"for":"15m","severity":"warning","threshold":5}` | Container is being throttled by the CGroup - needs more resources. This value is appropriate for applications that are highly sensitive to request latency. Insensitive workloads might need to raise this percentage to avoid alert noise. |
 | containerRules.ContainerWaiting.for | string | `"1h"` |  |
 | containerRules.ContainerWaiting.severity | string | `"warning"` |  |

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -20,6 +20,15 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 
 ## Upgrade Notes
 
+### 1.4.x -> 1.5.x
+
+**NOTE: New metrics added**
+
+We have added a new metric which attempts to detect if you have misconfigured
+your selectors. After upgrading, you may get alerted. You should respond to the
+alert appropriately by reading the alert information and making changes to your
+selectors.
+
 ### 1.1.x -> 1.2.x
 
 **CHANGE: Resource Names have changed**

--- a/charts/prometheus-alerts/README.md.gotmpl
+++ b/charts/prometheus-alerts/README.md.gotmpl
@@ -19,6 +19,15 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 
 ## Upgrade Notes
 
+### 1.4.x -> 1.5.x
+
+**NOTE: New metrics added**
+
+We have added a new metric which attempts to detect if you have misconfigured
+your selectors. After upgrading, you may get alerted. You should respond to the
+alert appropriately by reading the alert information and making changes to your
+selectors.
+
 ### 1.1.x -> 1.2.x
 
 **CHANGE: Resource Names have changed**

--- a/charts/prometheus-alerts/runbook.md
+++ b/charts/prometheus-alerts/runbook.md
@@ -101,3 +101,15 @@ help you determine the root cause of the issue. Follow the instructions in the
 into the relevant cluster and namespace, and use the `kubectl describe pod <podname>`
 to see the status of the pod and any events related to it. The pod logs may also 
 provide hints as to what may be going wrong.
+
+## Alert-Rules-Selectors-Validity
+
+This alert fires when there may be an error in setting the proper selectors used
+by the other alerts in this chart. It attempts to read a basic metric using the
+selector you provided. For instance, if you have a pod selector that looks for
+`pod=~"foo-bar-.*"` but your pods are actually named `baz-.*`, this alert will
+notify you of the misconfiguration. Read the alert description to see exactly
+which selector is having an issue. Also note that you need to collect the
+metrics that this alert uses. For instance, to test pod selectors, we use the
+`kube_pod_info` metric. If you do not collect this metric, this alert will
+continiously fire.

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -480,4 +480,154 @@ spec:
         {{- end }}
     {{- end }}
 
+  - name: {{ .Release.Name }}.{{ .Release.Namespace }}.alertRulesSelectorsValidity
+    rules:
+    {{ with .Values.containerRules.AlertRulesSelectorsValidity -}}
+    - alert: DaemonsetSelectorValidity
+      annotations:
+        summary: DaemonsetSelector for prometheus-alerts is invalid
+        runbook_url: {{ $values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The DaemonsetSelector used for daemonset level alerts did not return any data.
+          Please check the DaemonsetSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your daemonsets so that you
+          will be alerted for daemonset issues. The current selector is
+          `{daemonsetSelector="{{ $daemonsetSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_daemonset_labels{
+              {{ $daemonsetSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    - alert: DeploymentSelectorValidity
+      annotations:
+        summary: DeploymentSelector for prometheus-alerts is invalid
+        runbook_url: {{ $values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The DeploymentSelector used for deployment level alerts did not return any data.
+          Please check the DeploymentSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your deployments so that you
+          will be alerted for deployment issues. The current selector is
+          `{deploymentSelector="{{ $deploymentSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_deployment_labels{
+              {{ $deploymentSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    - alert: PodSelectorValidity
+      annotations:
+        summary: PodSelector for prometheus-alerts is invalid
+        runbook_url: {{ $values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The PodSelector used for pod level alerts did not return any data.
+          Please check the PodSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your pods so that you
+          will be alerted for pod issues. The current selector is
+          `{podSelector="{{ $podSelector }}", namespaceSelector="{{ $namespaceSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_pod_info{
+              {{ $podSelector }},
+              {{ $namespaceSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    - alert: JobSelectorValidity
+      annotations:
+        summary: JobSelector for prometheus-alerts is invalid
+        runbook_url: {{ $values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The JobSelector used for job level alerts did not return any data.
+          Please check the JobSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your jobs so that you
+          will be alerted for job issues. The current selector is
+          `{jobSelector="{{ $jobSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_job_info{
+              {{ $jobSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    - alert: HpaSelectorValidity
+      annotations:
+        summary: HpaSelector for prometheus-alerts is invalid
+        runbook_url: {{ $values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The HpaSelector used for hpa level alerts did not return any data.
+          Please check the HpaSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your hpas so that you
+          will be alerted for hpa issues. The current selector is
+          `{hpaSelector="{{ $hpaSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_horizontalpodautoscaler_info{
+              {{ $hpaSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    - alert: StatefulsetSelectorValidity
+      annotations:
+        summary: StatefulsetSelector for prometheus-alerts is invalid
+        runbook_url: {{ $values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The StatefulsetSelector used for statefulset level alerts did not return any data.
+          Please check the StatefulsetSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your statefulsets so that you
+          will be alerted for statefulset issues. The current selector is
+          `{statefulsetSelector="{{ $statefulsetSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_statefulset_created{
+              {{ $statefulsetSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $values.defaults.additionalRuleLabels }}
+        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
 {{- end }}

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -228,3 +228,11 @@ containerRules:
     severity: warning
     threshold: 5
     for: 15m
+
+  # -- Does a basic lookup using the defined selectors to see if we can see any
+  # info for a given selector. This is the "watcher for the watcher". If we get
+  # alerted by this, we likely have a bad selector and our alerts are not going
+  # to ever fire.
+  AlertRulesSelectorsValidity:
+    severity: warning
+    for: 1h

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: istio-alerts
-    version: 0.2.0
+    version: 0.3.0
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -174,7 +174,7 @@ secretsEngine: sealed
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../nd-common | nd-common | 0.3.1 |
-| https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.3.0 |
 
 ## Values
 

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: istio-alerts
-    version: 0.2.0
+    version: 0.3.0
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -319,7 +319,7 @@ secretsEngine: sealed
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../nd-common | nd-common | 0.3.1 |
-| https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.3.0 |
 
 ## Values
 

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: matt@nextdoor.com
 dependencies:
   - name: istio-alerts
-    version: 0.2.0
+    version: 0.3.0
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -266,7 +266,7 @@ secretsEngine: sealed
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../nd-common | nd-common | 0.3.1 |
-| https://k8s-charts.nextdoor.com | istio-alerts | 0.2.0 |
+| https://k8s-charts.nextdoor.com | istio-alerts | 0.3.0 |
 
 ## Values
 


### PR DESCRIPTION
We ran into an issue where unbeknownst to us, our pod selector was set incorrectly and therefore all of our rules deployed via prometheus-alerts did not have any series to evaluate. This lack of series data is silently ignored. Here we are resolving this by implementing a rule which will use the various selectors to see if a basic metric exists or not. If it does not exist then we want to warn the user that non of the other rules will be evaluated.

I tried to choose metrics for each selector that were generic enough and did not rely on a specific metric that may not be gathered. Most types had an associated `info` or `label` metric which are good candidates for this use-case.

Lastly, I set the timing of this metric up for 1 hour by default. This felt okay to me as we want to be a little bit resilient to prometheus metric collection outages and not accidentally page every service owner if we have a centralized outage of the platform itself. Normally, a team might only be paged once for this when they first setup their application if they had not setup their selectors correctly. This alert is not expected to go into an alert state without some heavy handed naming changes (mostly done during things like migrations).

Proof:

<img width="1451" alt="image" src="https://github.com/Nextdoor/k8s-charts/assets/206373/c1fd85eb-99c4-4ccd-b50f-54ac8ca213e2">

Here we can see that query A (bad selector) does not return any metrics, therefore gets zero filled, and we trigger an alert. Contrarily, we see that query B (good selector) does have series associated and therefore we do not alert.