### PR TITLE
chore(prometheus-alerts): Group alerts by resource type

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -3,7 +3,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -19,6 +19,21 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 `charts/stateful-app` charts.
 
 ## Upgrade Notes
+
+### 1.4.x -> 1.5.x
+
+**BREAKING: Values files schema has been updated to group alerts by resource type**
+
+Motivation: We have regrouped alerts to be able to turn them on and off by
+resource type.
+
+As an example:
+
+> Value `.Values.containerRules.ContainerWaiting` has been migrated to
+> `.Values.containerRules.pods.ContainerWaiting`. Please update your values
+> files.
+
+The helm chart will produce errors if you do not migrate your values files.
 
 ### 1.1.x -> 1.2.x
 
@@ -68,35 +83,41 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | alertManager.repeatInterval | string | `"1h"` | How long to wait before sending a notification again if it has already been sent successfully for an alert. (Usually ~3h or more). |
 | chart_name | string | `"prometheus-rules"` |  |
 | chart_source | string | `"https://github.com/Nextdoor/k8s-charts"` |  |
-| containerRules.CPUThrottlingHigh | object | `{"for":"15m","severity":"warning","threshold":5}` | Container is being throttled by the CGroup - needs more resources. This value is appropriate for applications that are highly sensitive to request latency. Insensitive workloads might need to raise this percentage to avoid alert noise. |
-| containerRules.ContainerWaiting.for | string | `"1h"` |  |
-| containerRules.ContainerWaiting.severity | string | `"warning"` |  |
-| containerRules.KubeDaemonSetMisScheduled.for | string | `"15m"` |  |
-| containerRules.KubeDaemonSetMisScheduled.severity | string | `"warning"` |  |
-| containerRules.KubeDaemonSetNotScheduled.for | string | `"10m"` |  |
-| containerRules.KubeDaemonSetNotScheduled.severity | string | `"warning"` |  |
-| containerRules.KubeDaemonSetRolloutStuck.for | string | `"15m"` |  |
-| containerRules.KubeDaemonSetRolloutStuck.severity | string | `"warning"` |  |
-| containerRules.KubeDeploymentGenerationMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment generation mismatch due to possible roll-back |
-| containerRules.KubeHpaMaxedOut.for | string | `"15m"` |  |
-| containerRules.KubeHpaMaxedOut.severity | string | `"warning"` |  |
-| containerRules.KubeHpaReplicasMismatch.for | string | `"15m"` |  |
-| containerRules.KubeHpaReplicasMismatch.severity | string | `"warning"` |  |
-| containerRules.KubeJobCompletion.for | string | `"12h"` |  |
-| containerRules.KubeJobCompletion.severity | string | `"warning"` |  |
-| containerRules.KubeJobFailed.for | string | `"15m"` |  |
-| containerRules.KubeJobFailed.severity | string | `"warning"` |  |
-| containerRules.KubeStatefulSetGenerationMismatch.for | string | `"15m"` |  |
-| containerRules.KubeStatefulSetGenerationMismatch.severity | string | `"warning"` |  |
-| containerRules.KubeStatefulSetReplicasMismatch.for | string | `"15m"` |  |
-| containerRules.KubeStatefulSetReplicasMismatch.severity | string | `"warning"` |  |
-| containerRules.KubeStatefulSetUpdateNotRolledOut.for | string | `"15m"` |  |
-| containerRules.KubeStatefulSetUpdateNotRolledOut.severity | string | `"warning"` |  |
-| containerRules.PodContainerOOMKilled | object | `{"for":"1m","over":"60m","severity":"warning","threshold":0}` | Sums up all of the OOMKilled events per pod over the $over time (60m). If that number breaches the $threshold (0) for $for (1m), then it will alert. |
-| containerRules.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
-| containerRules.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
-| containerRules.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| containerRules.daemonsets.KubeDaemonSetMisScheduled.for | string | `"15m"` |  |
+| containerRules.daemonsets.KubeDaemonSetMisScheduled.severity | string | `"warning"` |  |
+| containerRules.daemonsets.KubeDaemonSetNotScheduled.for | string | `"10m"` |  |
+| containerRules.daemonsets.KubeDaemonSetNotScheduled.severity | string | `"warning"` |  |
+| containerRules.daemonsets.KubeDaemonSetRolloutStuck.for | string | `"15m"` |  |
+| containerRules.daemonsets.KubeDaemonSetRolloutStuck.severity | string | `"warning"` |  |
+| containerRules.daemonsets.enabled | bool | `true` | Enables the DaemonSet resource rules |
+| containerRules.deployments.KubeDeploymentGenerationMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment generation mismatch due to possible roll-back |
+| containerRules.deployments.enabled | bool | `true` | Enables the Deployment resource rules |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
+| containerRules.hpas.KubeHpaMaxedOut.for | string | `"15m"` |  |
+| containerRules.hpas.KubeHpaMaxedOut.severity | string | `"warning"` |  |
+| containerRules.hpas.KubeHpaReplicasMismatch.for | string | `"15m"` |  |
+| containerRules.hpas.KubeHpaReplicasMismatch.severity | string | `"warning"` |  |
+| containerRules.hpas.enabled | bool | `true` | Enables the HorizontalPodAutoscaler resource rules |
+| containerRules.jobs.KubeJobCompletion.for | string | `"12h"` |  |
+| containerRules.jobs.KubeJobCompletion.severity | string | `"warning"` |  |
+| containerRules.jobs.KubeJobFailed.for | string | `"15m"` |  |
+| containerRules.jobs.KubeJobFailed.severity | string | `"warning"` |  |
+| containerRules.jobs.enabled | bool | `true` | Enables the Job resource rules |
+| containerRules.pods.CPUThrottlingHigh | object | `{"for":"15m","severity":"warning","threshold":5}` | Container is being throttled by the CGroup - needs more resources. This value is appropriate for applications that are highly sensitive to request latency. Insensitive workloads might need to raise this percentage to avoid alert noise. |
+| containerRules.pods.ContainerWaiting.for | string | `"1h"` |  |
+| containerRules.pods.ContainerWaiting.severity | string | `"warning"` |  |
+| containerRules.pods.PodContainerOOMKilled | object | `{"for":"1m","over":"60m","severity":"warning","threshold":0}` | Sums up all of the OOMKilled events per pod over the $over time (60m). If that number breaches the $threshold (0) for $for (1m), then it will alert. |
+| containerRules.pods.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
+| containerRules.pods.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
+| containerRules.pods.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| containerRules.pods.enabled | bool | `true` | Enables the Pod resource rules |
+| containerRules.statefulsets.KubeStatefulSetGenerationMismatch.for | string | `"15m"` |  |
+| containerRules.statefulsets.KubeStatefulSetGenerationMismatch.severity | string | `"warning"` |  |
+| containerRules.statefulsets.KubeStatefulSetReplicasMismatch.for | string | `"15m"` |  |
+| containerRules.statefulsets.KubeStatefulSetReplicasMismatch.severity | string | `"warning"` |  |
+| containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut.for | string | `"15m"` |  |
+| containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut.severity | string | `"warning"` |  |
+| containerRules.statefulsets.enabled | bool | `true` | Enables the StatefulSet resource rules |
 | defaults.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.daemonsetNameSelector | `string` | `"{{ .Release.Name }}-.*"` | Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |
 | defaults.deploymentNameSelector | `string` | `"{{ .Release.Name }}-.*"` | Pattern used to scope down the Deployment alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the Deployments in the namespace. This string is run through the `tpl` function. |

--- a/charts/prometheus-alerts/README.md.gotmpl
+++ b/charts/prometheus-alerts/README.md.gotmpl
@@ -19,6 +19,21 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 
 ## Upgrade Notes
 
+### 1.4.x -> 1.5.x
+
+**BREAKING: Values files schema has been updated to group alerts by resource type**
+
+Motivation: We have regrouped alerts to be able to turn them on and off by
+resource type.
+
+As an example:
+
+> Value `.Values.containerRules.ContainerWaiting` has been migrated to
+> `.Values.containerRules.pods.ContainerWaiting`. Please update your values
+> files.
+
+The helm chart will produce errors if you do not migrate your values files.
+
 ### 1.1.x -> 1.2.x
 
 **CHANGE: Resource Names have changed**

--- a/charts/prometheus-alerts/templates/_migrations.tpl
+++ b/charts/prometheus-alerts/templates/_migrations.tpl
@@ -1,10 +1,14 @@
-{{/*
+{{- /*
 These checks are in place to ensure that the values files are up-to-date with
 values schema changes in v1.5.0.
 */}}
-{{ $rules := dict "ContainerWaiting" "pods" "CPUThrottlingHigh" "pods" "KubeDaemonSetMisScheduled" "daemonsets" "KubeDaemonSetNotScheduled" "daemonsets" "KubeDaemonSetRolloutStuck" "daemonsets" "KubeDeploymentGenerationMismatch" "deployments" "KubeHpaMaxedOut" "hpas" "KubeHpaReplicasMismatch" "hpas" "KubeJobCompletion" "jobs" "KubeJobFailed" "jobs" "KubeStatefulSetGenerationMismatch" "statefulsets" "KubeStatefulSetReplicasMismatch" "statefulsets" "KubeStatefulSetUpdateNotRolledOut" "statefulsets" "PodContainerOOMKilled" "pods" "PodContainerTerminated" "pods" "PodCrashLoopBackOff" "pods" "PodNotReady" "pods" }}
-{{ range $rule, $type := $rules }}
-{{ if index .Values.containerRules $rule }}
-{{ printf "Value `.Values.containerRules.%s` has been migrated to `.Values.containerRules.%s.%s`. Please update your values files." $rule $type $rule | fail }}
-{{ end }}
-{{ end }}
+
+{{- define "prometheus-alerts.check_migration_alerts_grouped_by_resource" }}
+    {{- $rules := dict "ContainerWaiting" "pods" "CPUThrottlingHigh" "pods" "KubeDaemonSetMisScheduled" "daemonsets" "KubeDaemonSetNotScheduled" "daemonsets" "KubeDaemonSetRolloutStuck" "daemonsets" "KubeDeploymentGenerationMismatch" "deployments" "KubeHpaMaxedOut" "hpas" "KubeHpaReplicasMismatch" "hpas" "KubeJobCompletion" "jobs" "KubeJobFailed" "jobs" "KubeStatefulSetGenerationMismatch" "statefulsets" "KubeStatefulSetReplicasMismatch" "statefulsets" "KubeStatefulSetUpdateNotRolledOut" "statefulsets" "PodContainerOOMKilled" "pods" "PodContainerTerminated" "pods" "PodCrashLoopBackOff" "pods" "PodNotReady" "pods" }}
+    
+    {{- range $rule, $type := $rules }}
+        {{- if index $.Values.containerRules $rule }}
+            {{- printf "Value `.Values.containerRules.%s` has been migrated to `.Values.containerRules.%s.%s`. Please update your values files." $rule $type $rule | fail }}
+        {{- end }}
+    {{- end }}
+{{- end -}}

--- a/charts/prometheus-alerts/templates/_migrations.tpl
+++ b/charts/prometheus-alerts/templates/_migrations.tpl
@@ -1,0 +1,54 @@
+{{- /*
+These checks are in place to ensure that the values files are up-to-date with values schema changes in v1.5.0.
+*/}}
+{{- if .Values.containerRules.ContainerWaiting }}
+{{- fail "Value `.Values.containerRules.ContainerWaiting` has been migrated to `.Values.containerRules.pods.ContainerWaiting`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.CPUThrottlingHigh }}
+{{- fail "Value `.Values.containerRules.CPUThrottlingHigh` has been migrated to `.Values.containerRules.pods.CPUThrottlingHigh`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeDaemonSetMisScheduled }}
+{{- fail "Value `.Values.containerRules.KubeDaemonSetMisScheduled` has been migrated to `.Values.containerRules.daemonsets.KubeDaemonSetMisScheduled`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeDaemonSetNotScheduled }}
+{{- fail "Value `.Values.containerRules.KubeDaemonSetNotScheduled` has been migrated to `.Values.containerRules.daemonsets.KubeDaemonSetNotScheduled`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeDaemonSetRolloutStuck }}
+{{- fail "Value `.Values.containerRules.KubeDaemonSetRolloutStuck` has been migrated to `.Values.containerRules.daemonsets.KubeDaemonSetRolloutStuck`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeDeploymentGenerationMismatch }}
+{{- fail "Value `.Values.containerRules.KubeDeploymentGenerationMismatch` has been migrated to `.Values.containerRules.deployments.KubeDeploymentGenerationMismatch`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeHpaMaxedOut }}
+{{- fail "Value `.Values.containerRules.KubeHpaMaxedOut` has been migrated to `.Values.containerRules.hpas.KubeHpaMaxedOut`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeHpaReplicasMismatch }}
+{{- fail "Value `.Values.containerRules.KubeHpaReplicasMismatch` has been migrated to `.Values.containerRules.hpas.KubeHpaReplicasMismatch`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeJobCompletion }}
+{{- fail "Value `.Values.containerRules.KubeJobCompletion` has been migrated to `.Values.containerRules.jobs.KubeJobCompletion`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeJobFailed }}
+{{- fail "Value `.Values.containerRules.KubeJobFailed` has been migrated to `.Values.containerRules.jobs.KubeJobFailed`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeStatefulSetGenerationMismatch }}
+{{- fail "Value `.Values.containerRules.KubeStatefulSetGenerationMismatch` has been migrated to `.Values.containerRules.statefulsets.KubeStatefulSetGenerationMismatch`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeStatefulSetReplicasMismatch }}
+{{- fail "Value `.Values.containerRules.KubeStatefulSetReplicasMismatch` has been migrated to `.Values.containerRules.statefulsets.KubeStatefulSetReplicasMismatch`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.KubeStatefulSetUpdateNotRolledOut }}
+{{- fail "Value `.Values.containerRules.KubeStatefulSetUpdateNotRolledOut` has been migrated to `.Values.containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.PodContainerOOMKilled }}
+{{- fail "Value `.Values.containerRules.PodContainerOOMKilled` has been migrated to `.Values.containerRules.pods.PodContainerOOMKilled`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.PodContainerTerminated }}
+{{- fail "Value `.Values.containerRules.PodContainerTerminated` has been migrated to `.Values.containerRules.pods.PodContainerTerminated`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.PodCrashLoopBackOff }}
+{{- fail "Value `.Values.containerRules.PodCrashLoopBackOff` has been migrated to `.Values.containerRules.pods.PodCrashLoopBackOff`. Please update your values files." }}
+{{- end }}
+{{- if .Values.containerRules.PodNotReady }}
+{{- fail "Value `.Values.containerRules.PodNotReady` has been migrated to `.Values.containerRules.pods.PodNotReady`. Please update your values files." }}
+{{- end }}

--- a/charts/prometheus-alerts/templates/_migrations.tpl
+++ b/charts/prometheus-alerts/templates/_migrations.tpl
@@ -1,54 +1,10 @@
-{{- /*
-These checks are in place to ensure that the values files are up-to-date with values schema changes in v1.5.0.
+{{/*
+These checks are in place to ensure that the values files are up-to-date with
+values schema changes in v1.5.0.
 */}}
-{{- if .Values.containerRules.ContainerWaiting }}
-{{- fail "Value `.Values.containerRules.ContainerWaiting` has been migrated to `.Values.containerRules.pods.ContainerWaiting`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.CPUThrottlingHigh }}
-{{- fail "Value `.Values.containerRules.CPUThrottlingHigh` has been migrated to `.Values.containerRules.pods.CPUThrottlingHigh`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeDaemonSetMisScheduled }}
-{{- fail "Value `.Values.containerRules.KubeDaemonSetMisScheduled` has been migrated to `.Values.containerRules.daemonsets.KubeDaemonSetMisScheduled`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeDaemonSetNotScheduled }}
-{{- fail "Value `.Values.containerRules.KubeDaemonSetNotScheduled` has been migrated to `.Values.containerRules.daemonsets.KubeDaemonSetNotScheduled`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeDaemonSetRolloutStuck }}
-{{- fail "Value `.Values.containerRules.KubeDaemonSetRolloutStuck` has been migrated to `.Values.containerRules.daemonsets.KubeDaemonSetRolloutStuck`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeDeploymentGenerationMismatch }}
-{{- fail "Value `.Values.containerRules.KubeDeploymentGenerationMismatch` has been migrated to `.Values.containerRules.deployments.KubeDeploymentGenerationMismatch`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeHpaMaxedOut }}
-{{- fail "Value `.Values.containerRules.KubeHpaMaxedOut` has been migrated to `.Values.containerRules.hpas.KubeHpaMaxedOut`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeHpaReplicasMismatch }}
-{{- fail "Value `.Values.containerRules.KubeHpaReplicasMismatch` has been migrated to `.Values.containerRules.hpas.KubeHpaReplicasMismatch`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeJobCompletion }}
-{{- fail "Value `.Values.containerRules.KubeJobCompletion` has been migrated to `.Values.containerRules.jobs.KubeJobCompletion`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeJobFailed }}
-{{- fail "Value `.Values.containerRules.KubeJobFailed` has been migrated to `.Values.containerRules.jobs.KubeJobFailed`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeStatefulSetGenerationMismatch }}
-{{- fail "Value `.Values.containerRules.KubeStatefulSetGenerationMismatch` has been migrated to `.Values.containerRules.statefulsets.KubeStatefulSetGenerationMismatch`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeStatefulSetReplicasMismatch }}
-{{- fail "Value `.Values.containerRules.KubeStatefulSetReplicasMismatch` has been migrated to `.Values.containerRules.statefulsets.KubeStatefulSetReplicasMismatch`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.KubeStatefulSetUpdateNotRolledOut }}
-{{- fail "Value `.Values.containerRules.KubeStatefulSetUpdateNotRolledOut` has been migrated to `.Values.containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.PodContainerOOMKilled }}
-{{- fail "Value `.Values.containerRules.PodContainerOOMKilled` has been migrated to `.Values.containerRules.pods.PodContainerOOMKilled`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.PodContainerTerminated }}
-{{- fail "Value `.Values.containerRules.PodContainerTerminated` has been migrated to `.Values.containerRules.pods.PodContainerTerminated`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.PodCrashLoopBackOff }}
-{{- fail "Value `.Values.containerRules.PodCrashLoopBackOff` has been migrated to `.Values.containerRules.pods.PodCrashLoopBackOff`. Please update your values files." }}
-{{- end }}
-{{- if .Values.containerRules.PodNotReady }}
-{{- fail "Value `.Values.containerRules.PodNotReady` has been migrated to `.Values.containerRules.pods.PodNotReady`. Please update your values files." }}
-{{- end }}
+{{ $rules := dict "ContainerWaiting" "pods" "CPUThrottlingHigh" "pods" "KubeDaemonSetMisScheduled" "daemonsets" "KubeDaemonSetNotScheduled" "daemonsets" "KubeDaemonSetRolloutStuck" "daemonsets" "KubeDeploymentGenerationMismatch" "deployments" "KubeHpaMaxedOut" "hpas" "KubeHpaReplicasMismatch" "hpas" "KubeJobCompletion" "jobs" "KubeJobFailed" "jobs" "KubeStatefulSetGenerationMismatch" "statefulsets" "KubeStatefulSetReplicasMismatch" "statefulsets" "KubeStatefulSetUpdateNotRolledOut" "statefulsets" "PodContainerOOMKilled" "pods" "PodContainerTerminated" "pods" "PodCrashLoopBackOff" "pods" "PodNotReady" "pods" }}
+{{ $rule, $type := range $rules }}
+{{ if index .Values.containerRules $rule }}
+{{ printf "Value `.Values.containerRules.%s` has been migrated to `.Values.containerRules.%s.%s`. Please update your values files." $rule $type $rule | fail }}
+{{ end }}
+{{ end }}

--- a/charts/prometheus-alerts/templates/_migrations.tpl
+++ b/charts/prometheus-alerts/templates/_migrations.tpl
@@ -3,7 +3,7 @@ These checks are in place to ensure that the values files are up-to-date with
 values schema changes in v1.5.0.
 */}}
 {{ $rules := dict "ContainerWaiting" "pods" "CPUThrottlingHigh" "pods" "KubeDaemonSetMisScheduled" "daemonsets" "KubeDaemonSetNotScheduled" "daemonsets" "KubeDaemonSetRolloutStuck" "daemonsets" "KubeDeploymentGenerationMismatch" "deployments" "KubeHpaMaxedOut" "hpas" "KubeHpaReplicasMismatch" "hpas" "KubeJobCompletion" "jobs" "KubeJobFailed" "jobs" "KubeStatefulSetGenerationMismatch" "statefulsets" "KubeStatefulSetReplicasMismatch" "statefulsets" "KubeStatefulSetUpdateNotRolledOut" "statefulsets" "PodContainerOOMKilled" "pods" "PodContainerTerminated" "pods" "PodCrashLoopBackOff" "pods" "PodNotReady" "pods" }}
-{{ $rule, $type := range $rules }}
+{{ range $rule, $type := $rules }}
 {{ if index .Values.containerRules $rule }}
 {{ printf "Value `.Values.containerRules.%s` has been migrated to `.Values.containerRules.%s.%s`. Please update your values files." $rule $type $rule | fail }}
 {{ end }}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -20,12 +20,12 @@ metadata:
     {{- include "nd-common.labels" . | nindent 4 }}
 spec:
   groups:
-  {{- with .Values.containerRules.pods -}}
+  {{- with .Values.containerRules.pods }}
   {{- if .enabled }}
 
   - name: {{ $release.Name }}.{{ $release.Namespace }}.containerRules
     rules:
-    {{- with .PodContainerTerminated -}}
+    {{- with .PodContainerTerminated }}
     - alert: PodContainerTerminated
       annotations:
         summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
@@ -52,7 +52,7 @@ spec:
         {{- end }}
     {{ end -}}
 
-    {{- with .PodContainerOOMKilled -}}
+    {{- with .PodContainerOOMKilled }}
     - alert: PodContainerOOMKilled
       annotations:
         summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
@@ -79,7 +79,7 @@ spec:
         {{- end }}
     {{ end -}}
 
-    {{- with .ContainerWaiting -}}
+    {{- with .ContainerWaiting }}
     - alert: ContainerWaiting
       annotations:
         summary: Pod container waiting longer than {{ .for }}
@@ -139,10 +139,10 @@ spec:
   #
   - name: {{ .Release.Name }}.{{ .Release.Namespace }}.kubernetesAppsRules
     rules:
-    {{- with .Values.containerRules.pods -}}
+    {{- with .Values.containerRules.pods }}
     {{- if .enabled }}
 
-    {{- with .PodCrashLoopBackOff -}}
+    {{- with .PodCrashLoopBackOff }}
     - alert: PodCrashLoopBackOff
       annotations:
         summary: {{`Container inside pod {{ $labels.pod }} is crash looping`}}
@@ -168,7 +168,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .PodNotReady -}}
+    {{- with .PodNotReady }}
     - alert: PodNotReady
       annotations:
         summary: Pod has been in a non-ready state for more than {{ .for }}
@@ -205,10 +205,10 @@ spec:
     {{- end }}
     {{- end }}
 
-    {{- with .Values.containerRules.deployments -}}
+    {{- with .Values.containerRules.deployments }}
     {{- if .enabled }}
 
-    {{- with .KubeDeploymentGenerationMismatch -}}
+    {{- with .KubeDeploymentGenerationMismatch }}
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         summary: Deployment generation mismatch due to possible roll-back
@@ -233,10 +233,10 @@ spec:
     {{- end }}
     {{- end }}
 
-    {{- with .Values.containerRules.statefulsets -}}
+    {{- with .Values.containerRules.statefulsets }}
     {{- if .enabled }}
 
-    {{- with .KubeStatefulSetReplicasMismatch -}}
+    {{- with .KubeStatefulSetReplicasMismatch }}
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         summary: StatefulSet has not matched the expected number of replicas.
@@ -263,7 +263,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .KubeStatefulSetGenerationMismatch -}}
+    {{- with .KubeStatefulSetGenerationMismatch }}
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         summary: StatefulSet generation mismatch due to possible roll-back
@@ -285,7 +285,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .KubeStatefulSetUpdateNotRolledOut -}}
+    {{- with .KubeStatefulSetUpdateNotRolledOut }}
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
         summary: StatefulSet update has not been rolled out.
@@ -322,10 +322,10 @@ spec:
     {{- end }}
     {{- end }}
 
-    {{- with .Values.containerRules.daemonsets -}}
+    {{- with .Values.containerRules.daemonsets }}
     {{- if .enabled }}
 
-    {{- with .KubeDaemonSetRolloutStuck -}}
+    {{- with .KubeDaemonSetRolloutStuck }}
     - alert: KubeDaemonSetRolloutStuck
       annotations:
         summary: DaemonSet rollout is stuck.
@@ -366,7 +366,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .KubeDaemonSetNotScheduled -}}
+    {{- with .KubeDaemonSetNotScheduled }}
     - alert: KubeDaemonSetNotScheduled
       annotations:
         summary: DaemonSet pods are not scheduled.
@@ -387,7 +387,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .KubeDaemonSetMisScheduled -}}
+    {{- with .KubeDaemonSetMisScheduled }}
     - alert: KubeDaemonSetMisScheduled
       annotations:
         summary: DaemonSet pods are misscheduled.
@@ -408,10 +408,10 @@ spec:
     {{- end }}
     {{- end }}
 
-    {{- with .Values.containerRules.jobs -}}
+    {{- with .Values.containerRules.jobs }}
     {{- if .enabled }}
 
-    {{- with .KubeJobCompletion -}}
+    {{- with .KubeJobCompletion }}
     - alert: KubeJobCompletion
       annotations:
         summary: Job did not complete in time
@@ -432,7 +432,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .KubeJobFailed -}}
+    {{- with .KubeJobFailed }}
     - alert: KubeJobFailed
       annotations:
         summary: Job failed to complete.
@@ -453,10 +453,10 @@ spec:
     {{- end }}
     {{- end }}
 
-    {{- with .Values.containerRules.hpas -}}
+    {{- with .Values.containerRules.hpas }}
     {{- if .enabled }}
     
-    {{- with .KubeHpaReplicasMismatch -}}
+    {{- with .KubeHpaReplicasMismatch }}
     - alert: KubeHpaReplicasMismatch
       annotations:
         summary: HPA has not matched descired number of replicas.
@@ -499,7 +499,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .KubeHpaMaxedOut -}}
+    {{- with .KubeHpaMaxedOut }}
     - alert: KubeHpaMaxedOut
       annotations:
         summary: HPA is running at max replicas

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -467,30 +467,22 @@ spec:
           minutes.
       expr: |-
         (
-         kube_horizontalpodautoscaler_status_desired_replicas{ {{- $hpaSelector -}} }
-          !=
-         kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
+          kube_horizontalpodautoscaler_status_desired_replicas{ {{- $hpaSelector -}} }
+            !=
+          kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
+        ) and (
+          kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
+            >
+          kube_horizontalpodautoscaler_spec_min_replicas{ {{- $hpaSelector -}} }
+        ) and (
+          kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
+            <
+          kube_horizontalpodautoscaler_spec_max_replicas{ {{- $hpaSelector -}} }
+        ) and (
+          changes(kube_horizontalpodautoscaler_status_current_replicas[15m])
+            ==
+          0
         )
-          and
-
-        (
-         kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
-          >
-         kube_horizontalpodautoscaler_spec_min_replicas{ {{- $hpaSelector -}} }
-        )
-
-          and
-
-        (
-         kube_horizontalpodautoscaler_status_current_replicas{ {{- $hpaSelector -}} }
-          <
-         kube_horizontalpodautoscaler_spec_max_replicas{ {{- $hpaSelector -}} }
-        )
-
-          and
-
-        changes(kube_horizontalpodautoscaler_status_current_replicas[15m]) == 0
-
       for: {{ .for }}
       labels:
         severity: {{ .severity }}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -1,5 +1,3 @@
-{{ $values              := .Values }}
-{{ $release             := .Release }}
 {{ $daemonsetSelector   := include "prometheus-alerts.daemonsetSelector" . }}
 {{ $deploymentSelector  := include "prometheus-alerts.deploymentSelector" . }}
 {{ $namespaceSelector   := include "prometheus-alerts.namespaceSelector" . }}
@@ -23,13 +21,13 @@ spec:
   {{- with .Values.containerRules.pods }}
   {{- if .enabled }}
 
-  - name: {{ $release.Name }}.{{ $release.Namespace }}.containerRules
+  - name: {{ $.Release.Name }}.{{ $.Release.Namespace }}.containerRules
     rules:
     {{- with .PodContainerTerminated }}
     - alert: PodContainerTerminated
       annotations:
         summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
-        runbook_url: {{ $values.defaults.runbookUrl }}#kube-pod-container-terminated
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#kube-pod-container-terminated
         description: >-
           Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
           has a container that has been terminated ({{`{{ $value }}`}} times) due to
@@ -47,8 +45,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{ end -}}
 
@@ -56,7 +54,7 @@ spec:
     - alert: PodContainerOOMKilled
       annotations:
         summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
-        runbook_url: {{ $values.defaults.runbookUrl }}#kube-pod-container-terminated
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#kube-pod-container-terminated
         description: >-
           Pod {{`{{$labels.pod}}`}} in namespace {{`{{$labels.namespace}}`}}
           has a container that has been terminated ({{`{{ $value }}`}} times) due to
@@ -74,8 +72,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{ end -}}
 
@@ -83,7 +81,7 @@ spec:
     - alert: ContainerWaiting
       annotations:
         summary: Pod container waiting longer than {{ .for }}
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubecontainerwaiting
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubecontainerwaiting
         description: >-
           Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
           container {{`{{`}} $labels.container{{`}}`}} has been in waiting
@@ -95,8 +93,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -104,7 +102,7 @@ spec:
     - alert: CPUThrottlingHigh
       annotations:
         summary: Processes experience elevated CPU throttling.
-        runbook_url: {{ $values.defaults.runbookUrl }}#CPUThrottlingHigh
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#CPUThrottlingHigh
         description: >-
           {{`{{ $value | humanizePercentage }} throttling of CPU in
           namespace {{ $labels.namespace }} for container {{ $labels.container
@@ -121,8 +119,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -146,7 +144,7 @@ spec:
     - alert: PodCrashLoopBackOff
       annotations:
         summary: {{`Container inside pod {{ $labels.pod }} is crash looping`}}
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubepodcrashlooping
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubepodcrashlooping
         description: >-
           {{`Container {{ $labels.container }} within pod {{ $labels.pod }} is in
           a {{ $labels.reason }} state. Investigate because it indicates that
@@ -163,8 +161,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -172,7 +170,7 @@ spec:
     - alert: PodNotReady
       annotations:
         summary: Pod has been in a non-ready state for more than {{ .for }}
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubepodnotready
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubepodnotready
         description: >-
           Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
           has been in a non-ready state for longer than {{ .for }}.
@@ -197,8 +195,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -212,7 +210,7 @@ spec:
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         summary: Deployment generation mismatch due to possible roll-back
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubedeploymentgenerationmismatch
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubedeploymentgenerationmismatch
         description: >-
           Deployment generation for {{`{{`}} $labels.namespace
           {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} does not match, this
@@ -225,8 +223,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -240,7 +238,7 @@ spec:
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         summary: StatefulSet has not matched the expected number of replicas.
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubestatefulsetreplicasmismatch
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubestatefulsetreplicasmismatch
         description: >-
           StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}}
           $labels.statefulset {{`}}`}} has not matched the expected number of
@@ -258,8 +256,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -267,7 +265,7 @@ spec:
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         summary: StatefulSet generation mismatch due to possible roll-back
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubestatefulsetgenerationmismatch
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubestatefulsetgenerationmismatch
         description: >-
           StatefulSet generation for {{`{{`}} $labels.namespace
           {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} does not match, this
@@ -280,8 +278,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -289,7 +287,7 @@ spec:
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
         summary: StatefulSet update has not been rolled out.
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubestatefulsetupdatenotrolledout
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubestatefulsetupdatenotrolledout
         description: >-
           StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}}
           $labels.statefulset {{`}}`}} update has not been rolled out.
@@ -314,8 +312,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -329,7 +327,7 @@ spec:
     - alert: KubeDaemonSetRolloutStuck
       annotations:
         summary: DaemonSet rollout is stuck.
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubedaemonsetrolloutstuck
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubedaemonsetrolloutstuck
         description: >-
           DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}}
           $labels.daemonset {{`}}`}} has not finished or progressed for at
@@ -361,8 +359,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -370,7 +368,7 @@ spec:
     - alert: KubeDaemonSetNotScheduled
       annotations:
         summary: DaemonSet pods are not scheduled.
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubedaemonsetnotscheduled
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubedaemonsetnotscheduled
         description: >-
           '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}}
           $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are
@@ -382,8 +380,8 @@ spec:
       for: 10m
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -391,7 +389,7 @@ spec:
     - alert: KubeDaemonSetMisScheduled
       annotations:
         summary: DaemonSet pods are misscheduled.
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubedaemonsetmisscheduled
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubedaemonsetmisscheduled
         description: >-
           '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}}
           $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are
@@ -400,8 +398,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -415,7 +413,7 @@ spec:
     - alert: KubeJobCompletion
       annotations:
         summary: Job did not complete in time
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubejobcompletion
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubejobcompletion
         description: >-
           Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name
           {{`}}`}} is taking more than 12 hours to complete.
@@ -427,8 +425,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -436,7 +434,7 @@ spec:
     - alert: KubeJobFailed
       annotations:
         summary: Job failed to complete.
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubejobfailed
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubejobfailed
         description: >-
           Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name
           {{`}}`}} failed to complete. Removing failed job after investigation
@@ -445,8 +443,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -460,7 +458,7 @@ spec:
     - alert: KubeHpaReplicasMismatch
       annotations:
         summary: HPA has not matched descired number of replicas.
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubehpareplicasmismatch
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubehpareplicasmismatch
         description: >-
           HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}}
           has not matched the desired number of replicas for longer than 15
@@ -486,8 +484,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -495,7 +493,7 @@ spec:
     - alert: KubeHpaMaxedOut
       annotations:
         summary: HPA is running at max replicas
-        runbook_url: {{ $values.defaults.runbookUrl }}#alert-name-kubehpamaxedout
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubehpamaxedout
         description: >-
           HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.hpa {{`}}`}}
           has been running at max replicas for longer than 15 minutes.
@@ -506,8 +504,8 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $values.defaults.additionalRuleLabels }}
-        {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
 

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -21,7 +21,6 @@ spec:
   groups:
   {{- with .Values.containerRules.pods }}
   {{- if .enabled }}
-
   - name: {{ $.Release.Name }}.{{ $.Release.Namespace }}.containerRules
     rules:
     {{- with .PodContainerTerminated }}
@@ -49,7 +48,7 @@ spec:
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
-    {{ end -}}
+    {{- end }}
 
     {{- with .PodContainerOOMKilled }}
     - alert: PodContainerOOMKilled
@@ -76,7 +75,7 @@ spec:
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
-    {{ end -}}
+    {{- end }}
 
     {{- with .ContainerWaiting }}
     - alert: ContainerWaiting
@@ -128,14 +127,14 @@ spec:
   {{- end }}
   {{- end }}
 
-  #
-  # Original Source:
-  #    https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-13.3.0/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
-  #
-  # This file has been modified so that the individual alarms are configurable.
-  # The default values for thresholds, periods and severities made these alarms
-  # too limited for us.
-  #
+  {{- /*
+    Original Source:
+      https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-13.3.0/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+    
+    This file has been modified so that the individual alarms are configurable.
+    The default values for thresholds, periods and severities made these alarms
+    too limited for us.
+  */}}
   - name: {{ .Release.Name }}.{{ .Release.Namespace }}.kubernetesAppsRules
     rules:
     {{- with .Values.containerRules.pods }}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -454,7 +454,7 @@ spec:
 
     {{- with .Values.containerRules.hpas }}
     {{- if .enabled }}
-    
+
     {{- with .KubeHpaReplicasMismatch }}
     - alert: KubeHpaReplicasMismatch
       annotations:

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -1,4 +1,5 @@
 {{ $values              := .Values }}
+{{ $release             := .Release }}
 {{ $daemonsetSelector   := include "prometheus-alerts.daemonsetSelector" . }}
 {{ $deploymentSelector  := include "prometheus-alerts.deploymentSelector" . }}
 {{ $namespaceSelector   := include "prometheus-alerts.namespaceSelector" . }}
@@ -19,9 +20,12 @@ metadata:
     {{- include "nd-common.labels" . | nindent 4 }}
 spec:
   groups:
-  - name: {{ .Release.Name }}.{{ .Release.Namespace }}.containerRules
+  {{- with .Values.containerRules.pods -}}
+  {{- if .enabled }}
+
+  - name: {{ $release.Name }}.{{ $release.Namespace }}.containerRules
     rules:
-    {{ with .Values.containerRules.PodContainerTerminated -}}
+    {{- with .PodContainerTerminated -}}
     - alert: PodContainerTerminated
       annotations:
         summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
@@ -48,7 +52,7 @@ spec:
         {{- end }}
     {{ end -}}
 
-    {{ with .Values.containerRules.PodContainerOOMKilled -}}
+    {{- with .PodContainerOOMKilled -}}
     - alert: PodContainerOOMKilled
       annotations:
         summary: {{`Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status`}}
@@ -75,7 +79,7 @@ spec:
         {{- end }}
     {{ end -}}
 
-    {{ with .Values.containerRules.ContainerWaiting -}}
+    {{- with .ContainerWaiting -}}
     - alert: ContainerWaiting
       annotations:
         summary: Pod container waiting longer than {{ .for }}
@@ -96,7 +100,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- with .Values.containerRules.CPUThrottlingHigh }}
+    {{- with .CPUThrottlingHigh }}
     - alert: CPUThrottlingHigh
       annotations:
         summary: Processes experience elevated CPU throttling.
@@ -122,6 +126,9 @@ spec:
         {{- end }}
     {{- end }}
 
+  {{- end }}
+  {{- end }}
+
   #
   # Original Source:
   #    https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-13.3.0/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -132,8 +139,10 @@ spec:
   #
   - name: {{ .Release.Name }}.{{ .Release.Namespace }}.kubernetesAppsRules
     rules:
+    {{- with .Values.containerRules.pods -}}
+    {{- if .enabled }}
 
-    {{ with .Values.containerRules.PodCrashLoopBackOff -}}
+    {{- with .PodCrashLoopBackOff -}}
     - alert: PodCrashLoopBackOff
       annotations:
         summary: {{`Container inside pod {{ $labels.pod }} is crash looping`}}
@@ -159,7 +168,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.PodNotReady -}}
+    {{- with .PodNotReady -}}
     - alert: PodNotReady
       annotations:
         summary: Pod has been in a non-ready state for more than {{ .for }}
@@ -193,7 +202,13 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeDeploymentGenerationMismatch -}}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.containerRules.deployments -}}
+    {{- if .enabled }}
+
+    {{- with .KubeDeploymentGenerationMismatch -}}
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         summary: Deployment generation mismatch due to possible roll-back
@@ -215,7 +230,13 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeStatefulSetReplicasMismatch -}}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.containerRules.statefulsets -}}
+    {{- if .enabled }}
+
+    {{- with .KubeStatefulSetReplicasMismatch -}}
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         summary: StatefulSet has not matched the expected number of replicas.
@@ -242,7 +263,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeStatefulSetGenerationMismatch -}}
+    {{- with .KubeStatefulSetGenerationMismatch -}}
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         summary: StatefulSet generation mismatch due to possible roll-back
@@ -264,7 +285,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeStatefulSetUpdateNotRolledOut -}}
+    {{- with .KubeStatefulSetUpdateNotRolledOut -}}
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
         summary: StatefulSet update has not been rolled out.
@@ -298,7 +319,13 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeDaemonSetRolloutStuck -}}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.containerRules.daemonsets -}}
+    {{- if .enabled }}
+
+    {{- with .KubeDaemonSetRolloutStuck -}}
     - alert: KubeDaemonSetRolloutStuck
       annotations:
         summary: DaemonSet rollout is stuck.
@@ -339,7 +366,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeDaemonSetNotScheduled -}}
+    {{- with .KubeDaemonSetNotScheduled -}}
     - alert: KubeDaemonSetNotScheduled
       annotations:
         summary: DaemonSet pods are not scheduled.
@@ -360,7 +387,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeDaemonSetMisScheduled -}}
+    {{- with .KubeDaemonSetMisScheduled -}}
     - alert: KubeDaemonSetMisScheduled
       annotations:
         summary: DaemonSet pods are misscheduled.
@@ -378,7 +405,13 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeJobCompletion -}}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.containerRules.jobs -}}
+    {{- if .enabled }}
+
+    {{- with .KubeJobCompletion -}}
     - alert: KubeJobCompletion
       annotations:
         summary: Job did not complete in time
@@ -399,7 +432,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeJobFailed -}}
+    {{- with .KubeJobFailed -}}
     - alert: KubeJobFailed
       annotations:
         summary: Job failed to complete.
@@ -417,7 +450,13 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeHpaReplicasMismatch -}}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.containerRules.hpas -}}
+    {{- if .enabled }}
+    
+    {{- with .KubeHpaReplicasMismatch -}}
     - alert: KubeHpaReplicasMismatch
       annotations:
         summary: HPA has not matched descired number of replicas.
@@ -460,7 +499,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{ with .Values.containerRules.KubeHpaMaxedOut -}}
+    {{- with .KubeHpaMaxedOut -}}
     - alert: KubeHpaMaxedOut
       annotations:
         summary: HPA is running at max replicas
@@ -478,6 +517,9 @@ spec:
         {{- if $values.defaults.additionalRuleLabels }}
         {{ toYaml $values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
+    {{- end }}
+
+    {{- end }}
     {{- end }}
 
 {{- end }}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -1,10 +1,11 @@
-{{ $daemonsetSelector   := include "prometheus-alerts.daemonsetSelector" . }}
-{{ $deploymentSelector  := include "prometheus-alerts.deploymentSelector" . }}
-{{ $namespaceSelector   := include "prometheus-alerts.namespaceSelector" . }}
-{{ $podSelector         := include "prometheus-alerts.podSelector" . }}
-{{ $jobSelector         := include "prometheus-alerts.jobSelector" . }}
-{{ $hpaSelector         := include "prometheus-alerts.hpaSelector" . }}
-{{ $statefulsetSelector := include "prometheus-alerts.statefulsetSelector" . }}
+{{- include "prometheus-alerts.check_migration_alerts_grouped_by_resource" . }}
+{{- $daemonsetSelector   := include "prometheus-alerts.daemonsetSelector" . }}
+{{- $deploymentSelector  := include "prometheus-alerts.deploymentSelector" . }}
+{{- $namespaceSelector   := include "prometheus-alerts.namespaceSelector" . }}
+{{- $podSelector         := include "prometheus-alerts.podSelector" . }}
+{{- $jobSelector         := include "prometheus-alerts.jobSelector" . }}
+{{- $hpaSelector         := include "prometheus-alerts.hpaSelector" . }}
+{{- $statefulsetSelector := include "prometheus-alerts.statefulsetSelector" . }}
 
 {{- if .Values.containerRules.enabled }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -129,102 +129,126 @@ containerRules:
   # -- Whether or not to enable the container rules template
   enabled: true
 
-  # -- Monitors Pods for Containers that are terminated either for unexpected
-  # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
-  # for $for (1m), then it will alert.
-  PodContainerTerminated:
-    severity: warning
-    threshold: 0
-    over: 10m
-    for: 1m
-    reasons:
-      # - Error  < when a container is evicted gracefully, the "error" state is used.
-      - ContainerCannotRun
-      - DeadlineExceeded
+  pods:
+    # -- Enables the Pod resource rules
+    enabled: true
 
-  # -- Sums up all of the OOMKilled events per pod over the $over time (60m). If
-  # that number breaches the $threshold (0) for $for (1m), then it will alert.
-  PodContainerOOMKilled:
-    severity: warning
-    threshold: 0
-    over: 60m
-    for: 1m
+    # -- Monitors Pods for Containers that are terminated either for unexpected
+    # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
+    # for $for (1m), then it will alert.
+    PodContainerTerminated:
+      severity: warning
+      threshold: 0
+      over: 10m
+      for: 1m
+      reasons:
+        # - Error  < when a container is evicted gracefully, the "error" state is used.
+        - ContainerCannotRun
+        - DeadlineExceeded
 
-  # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
-  PodCrashLoopBackOff:
-    severity: warning
-    for: 10m
+    # -- Sums up all of the OOMKilled events per pod over the $over time (60m). If
+    # that number breaches the $threshold (0) for $for (1m), then it will alert.
+    PodContainerOOMKilled:
+      severity: warning
+      threshold: 0
+      over: 60m
+      for: 1m
 
-  # -- Pod has been in a non-ready state for more than a specific threshold
-  PodNotReady:
-    severity: warning
-    for: 15m
+    # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
+    PodCrashLoopBackOff:
+      severity: warning
+      for: 10m
 
-  # Pod container waiting longer than threshold
-  ContainerWaiting:
-    severity: warning
-    for: 1h
+    # -- Pod has been in a non-ready state for more than a specific threshold
+    PodNotReady:
+      severity: warning
+      for: 15m
 
-  # -- Deployment generation mismatch due to possible roll-back
-  KubeDeploymentGenerationMismatch:
-    severity: warning
-    for: 15m
+    # Pod container waiting longer than threshold
+    ContainerWaiting:
+      severity: warning
+      for: 1h
 
-  # Deployment has not matched the expected number of replicas
-  KubeStatefulSetReplicasMismatch:
-    severity: warning
-    for: 15m
+    # -- Container is being throttled by the CGroup - needs more resources.
+    # This value is appropriate for applications that are highly sensitive to
+    # request latency. Insensitive workloads might need to raise this percentage
+    # to avoid alert noise.
+    CPUThrottlingHigh:
+      severity: warning
+      threshold: 5
+      for: 15m
 
-  # StatefulSet generation mismatch due to possible roll-back
-  KubeStatefulSetGenerationMismatch:
-    severity: warning
-    for: 15m
+  deployments:
+    # -- Enables the Deployment resource rules
+    enabled: true
 
-  # StatefulSet update has not been rolled out
-  KubeStatefulSetUpdateNotRolledOut:
-    severity: warning
-    for: 15m
+    # -- Deployment generation mismatch due to possible roll-back
+    KubeDeploymentGenerationMismatch:
+      severity: warning
+      for: 15m
 
-  # DaemonSet rollout is stuck
-  KubeDaemonSetRolloutStuck:
-    severity: warning
-    for: 15m
+  statefulsets:
+    # -- Enables the StatefulSet resource rules
+    enabled: true
 
-  # DaemonSet pods are not scheduled
-  KubeDaemonSetNotScheduled:
-    severity: warning
-    for: 10m
+    # Deployment has not matched the expected number of replicas
+    KubeStatefulSetReplicasMismatch:
+      severity: warning
+      for: 15m
 
-  # DaemonSet pods are misscheduled
-  KubeDaemonSetMisScheduled:
-    severity: warning
-    for: 15m
+    # StatefulSet generation mismatch due to possible roll-back
+    KubeStatefulSetGenerationMismatch:
+      severity: warning
+      for: 15m
 
-  # Job did not complete in time
-  KubeJobCompletion:
-    severity: warning
-    for: 12h
+    # StatefulSet update has not been rolled out
+    KubeStatefulSetUpdateNotRolledOut:
+      severity: warning
+      for: 15m
 
-  # Job failed to complete
-  KubeJobFailed:
-    severity: warning
-    for: 15m
+  daemonsets:
+    # -- Enables the DaemonSet resource rules
+    enabled: true
 
-  # HPA has not matched descired number of replicas
-  KubeHpaReplicasMismatch:
-    severity: warning
-    for: 15m
+    # DaemonSet rollout is stuck
+    KubeDaemonSetRolloutStuck:
+      severity: warning
+      for: 15m
 
-  # HPA is running at max replicas
-  KubeHpaMaxedOut:
-    severity: warning
-    for: 15m
+    # DaemonSet pods are not scheduled
+    KubeDaemonSetNotScheduled:
+      severity: warning
+      for: 10m
 
-  # -- Container is being throttled by the CGroup - needs more resources.
-  # This value is appropriate for applications that are highly sensitive to
-  # request latency. Insensitive workloads might need to raise this percentage
-  # to avoid alert noise.
-  CPUThrottlingHigh:
-    severity: warning
-    threshold: 5
-    for: 15m
+    # DaemonSet pods are misscheduled
+    KubeDaemonSetMisScheduled:
+      severity: warning
+      for: 15m
+
+  jobs:
+    # -- Enables the Job resource rules
+    enabled: true
+
+    # Job did not complete in time
+    KubeJobCompletion:
+      severity: warning
+      for: 12h
+
+    # Job failed to complete
+    KubeJobFailed:
+      severity: warning
+      for: 15m
+
+  hpas:
+    # -- Enables the HorizontalPodAutoscaler resource rules
+    enabled: true
+
+    # HPA has not matched descired number of replicas
+    KubeHpaReplicasMismatch:
+      severity: warning
+      for: 15m
+
+    # HPA is running at max replicas
+    KubeHpaMaxedOut:
+      severity: warning
+      for: 15m


### PR DESCRIPTION
Values files schema has been updated to group alerts by resource type

Motivation: We have regrouped alerts to be able to turn them on and off by
resource type.

As an example:

> Value `.Values.containerRules.ContainerWaiting` has been migrated to
> `.Values.containerRules.pods.ContainerWaiting`. Please update your values
> files.

The helm chart will produce errors if you do not migrate your values files.

Proof:
```
akennedy@ndm2a prometheus-alerts % VALUES=values-akennedy.yaml make template > new
install.go:214: [debug] Original chart version: ""
install.go:231: [debug] CHART PATH: /Users/akennedy/src/k8s-charts/charts/prometheus-alerts

Error: execution error at (prometheus-alerts/templates/containers-prometheusrule.yaml:1:4): Value `.Values.containerRules.ContainerWaiting` has been migrated to `.Values.containerRules.pods.ContainerWaiting`. Please update your values files.
helm.go:84: [debug] execution error at (prometheus-alerts/templates/containers-prometheusrule.yaml:1:4): Value `.Values.containerRules.ContainerWaiting` has been migrated to `.Values.containerRules.pods.ContainerWaiting`. Please update your values files.
make: *** [template] Error 1
```

Proof:
```diff
--- orig        2024-04-22 18:47:11
+++ new 2024-04-22 19:14:18
@@ -47,7 +47,7 @@
     nextdoor.com/chart: prometheus-rules
     nextdoor.com/source: https://github.com/Nextdoor/k8s-charts
   labels:
-    helm.sh/chart: prometheus-alerts-1.4.1
+    helm.sh/chart: prometheus-alerts-1.5.0
     app.kubernetes.io/version: "0.0.1"
     app.kubernetes.io/managed-by: Helm
     
@@ -134,18 +134,8 @@
       for: 15m
       labels:
         severity: warning
-
-  #
-  # Original Source:
-  #    https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-13.3.0/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
-  #
-  # This file has been modified so that the individual alarms are configurable.
-  # The default values for thresholds, periods and severities made these alarms
-  # too limited for us.
-  #
   - name: prometheus-alerts.kube-system.kubernetesAppsRules
     rules:
-
     - alert: PodCrashLoopBackOff
       annotations:
         summary: Container inside pod {{ $labels.pod }} is crash looping
@@ -166,7 +156,6 @@
       for: 10m
       labels:
         severity: warning
-
     - alert: PodNotReady
       annotations:
         summary: Pod has been in a non-ready state for more than 15m
@@ -195,7 +184,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         summary: Deployment generation mismatch due to possible roll-back
@@ -212,7 +200,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         summary: StatefulSet has not matched the expected number of replicas.
@@ -234,7 +221,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         summary: StatefulSet generation mismatch due to possible roll-back
@@ -251,7 +237,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
         summary: StatefulSet update has not been rolled out.
@@ -280,7 +265,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeDaemonSetRolloutStuck
       annotations:
         summary: DaemonSet rollout is stuck.
@@ -316,7 +300,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeDaemonSetNotScheduled
       annotations:
         summary: DaemonSet pods are not scheduled.
@@ -332,7 +315,6 @@
       for: 10m
       labels:
         severity: warning
-
     - alert: KubeDaemonSetMisScheduled
       annotations:
         summary: DaemonSet pods are misscheduled.
@@ -345,7 +327,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeJobCompletion
       annotations:
         summary: Job did not complete in time
@@ -361,7 +342,6 @@
       for: 12h
       labels:
         severity: warning
-
     - alert: KubeJobFailed
       annotations:
         summary: Job failed to complete.
@@ -374,7 +354,6 @@
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeHpaReplicasMismatch
       annotations:
         summary: HPA has not matched descired number of replicas.
@@ -388,31 +367,22 @@
          kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics", horizontalpodautoscaler=~"prometheus-alerts-.*", namespace="kube-system"}
           !=
          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", horizontalpodautoscaler=~"prometheus-alerts-.*", namespace="kube-system"}
-        )
-          and
-
-        (
+        ) and (
          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", horizontalpodautoscaler=~"prometheus-alerts-.*", namespace="kube-system"}
           >
          kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", horizontalpodautoscaler=~"prometheus-alerts-.*", namespace="kube-system"}
-        )
-
-          and
-
-        (
+        ) and (
           kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", horizontalpodautoscaler=~"prometheus-alerts-.*", namespace="kube-system"}
             <
           kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", horizontalpodautoscaler=~"prometheus-alerts-.*", namespace="kube-system"}
+        ) and (
+          changes(kube_horizontalpodautoscaler_status_current_replicas[15m])
+            ==
+          0
         )
-
-          and
-
-        changes(kube_horizontalpodautoscaler_status_current_replicas[15m]) == 0
-
       for: 15m
       labels:
         severity: warning
-
     - alert: KubeHpaMaxedOut
       annotations:
         summary: HPA is running at max replicas
```