### PR TITLE
feat(prometheus-alerts): Add selector validity alarms

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.5.0
+version: 1.6.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -1,4 +1,3 @@
-
 # prometheus-alerts
 
 Helm Chart that provisions a series of common Prometheus Alerts
@@ -19,6 +18,19 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 `charts/stateful-app` charts.
 
 ## Upgrade Notes
+
+### 1.5.x -> 1.6.x
+
+**BREAKING: The AlertSelectorValidity alert rules requires kube-state-metrics.**
+
+An alert was introduced in that requires kube-state-metrics to be installed in the cluster. If
+you do not have kube-state-metrics installed, you will need to disable the alert in your values
+file.
+
+We have added a new metric which attempts to detect if you have misconfigured
+your selectors. After upgrading, you may get alerted. You should respond to the
+alert appropriately by reading the alert information and making changes to your
+selectors.
 
 ### 1.4.x -> 1.5.x
 
@@ -103,6 +115,8 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.jobs.KubeJobFailed.for | string | `"15m"` |  |
 | containerRules.jobs.KubeJobFailed.severity | string | `"warning"` |  |
 | containerRules.jobs.enabled | bool | `true` | Enables the Job resource rules |
+| containerRules.meta | object | `{"AlertRulesSelectorsValidity":{"for":"1h","severity":"warning"}}` | This is not a real resource type, but used to hold additional alarms for multiple resource types. |
+| containerRules.meta.AlertRulesSelectorsValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.pods.CPUThrottlingHigh | object | `{"for":"15m","severity":"warning","threshold":5}` | Container is being throttled by the CGroup - needs more resources. This value is appropriate for applications that are highly sensitive to request latency. Insensitive workloads might need to raise this percentage to avoid alert noise. |
 | containerRules.pods.ContainerWaiting.for | string | `"1h"` |  |
 | containerRules.pods.ContainerWaiting.severity | string | `"warning"` |  |

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -2,7 +2,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -21,11 +21,7 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 
 ### 1.5.x -> 1.6.x
 
-**BREAKING: The AlertSelectorValidity alert rules requires kube-state-metrics.**
-
-An alert was introduced in that requires kube-state-metrics to be installed in the cluster. If
-you do not have kube-state-metrics installed, you will need to disable the alert in your values
-file.
+**CHANGE: The AlertSelectorValidity alert rules added.**
 
 We have added a new metric which attempts to detect if you have misconfigured
 your selectors. After upgrading, you may get alerted. You should respond to the
@@ -95,6 +91,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | alertManager.repeatInterval | string | `"1h"` | How long to wait before sending a notification again if it has already been sent successfully for an alert. (Usually ~3h or more). |
 | chart_name | string | `"prometheus-rules"` |  |
 | chart_source | string | `"https://github.com/Nextdoor/k8s-charts"` |  |
+| containerRules.daemonsets.DaemonsetSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.daemonsets.KubeDaemonSetMisScheduled.for | string | `"15m"` |  |
 | containerRules.daemonsets.KubeDaemonSetMisScheduled.severity | string | `"warning"` |  |
 | containerRules.daemonsets.KubeDaemonSetNotScheduled.for | string | `"10m"` |  |
@@ -102,21 +99,22 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.daemonsets.KubeDaemonSetRolloutStuck.for | string | `"15m"` |  |
 | containerRules.daemonsets.KubeDaemonSetRolloutStuck.severity | string | `"warning"` |  |
 | containerRules.daemonsets.enabled | bool | `true` | Enables the DaemonSet resource rules |
+| containerRules.deployments.DeploymentSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.deployments.KubeDeploymentGenerationMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment generation mismatch due to possible roll-back |
 | containerRules.deployments.enabled | bool | `true` | Enables the Deployment resource rules |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
+| containerRules.hpas.HpaSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.hpas.KubeHpaMaxedOut.for | string | `"15m"` |  |
 | containerRules.hpas.KubeHpaMaxedOut.severity | string | `"warning"` |  |
 | containerRules.hpas.KubeHpaReplicasMismatch.for | string | `"15m"` |  |
 | containerRules.hpas.KubeHpaReplicasMismatch.severity | string | `"warning"` |  |
 | containerRules.hpas.enabled | bool | `true` | Enables the HorizontalPodAutoscaler resource rules |
+| containerRules.jobs.JobSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.jobs.KubeJobCompletion.for | string | `"12h"` |  |
 | containerRules.jobs.KubeJobCompletion.severity | string | `"warning"` |  |
 | containerRules.jobs.KubeJobFailed.for | string | `"15m"` |  |
 | containerRules.jobs.KubeJobFailed.severity | string | `"warning"` |  |
 | containerRules.jobs.enabled | bool | `true` | Enables the Job resource rules |
-| containerRules.meta | object | `{"AlertRulesSelectorsValidity":{"for":"1h","severity":"warning"}}` | This is not a real resource type, but used to hold additional alarms for multiple resource types. |
-| containerRules.meta.AlertRulesSelectorsValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.pods.CPUThrottlingHigh | object | `{"for":"15m","severity":"warning","threshold":5}` | Container is being throttled by the CGroup - needs more resources. This value is appropriate for applications that are highly sensitive to request latency. Insensitive workloads might need to raise this percentage to avoid alert noise. |
 | containerRules.pods.ContainerWaiting.for | string | `"1h"` |  |
 | containerRules.pods.ContainerWaiting.severity | string | `"warning"` |  |
@@ -124,6 +122,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.pods.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
 | containerRules.pods.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
 | containerRules.pods.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| containerRules.pods.PodSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.pods.enabled | bool | `true` | Enables the Pod resource rules |
 | containerRules.statefulsets.KubeStatefulSetGenerationMismatch.for | string | `"15m"` |  |
 | containerRules.statefulsets.KubeStatefulSetGenerationMismatch.severity | string | `"warning"` |  |
@@ -131,6 +130,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | containerRules.statefulsets.KubeStatefulSetReplicasMismatch.severity | string | `"warning"` |  |
 | containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut.for | string | `"15m"` |  |
 | containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut.severity | string | `"warning"` |  |
+| containerRules.statefulsets.StatefulsetSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.statefulsets.enabled | bool | `true` | Enables the StatefulSet resource rules |
 | defaults.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.daemonsetNameSelector | `string` | `"{{ .Release.Name }}-.*"` | Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |

--- a/charts/prometheus-alerts/README.md.gotmpl
+++ b/charts/prometheus-alerts/README.md.gotmpl
@@ -21,11 +21,7 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 
 ### 1.5.x -> 1.6.x
 
-**BREAKING: The AlertSelectorValidity alert rules requires kube-state-metrics.**
-
-An alert was introduced in that requires kube-state-metrics to be installed in the cluster. If
-you do not have kube-state-metrics installed, you will need to disable the alert in your values
-file.
+**CHANGE: The AlertSelectorValidity alert rules added.**
 
 We have added a new metric which attempts to detect if you have misconfigured
 your selectors. After upgrading, you may get alerted. You should respond to the

--- a/charts/prometheus-alerts/README.md.gotmpl
+++ b/charts/prometheus-alerts/README.md.gotmpl
@@ -1,5 +1,5 @@
-
 {{ template "chart.header" . }}
+
 {{ template "chart.description" . }}
 
 {{ template "chart.versionBadge" .  }}{{ template "chart.typeBadge" .  }}{{ template "chart.appVersionBadge" .  }}
@@ -18,6 +18,19 @@ those changes in the `charts/simple-app`, `charts/daemonset-app` and
 `charts/stateful-app` charts.
 
 ## Upgrade Notes
+
+### 1.5.x -> 1.6.x
+
+**BREAKING: The AlertSelectorValidity alert rules requires kube-state-metrics.**
+
+An alert was introduced in that requires kube-state-metrics to be installed in the cluster. If
+you do not have kube-state-metrics installed, you will need to disable the alert in your values
+file.
+
+We have added a new metric which attempts to detect if you have misconfigured
+your selectors. After upgrading, you may get alerted. You should respond to the
+alert appropriately by reading the alert information and making changes to your
+selectors.
 
 ### 1.4.x -> 1.5.x
 

--- a/charts/prometheus-alerts/runbook.md
+++ b/charts/prometheus-alerts/runbook.md
@@ -101,3 +101,15 @@ help you determine the root cause of the issue. Follow the instructions in the
 into the relevant cluster and namespace, and use the `kubectl describe pod <podname>`
 to see the status of the pod and any events related to it. The pod logs may also 
 provide hints as to what may be going wrong.
+
+## Alert-Rules-Selectors-Validity
+
+This alert fires when there may be an error in setting the proper selectors used
+by the other alerts in this chart. It attempts to read a basic metric using the
+selector you provided. For instance, if you have a pod selector that looks for
+`pod=~"foo-bar-.*"` but your pods are actually named `baz-.*`, this alert will
+notify you of the misconfiguration. Read the alert description to see exactly
+which selector is having an issue. Also note that you need to collect the
+metrics that this alert uses. For instance, to test pod selectors, we use the
+`kube_pod_info` metric. If you do not collect this metric, this alert will
+continiously fire.

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -200,6 +200,34 @@ spec:
         {{- end }}
     {{- end }}
 
+    {{ with .PodSelectorValidity -}}
+    - alert: PodSelectorValidity
+      annotations:
+        summary: PodSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The PodSelector used for pod level alerts did not return any data.
+          Please check the PodSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your pods so that you
+          will be alerted for pod issues. The current selector is
+          `{podSelector="{{ $podSelector }}", namespaceSelector="{{ $namespaceSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_pod_info{
+              {{ $podSelector }},
+              {{ $namespaceSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
     {{- end }}
     {{- end }}
 
@@ -220,6 +248,33 @@ spec:
         kube_deployment_status_observed_generation{ {{- $deploymentSelector -}} }
           !=
         kube_deployment_metadata_generation{ {{- $deploymentSelector -}} }
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{ with .DeploymentSelectorValidity -}}
+    - alert: DeploymentSelectorValidity
+      annotations:
+        summary: DeploymentSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The DeploymentSelector used for deployment level alerts did not return any data.
+          Please check the DeploymentSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your deployments so that you
+          will be alerted for deployment issues. The current selector is
+          `{deploymentSelector="{{ $deploymentSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_deployment_labels{
+              {{ $deploymentSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -317,6 +372,33 @@ spec:
         {{- end }}
     {{- end }}
 
+    {{ with .StatefulsetSelectorValidity -}}
+    - alert: StatefulsetSelectorValidity
+      annotations:
+        summary: StatefulsetSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The StatefulsetSelector used for statefulset level alerts did not return any data.
+          Please check the StatefulsetSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your statefulsets so that you
+          will be alerted for statefulset issues. The current selector is
+          `{statefulsetSelector="{{ $statefulsetSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_statefulset_created{
+              {{ $statefulsetSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
     {{- end }}
     {{- end }}
 
@@ -403,6 +485,33 @@ spec:
         {{- end }}
     {{- end }}
 
+    {{ with .DaemonsetSelectorValidity -}}
+    - alert: DaemonsetSelectorValidity
+      annotations:
+        summary: DaemonsetSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The DaemonsetSelector used for daemonset level alerts did not return any data.
+          Please check the DaemonsetSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your daemonsets so that you
+          will be alerted for daemonset issues. The current selector is
+          `{daemonsetSelector="{{ $daemonsetSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_daemonset_labels{
+              {{ $daemonsetSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
     {{- end }}
     {{- end }}
 
@@ -440,6 +549,33 @@ spec:
           {{`}}`}} failed to complete. Removing failed job after investigation
           should clear this alert.
       expr: kube_job_failed{ {{- $jobSelector -}} }  > 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+
+    {{ with .JobSelectorValidity -}}
+    - alert: JobSelectorValidity
+      annotations:
+        summary: JobSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The JobSelector used for job level alerts did not return any data.
+          Please check the JobSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your jobs so that you
+          will be alerted for job issues. The current selector is
+          `{jobSelector="{{ $jobSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_job_info{
+              {{ $jobSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
@@ -509,118 +645,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- end }}
-    {{- end }}
-
-  - name: {{ .Release.Name }}.{{ .Release.Namespace }}.alertRulesSelectorsValidity
-    rules:
-    {{ with .Values.containerRules.meta.AlertRulesSelectorsValidity -}}
-    {{- if $.Values.containerRules.daemonsets.enabled }}
-    - alert: DaemonsetSelectorValidity
-      annotations:
-        summary: DaemonsetSelector for prometheus-alerts is invalid
-        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
-        description: >-
-          The DaemonsetSelector used for daemonset level alerts did not return any data.
-          Please check the DaemonsetSelector applied in your prometheus-alerts chart
-          is correct to ensure you are properly selecting your daemonsets so that you
-          will be alerted for daemonset issues. The current selector is
-          `{daemonsetSelector="{{ $daemonsetSelector }}"}`.
-      expr: |-
-        (
-          count(
-            kube_daemonset_labels{
-              {{ $daemonsetSelector }}
-            }
-          ) or on() vector(0)
-        ) == 0
-      for: {{ .for }}
-      labels:
-        severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
-        {{- end }}
-    {{- end }}
-    {{- if $.Values.containerRules.deployments.enabled }}
-    - alert: DeploymentSelectorValidity
-      annotations:
-        summary: DeploymentSelector for prometheus-alerts is invalid
-        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
-        description: >-
-          The DeploymentSelector used for deployment level alerts did not return any data.
-          Please check the DeploymentSelector applied in your prometheus-alerts chart
-          is correct to ensure you are properly selecting your deployments so that you
-          will be alerted for deployment issues. The current selector is
-          `{deploymentSelector="{{ $deploymentSelector }}"}`.
-      expr: |-
-        (
-          count(
-            kube_deployment_labels{
-              {{ $deploymentSelector }}
-            }
-          ) or on() vector(0)
-        ) == 0
-      for: {{ .for }}
-      labels:
-        severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
-        {{- end }}
-    {{- end }}
-    {{- if $.Values.containerRules.pods.enabled }}
-    - alert: PodSelectorValidity
-      annotations:
-        summary: PodSelector for prometheus-alerts is invalid
-        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
-        description: >-
-          The PodSelector used for pod level alerts did not return any data.
-          Please check the PodSelector applied in your prometheus-alerts chart
-          is correct to ensure you are properly selecting your pods so that you
-          will be alerted for pod issues. The current selector is
-          `{podSelector="{{ $podSelector }}", namespaceSelector="{{ $namespaceSelector }}"}`.
-      expr: |-
-        (
-          count(
-            kube_pod_info{
-              {{ $podSelector }},
-              {{ $namespaceSelector }}
-            }
-          ) or on() vector(0)
-        ) == 0
-      for: {{ .for }}
-      labels:
-        severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
-        {{- end }}
-    {{- end }}
-    {{- if $.Values.containerRules.jobs.enabled }}
-    - alert: JobSelectorValidity
-      annotations:
-        summary: JobSelector for prometheus-alerts is invalid
-        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
-        description: >-
-          The JobSelector used for job level alerts did not return any data.
-          Please check the JobSelector applied in your prometheus-alerts chart
-          is correct to ensure you are properly selecting your jobs so that you
-          will be alerted for job issues. The current selector is
-          `{jobSelector="{{ $jobSelector }}"}`.
-      expr: |-
-        (
-          count(
-            kube_job_info{
-              {{ $jobSelector }}
-            }
-          ) or on() vector(0)
-        ) == 0
-      for: {{ .for }}
-      labels:
-        severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
-        {{- end }}
-    {{- end }}
-    {{- if $.Values.containerRules.hpas.enabled }}
+    {{ with .HpaSelectorValidity -}}
     - alert: HpaSelectorValidity
       annotations:
         summary: HpaSelector for prometheus-alerts is invalid
@@ -646,31 +671,7 @@ spec:
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
     {{- end }}
-    {{- if $.Values.containerRules.statefulsets.enabled }}
-    - alert: StatefulsetSelectorValidity
-      annotations:
-        summary: StatefulsetSelector for prometheus-alerts is invalid
-        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
-        description: >-
-          The StatefulsetSelector used for statefulset level alerts did not return any data.
-          Please check the StatefulsetSelector applied in your prometheus-alerts chart
-          is correct to ensure you are properly selecting your statefulsets so that you
-          will be alerted for statefulset issues. The current selector is
-          `{statefulsetSelector="{{ $statefulsetSelector }}"}`.
-      expr: |-
-        (
-          count(
-            kube_statefulset_created{
-              {{ $statefulsetSelector }}
-            }
-          ) or on() vector(0)
-        ) == 0
-      for: {{ .for }}
-      labels:
-        severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
-        {{- end }}
+
     {{- end }}
     {{- end }}
 

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -512,4 +512,166 @@ spec:
     {{- end }}
     {{- end }}
 
+  - name: {{ .Release.Name }}.{{ .Release.Namespace }}.alertRulesSelectorsValidity
+    rules:
+    {{ with .Values.containerRules.meta.AlertRulesSelectorsValidity -}}
+    {{- if $.Values.containerRules.daemonsets.enabled }}
+    - alert: DaemonsetSelectorValidity
+      annotations:
+        summary: DaemonsetSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The DaemonsetSelector used for daemonset level alerts did not return any data.
+          Please check the DaemonsetSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your daemonsets so that you
+          will be alerted for daemonset issues. The current selector is
+          `{daemonsetSelector="{{ $daemonsetSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_daemonset_labels{
+              {{ $daemonsetSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- if $.Values.containerRules.deployments.enabled }}
+    - alert: DeploymentSelectorValidity
+      annotations:
+        summary: DeploymentSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The DeploymentSelector used for deployment level alerts did not return any data.
+          Please check the DeploymentSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your deployments so that you
+          will be alerted for deployment issues. The current selector is
+          `{deploymentSelector="{{ $deploymentSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_deployment_labels{
+              {{ $deploymentSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- if $.Values.containerRules.pods.enabled }}
+    - alert: PodSelectorValidity
+      annotations:
+        summary: PodSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The PodSelector used for pod level alerts did not return any data.
+          Please check the PodSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your pods so that you
+          will be alerted for pod issues. The current selector is
+          `{podSelector="{{ $podSelector }}", namespaceSelector="{{ $namespaceSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_pod_info{
+              {{ $podSelector }},
+              {{ $namespaceSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- if $.Values.containerRules.jobs.enabled }}
+    - alert: JobSelectorValidity
+      annotations:
+        summary: JobSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The JobSelector used for job level alerts did not return any data.
+          Please check the JobSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your jobs so that you
+          will be alerted for job issues. The current selector is
+          `{jobSelector="{{ $jobSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_job_info{
+              {{ $jobSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- if $.Values.containerRules.hpas.enabled }}
+    - alert: HpaSelectorValidity
+      annotations:
+        summary: HpaSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The HpaSelector used for hpa level alerts did not return any data.
+          Please check the HpaSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your hpas so that you
+          will be alerted for hpa issues. The current selector is
+          `{hpaSelector="{{ $hpaSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_horizontalpodautoscaler_info{
+              {{ $hpaSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- if $.Values.containerRules.statefulsets.enabled }}
+    - alert: StatefulsetSelectorValidity
+      annotations:
+        summary: StatefulsetSelector for prometheus-alerts is invalid
+        runbook_url: {{ $.Values.defaults.runbookUrl }}#Alert-Rules-Selectors-Validity
+        description: >-
+          The StatefulsetSelector used for statefulset level alerts did not return any data.
+          Please check the StatefulsetSelector applied in your prometheus-alerts chart
+          is correct to ensure you are properly selecting your statefulsets so that you
+          will be alerted for statefulset issues. The current selector is
+          `{statefulsetSelector="{{ $statefulsetSelector }}"}`.
+      expr: |-
+        (
+          count(
+            kube_statefulset_created{
+              {{ $statefulsetSelector }}
+            }
+          ) or on() vector(0)
+        ) == 0
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+        {{- if $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
 {{- end }}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -210,7 +210,7 @@ spec:
           Please check the PodSelector applied in your prometheus-alerts chart
           is correct to ensure you are properly selecting your pods so that you
           will be alerted for pod issues. The current selector is
-          `{podSelector="{{ $podSelector }}", namespaceSelector="{{ $namespaceSelector }}"}`.
+          `{{ $podSelector }}, {{ $namespaceSelector }}`.
       expr: |-
         (
           count(
@@ -266,7 +266,7 @@ spec:
           Please check the DeploymentSelector applied in your prometheus-alerts chart
           is correct to ensure you are properly selecting your deployments so that you
           will be alerted for deployment issues. The current selector is
-          `{deploymentSelector="{{ $deploymentSelector }}"}`.
+          `{{ $deploymentSelector }}`.
       expr: |-
         (
           count(
@@ -382,7 +382,7 @@ spec:
           Please check the StatefulsetSelector applied in your prometheus-alerts chart
           is correct to ensure you are properly selecting your statefulsets so that you
           will be alerted for statefulset issues. The current selector is
-          `{statefulsetSelector="{{ $statefulsetSelector }}"}`.
+          `{{ $statefulsetSelector }}`.
       expr: |-
         (
           count(
@@ -495,7 +495,7 @@ spec:
           Please check the DaemonsetSelector applied in your prometheus-alerts chart
           is correct to ensure you are properly selecting your daemonsets so that you
           will be alerted for daemonset issues. The current selector is
-          `{daemonsetSelector="{{ $daemonsetSelector }}"}`.
+          `{{ $daemonsetSelector }}`.
       expr: |-
         (
           count(
@@ -567,7 +567,7 @@ spec:
           Please check the JobSelector applied in your prometheus-alerts chart
           is correct to ensure you are properly selecting your jobs so that you
           will be alerted for job issues. The current selector is
-          `{jobSelector="{{ $jobSelector }}"}`.
+          `{{ $jobSelector }}`.
       expr: |-
         (
           count(
@@ -655,7 +655,7 @@ spec:
           Please check the HpaSelector applied in your prometheus-alerts chart
           is correct to ensure you are properly selecting your hpas so that you
           will be alerted for hpa issues. The current selector is
-          `{hpaSelector="{{ $hpaSelector }}"}`.
+          `{{ $hpaSelector }}`.
       expr: |-
         (
           count(

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -223,6 +223,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $.Release.Namespace }}
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
@@ -278,6 +279,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $.Release.Namespace }}
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
@@ -394,6 +396,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $.Release.Namespace }}
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
@@ -507,6 +510,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $.Release.Namespace }}
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
@@ -579,6 +583,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $.Release.Namespace }}
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}
@@ -667,6 +672,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        namespace: {{ $.Release.Namespace }}
         {{- if $.Values.defaults.additionalRuleLabels }}
         {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
         {{- end }}

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -129,20 +129,17 @@ containerRules:
   # -- Whether or not to enable the container rules template
   enabled: true
 
-  # -- This is not a real resource type, but used to hold additional alarms for
-  # multiple resource types.
-  meta:
+  pods:
+    # -- Enables the Pod resource rules
+    enabled: true
+
     # -- Does a basic lookup using the defined selectors to see if we can see any
     # info for a given selector. This is the "watcher for the watcher". If we get
     # alerted by this, we likely have a bad selector and our alerts are not going
     # to ever fire.
-    AlertRulesSelectorsValidity:
+    PodSelectorValidity:
       severity: warning
       for: 1h
-
-  pods:
-    # -- Enables the Pod resource rules
-    enabled: true
 
     # -- Monitors Pods for Containers that are terminated either for unexpected
     # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
@@ -193,6 +190,14 @@ containerRules:
     # -- Enables the Deployment resource rules
     enabled: true
 
+    # -- Does a basic lookup using the defined selectors to see if we can see any
+    # info for a given selector. This is the "watcher for the watcher". If we get
+    # alerted by this, we likely have a bad selector and our alerts are not going
+    # to ever fire.
+    DeploymentSelectorValidity:
+      severity: warning
+      for: 1h
+
     # -- Deployment generation mismatch due to possible roll-back
     KubeDeploymentGenerationMismatch:
       severity: warning
@@ -201,6 +206,14 @@ containerRules:
   statefulsets:
     # -- Enables the StatefulSet resource rules
     enabled: true
+
+    # -- Does a basic lookup using the defined selectors to see if we can see any
+    # info for a given selector. This is the "watcher for the watcher". If we get
+    # alerted by this, we likely have a bad selector and our alerts are not going
+    # to ever fire.
+    StatefulsetSelectorValidity:
+      severity: warning
+      for: 1h
 
     # Deployment has not matched the expected number of replicas
     KubeStatefulSetReplicasMismatch:
@@ -221,6 +234,14 @@ containerRules:
     # -- Enables the DaemonSet resource rules
     enabled: true
 
+    # -- Does a basic lookup using the defined selectors to see if we can see any
+    # info for a given selector. This is the "watcher for the watcher". If we get
+    # alerted by this, we likely have a bad selector and our alerts are not going
+    # to ever fire.
+    DaemonsetSelectorValidity:
+      severity: warning
+      for: 1h
+
     # DaemonSet rollout is stuck
     KubeDaemonSetRolloutStuck:
       severity: warning
@@ -240,6 +261,14 @@ containerRules:
     # -- Enables the Job resource rules
     enabled: true
 
+    # -- Does a basic lookup using the defined selectors to see if we can see any
+    # info for a given selector. This is the "watcher for the watcher". If we get
+    # alerted by this, we likely have a bad selector and our alerts are not going
+    # to ever fire.
+    JobSelectorValidity:
+      severity: warning
+      for: 1h
+
     # Job did not complete in time
     KubeJobCompletion:
       severity: warning
@@ -253,6 +282,14 @@ containerRules:
   hpas:
     # -- Enables the HorizontalPodAutoscaler resource rules
     enabled: true
+
+    # -- Does a basic lookup using the defined selectors to see if we can see any
+    # info for a given selector. This is the "watcher for the watcher". If we get
+    # alerted by this, we likely have a bad selector and our alerts are not going
+    # to ever fire.
+    HpaSelectorValidity:
+      severity: warning
+      for: 1h
 
     # HPA has not matched descired number of replicas
     KubeHpaReplicasMismatch:

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -129,6 +129,17 @@ containerRules:
   # -- Whether or not to enable the container rules template
   enabled: true
 
+  # -- This is not a real resource type, but used to hold additional alarms for
+  # multiple resource types.
+  meta:
+    # -- Does a basic lookup using the defined selectors to see if we can see any
+    # info for a given selector. This is the "watcher for the watcher". If we get
+    # alerted by this, we likely have a bad selector and our alerts are not going
+    # to ever fire.
+    AlertRulesSelectorsValidity:
+      severity: warning
+      for: 1h
+
   pods:
     # -- Enables the Pod resource rules
     enabled: true


### PR DESCRIPTION
We ran into an issue where unbeknownst to us, our pod selector was set incorrectly and therefore all of our rules deployed via prometheus-alerts did not have any series to evaluate. This lack of series data is silently ignored. Here we are resolving this by implementing a rule which will use the various selectors to see if a basic metric exists or not. If it does not exist then we want to warn the user that none of the other rules will be evaluated.

I tried to choose metrics for each selector that were generic enough and did not rely on a specific metric that may not be gathered. Most types had an associated info or label metric which are good candidates for this use-case.

Lastly, I set the timing of this metric up for 1 hour by default. This felt okay to me as we want to be a little bit resilient to prometheus metric collection outages and not accidentally page every service owner if we have a centralized outage of the platform itself. Normally, a team might only be paged once for this when they first setup their application if they had not setup their selectors correctly. This alert is not expected to go into an alert state without some heavy handed naming changes (mostly done during things like migrations).

See https://github.com/Nextdoor/k8s-charts/pull/285