### PR TITLE
chore(istio-alerts): Add common selector helper for istio and ksm metrics

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 

--- a/charts/istio-alerts/templates/_helpers.tpl
+++ b/charts/istio-alerts/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "istio-alerts.namespaceSelectorIstioForMetrics" -}}
+destination_service_namespace="{{ .Release.Namespace }}"
+{{- end }}
+
+{{- define "istio-alerts.destinationServiceSelectorForIstioMetrics" -}}
+{{- if .Values.serviceRules.destinationServiceName -}}
+destination_service_name=~"{{ tpl .Values.serviceRules.destinationServiceName $ }}", {{ include "istio-alerts.namespaceSelectorIstioForMetrics" $ }}
+{{- else -}}
+destination_service_name!="", {{ include "istio-alerts.namespaceSelectorIstioForMetrics" $ }}
+{{- end -}}
+{{- end -}}
+
+{{- define "istio-alerts.namespaceSelectorForKubeStateMetrics" -}}
+namespace="{{ .Release.Namespace }}"
+{{- end }}
+
+{{- define "istio-alerts.destinationServiceSelectorForKubeStateMetrics" -}}
+{{- if .Values.serviceRules.destinationServiceName -}}
+service=~"{{ tpl .Values.serviceRules.destinationServiceName $ }}", {{ include "istio-alerts.namespaceSelectorForKubeStateMetrics" $ }}
+{{- else -}}
+service!="", {{ include "istio-alerts.namespaceSelectorForKubeStateMetrics" $ }}
+{{- end -}}
+{{- end -}}

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -1,3 +1,5 @@
+{{ $destinationServiceSelectorForIstioMetrics     := include "istio-alerts.destinationServiceSelectorForIstioMetrics" . }}
+{{ $destinationServiceSelectorForKubeStateMetrics := include "istio-alerts.destinationServiceSelectorForKubeStateMetrics" . }}
 {{- $values     := .Values }}
 {{- $release    := .Release }}
 {{- if .Values.serviceRules.enabled }}
@@ -26,15 +28,13 @@ spec:
         sum by (destination_service_name, reporter, source_workload) (
           istio_requests:increase5m{
             response_code=~"5.*",
-            destination_service_namespace="{{ $release.Namespace }}",
-            destination_service_name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+            {{- $destinationServiceSelectorForIstioMetrics -}}
           }
         )
           /
         sum by (destination_service_name, reporter, source_workload) (
           istio_requests:increase5m{
-            destination_service_namespace="{{ $release.Namespace }}",
-            destination_service_name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+            {{- $destinationServiceSelectorForIstioMetrics -}}
           }
         )
           > {{ .threshold }}
@@ -62,8 +62,7 @@ spec:
           {{ .percentile }},
           sum(irate(
             istio_request_duration_milliseconds_bucket{
-              destination_service_namespace="{{ $release.Namespace }}",
-              destination_service_name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+              {{- $destinationServiceSelectorForIstioMetrics -}}
             }[5m]
           )) by (
             destination_service_name,
@@ -100,8 +99,7 @@ spec:
         (
           count(
             kube_service_info{
-              namespace="{{ $.Release.Namespace }}",
-              name=~"{{ $.Values.serviceRules.destinationServiceName }}"
+              {{- $destinationServiceSelectorForKubeStateMetrics -}}
             }
           ) or on() vector(0)
         ) == 0


### PR DESCRIPTION
This PR follows patterns established in https://github.com/Nextdoor/k8s-charts/blob/8655ff4458e309e86232c4ae0a1fecfcb2cbf0c3/charts/prometheus-alerts/templates/_helpers.tpl#L21-L59

Proof:

```diff
akennedy@ndm2a istio-alerts % diff -bu orig new
--- orig        2024-04-17 16:29:11
+++ new 2024-04-17 16:27:28
@@ -59,17 +59,11 @@
       expr: >
         sum by (destination_service_name, reporter, source_workload) (
           istio_requests:increase5m{
-            response_code=~"5.*",
-            destination_service_namespace="monolith",
-            destination_service_name=~".*"
-          }
+            response_code=~"5.*",destination_service_name=~".*", destination_service_namespace="monolith"}
         )
           /
         sum by (destination_service_name, reporter, source_workload) (
-          istio_requests:increase5m{
-            destination_service_namespace="monolith",
-            destination_service_name=~".*"
-          }
+          istio_requests:increase5m{destination_service_name=~".*", destination_service_namespace="monolith"}
         )
           > 0.0005
       for: 5m
@@ -88,10 +82,7 @@
         histogram_quantile(
           0.95,
           sum(irate(
-            istio_request_duration_milliseconds_bucket{
-              destination_service_namespace="monolith",
-              destination_service_name=~".*"
-            }[5m]
+            istio_request_duration_milliseconds_bucket{destination_service_name=~".*", destination_service_namespace="monolith"}[5m]
           )) by (
             destination_service_name,
             reporter,
@@ -119,10 +110,7 @@
       expr: >-
         (
           count(
-            kube_service_info{
-              namespace="monolith",
-              name=~".*"
-            }
+            kube_service_info{job="kube-state-metrics", service=~".*", namespace="monolith"}
           ) or on() vector(0)
         ) == 0
       for: 1h
```