### PR TITLE
feat(charts/istio-alerts): Part1: Parameterize the set of labels used for grouping 5XX alarms

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 
@@ -48,9 +48,10 @@ if the destinationServiceSelector is actually selecting series for a service tha
 | serviceRules.highRequestLatency.percentile | float | `0.95` | Which percentile to monitor - should be between 0 and 1. Default is 95th percentile. |
 | serviceRules.highRequestLatency.severity | string | `"warning"` | Severity of the latency monitor |
 | serviceRules.highRequestLatency.threshold | float | `0.5` | The threshold for considering the latency monitor to be alarming. This is in seconds. |
-| serviceRules.http5XXMonitor | object | `{"enabled":true,"for":"5m","severity":"critical","threshold":0.0005}` | Configuration related to the 5xx monitor for the VirtualService. |
+| serviceRules.http5XXMonitor | object | `{"enabled":true,"for":"5m","monitorGroupingLabels":["destination_service_name","reporter","source_workload"],"severity":"critical","threshold":0.0005}` | Configuration related to the 5xx monitor for the VirtualService. |
 | serviceRules.http5XXMonitor.enabled | bool | `true` | Whether to enable the monitor on 5xxs returned by the VirtualService. |
 | serviceRules.http5XXMonitor.for | string | `"5m"` | How long to evaluate the rate of 5xxs over. |
+| serviceRules.http5XXMonitor.monitorGroupingLabels | list | `["destination_service_name","reporter","source_workload"]` | The set of labels to use when evaluating the ratio of the 5XX. |
 | serviceRules.http5XXMonitor.severity | string | `"critical"` | Severity of the 5xx monitor |
 | serviceRules.http5XXMonitor.threshold | float | `0.0005` | The threshold for considering the 5xx monitor to be alarming. Default is 0.05% error rate, i.e 99.95% reliability. |
 

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -17,7 +17,7 @@ spec:
     rules:
     {{- with .Values.serviceRules.http5XXMonitor }}
     {{- if .enabled }}
-    {{ $http5XXMonitorGroupingLabelString := join ", " .monitorGroupingLabels }}
+    {{- $http5XXMonitorGroupingLabelString := join ", " .monitorGroupingLabels }}
     - alert: 5xx-Rate-Too-High
       annotations:
         summary: >-

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -2,6 +2,7 @@
 {{ $destinationServiceSelectorForKubeStateMetrics := include "istio-alerts.destinationServiceSelectorForKubeStateMetrics" . }}
 {{- $values     := .Values }}
 {{- $release    := .Release }}
+
 {{- if .Values.serviceRules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -16,6 +17,7 @@ spec:
     rules:
     {{- with .Values.serviceRules.http5XXMonitor }}
     {{- if .enabled }}
+    {{ $http5XXMonitorGroupingLabelString := join ", " .monitorGroupingLabels }}
     - alert: 5xx-Rate-Too-High
       annotations:
         summary: >-
@@ -25,14 +27,14 @@ spec:
           High rate of 5xx responses from the {{`{{$labels.destination_service_name}}`}} VirtualService
           in namespace {{`{{$labels.namespace}}`}}.
       expr: >
-        sum by (destination_service_name, reporter, source_workload) (
+        sum by ({{- $http5XXMonitorGroupingLabelString -}}) (
           istio_requests:increase5m{
             response_code=~"5.*",
             {{- $destinationServiceSelectorForIstioMetrics -}}
           }
         )
           /
-        sum by (destination_service_name, reporter, source_workload) (
+        sum by ({{- $http5XXMonitorGroupingLabelString -}}) (
           istio_requests:increase5m{
             {{- $destinationServiceSelectorForIstioMetrics -}}
           }

--- a/charts/istio-alerts/values.yaml
+++ b/charts/istio-alerts/values.yaml
@@ -99,6 +99,12 @@ serviceRules:
     # -- Severity of the 5xx monitor
     severity: critical
 
+    # -- The set of labels to use when evaluating the ratio of the 5XX.
+    monitorGroupingLabels:
+      - destination_service_name
+      - reporter
+      - source_workload
+
   # -- Configuration related to the latency monitor for the VirtualService.
   highRequestLatency:
     # -- Whether to enable the monitor on latency returned by the


### PR DESCRIPTION
**Context**
In https://github.com/Nextdoor/k8s-charts/commit/c8308088b2acdf509ee3c3c5c431534710210fd8 there was a change to the way the service level 5XX alarm worked such that it computes an alarms on the 5XX rate individually for each source service. 

While it is valuable to have an alarm from the "client"'s perspective from reporting, and provide capabilities for there to be an alarm on arbitrary grouping keys, this wasn't the historical behavior, and the alarm has a different meaning. 


**Proposal**
To improve the behavior, I am first moving the definition of these labels into a value so that in a subsequent PR we can change the default behavior to match the intention before https://github.com/Nextdoor/k8s-charts/commit/c8308088b2acdf509ee3c3c5c431534710210fd8 



The intention o this change is to have no impact on the behavior, and just move the definition. See helm template output below

```
➜  istio-alerts git:(main) ✗ diff -bu old.yaml new.yaml
--- old.yaml	2024-04-17 16:51:22
+++ new.yaml	2024-04-17 16:51:09
@@ -49,6 +49,7 @@
   groups:
   - name: observability.istio-alerts.istio-alerts.IstioServiceRules
     rules:
+
     - alert: 5xx-Rate-Too-High
       annotations:
         summary: >-
```

