### PR TITLE
feat(charts/nd-common): allow option to omit DD_ENTITY_ID

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.15.5
+version: 0.15.6
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.15.5](https://img.shields.io/badge/Version-0.15.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.15.6](https://img.shields.io/badge/Version-0.15.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -257,7 +257,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.1 |
+| file://../nd-common | nd-common | 0.3.2 |
 
 ## Values
 

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.3.1
+version: 0.3.2
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_datadog.tpl
+++ b/charts/nd-common/templates/_datadog.tpl
@@ -76,10 +76,12 @@ Datadog Client libraries want.
 {{- define "nd-common.datadogEnv" -}}
 {{- if .Values.datadog.enabled -}}
 # https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp
+{{- if not(.Values.datadog.disableEntityId) }}
 - name: DD_ENTITY_ID
   valueFrom:
     fieldRef:
       fieldPath: metadata.uid
+{{- end }}
 # https://www.datadoghq.com/blog/monitor-kubernetes-docker/#instrument-your-code-to-send-metrics-to-dogstatsd
 - name: DOGSTATSD_HOST_IP
   valueFrom:

--- a/charts/nd-common/templates/_datadog.tpl
+++ b/charts/nd-common/templates/_datadog.tpl
@@ -76,7 +76,7 @@ Datadog Client libraries want.
 {{- define "nd-common.datadogEnv" -}}
 {{- if .Values.datadog.enabled -}}
 # https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp
-{{- if not(.Values.datadog.disableEntityId) }}
+{{- if not .Values.datadog.disableEntityId }}
 - name: DD_ENTITY_ID
   valueFrom:
     fieldRef:

--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.7.2
+version: 1.7.3
 appVersion: 0.0.1
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../nd-common

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -2,7 +2,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -87,7 +87,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.1 |
+| file://../nd-common | nd-common | 0.3.2 |
 
 ## Values
 

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -185,7 +185,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.1 |
+| file://../nd-common | nd-common | 0.3.2 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.4.0 |
 
 ## Values

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.7.2
+version: 1.7.3
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -330,7 +330,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.1 |
+| file://../nd-common | nd-common | 0.3.2 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.4.0 |
 
 ## Values

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -277,7 +277,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.1 |
+| file://../nd-common | nd-common | 0.3.2 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.4.0 |
 
 ## Values


### PR DESCRIPTION
We are trying to reduce ingested tags in the monolith by using a dogstatsd client that utilizes Vector instead of the Datadog Agent. The reason for this is because the Datadog Agent automatically includes some tags such has `host_id` and `instance_id`. By using vector we are able to more granularly control the global tags that are added to each metric. While we have made significant progress in reducing indexed tags cost, we are still ingesting all these tags which is becoming more significant portion of our metrics cost.

An issue I ran into while testing routing metrics via Vector is that the dogstatsd library reads `DD_ENTITY_ID` and will set that as a tag automatically if the environment variable is set. Right now, `container_id` is being set instead of reading from `DD_ENTITY_ID` and setting the `dd.internal.entity_id` tag. If this tag gets added automatically, we lose a lot of the potential gains since we have another unique tag that will explode cardinality. 

This PR proposes an opt-out for `DD_ENTITY_ID` and I would like to test that by opting out in our monolith flavors. I am hoping to get "cleaner" metrics with this variable being unset.

Example [test metric](https://app.datadoghq.com/metric/explorer?fromUser=true&start=1715800595409&end=1715803231679&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyCJwxAhQOG4AdAh4GowY2k4I5k4AbnCZCG5O+YXAAFQ8AAQARljTwFBQTaI92pFoTXAiEnJO0DxNGBpOmfi7ABQAlCA8ALpUru54mKHhz6qvGDGl8XePEAaORoHKgeQYUEIHrKBowM5vDQQTKJNCiODdBQ5IE4NFQVHopz0JjKERuDxoO78CD2TBYTGKZRomoAnh8IHyNEIADCUmEMBQIleaB4QA).