### PR TITLE
fix(charts/prometheus-alerts): Fix deployment selector

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -2,7 +2,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/prometheus-alerts/templates/_helpers.tpl
+++ b/charts/prometheus-alerts/templates/_helpers.tpl
@@ -36,9 +36,9 @@ job="kube-state-metrics", job_name!="", {{ include "prometheus-alerts.namespaceS
 
 {{- define "prometheus-alerts.deploymentSelector" -}}
 {{- if .Values.defaults.deploymentNameSelector -}}
-job="kube-state-metrics", kube_deployment=~"{{ tpl .Values.defaults.deploymentNameSelector $ }}", {{ include "prometheus-alerts.namespaceSelector" $ }}
+job="kube-state-metrics", deployment=~"{{ tpl .Values.defaults.deploymentNameSelector $ }}", {{ include "prometheus-alerts.namespaceSelector" $ }}
 {{- else -}}
-job="kube-state-metrics", kube_deployment!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
+job="kube-state-metrics", deployment!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
The selector for the deployment queries was looking for `kube_deployment` instead of `deployment`. However, that is not a valid label on these metrics.

Maybe this was a change upstream as it looks like our chart always used `kube_deployment`. I am surprised we have not been alerted by this more since the validity alerts have been installed.

Using these queries:
```
kube_deployment_labels{deployment!="", namespace="xyz"}
kube_deployment_status_observed_generation{deployment!="", namespace="xyz"}
kube_deployment_labels{kube_deployment!="", namespace="xyz"}
kube_deployment_status_observed_generation{kube_deployment!="", namespace="xyz"}
```

We can see that only the following values are returned:
```
kube_deployment_labels{deployment="abc",namespace="xyz",[...]}
kube_deployment_status_observed_generation{deployment="abc",namespace="xyz",[...]}
```