### PR TITLE
chore(charts/prometheus-alerts): add individual label settings per alert

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.7.2
+version: 1.7.3
 appVersion: 0.0.1
 maintainers:
   - name: diranged

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -2,7 +2,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -101,46 +101,57 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | alertManager.repeatInterval | string | `"1h"` | How long to wait before sending a notification again if it has already been sent successfully for an alert. (Usually ~3h or more). |
 | chart_name | string | `"prometheus-rules"` |  |
 | chart_source | string | `"https://github.com/Nextdoor/k8s-charts"` |  |
-| containerRules.daemonsets.DaemonsetSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| containerRules.daemonsets.DaemonsetSelectorValidity | object | `{"for":"1h","labels":{},"severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.daemonsets.KubeDaemonSetMisScheduled.for | string | `"15m"` |  |
+| containerRules.daemonsets.KubeDaemonSetMisScheduled.labels | object | `{}` |  |
 | containerRules.daemonsets.KubeDaemonSetMisScheduled.severity | string | `"warning"` |  |
 | containerRules.daemonsets.KubeDaemonSetNotScheduled.for | string | `"10m"` |  |
+| containerRules.daemonsets.KubeDaemonSetNotScheduled.labels | object | `{}` |  |
 | containerRules.daemonsets.KubeDaemonSetNotScheduled.severity | string | `"warning"` |  |
 | containerRules.daemonsets.KubeDaemonSetRolloutStuck.for | string | `"15m"` |  |
+| containerRules.daemonsets.KubeDaemonSetRolloutStuck.labels | object | `{}` |  |
 | containerRules.daemonsets.KubeDaemonSetRolloutStuck.severity | string | `"warning"` |  |
 | containerRules.daemonsets.enabled | bool | `true` | Enables the DaemonSet resource rules |
-| containerRules.deployments.DeploymentSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
-| containerRules.deployments.KubeDeploymentGenerationMismatch | object | `{"for":"15m","severity":"warning"}` | Deployment generation mismatch due to possible roll-back |
+| containerRules.deployments.DeploymentSelectorValidity | object | `{"for":"1h","labels":{},"severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| containerRules.deployments.KubeDeploymentGenerationMismatch | object | `{"for":"15m","labels":{},"severity":"warning"}` | Deployment generation mismatch due to possible roll-back |
 | containerRules.deployments.enabled | bool | `true` | Enables the Deployment resource rules |
 | containerRules.enabled | bool | `true` | Whether or not to enable the container rules template |
-| containerRules.hpas.HpaSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| containerRules.hpas.HpaSelectorValidity | object | `{"for":"1h","labels":{},"severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.hpas.KubeHpaMaxedOut.for | string | `"15m"` |  |
+| containerRules.hpas.KubeHpaMaxedOut.labels | object | `{}` |  |
 | containerRules.hpas.KubeHpaMaxedOut.severity | string | `"warning"` |  |
 | containerRules.hpas.KubeHpaReplicasMismatch.for | string | `"15m"` |  |
+| containerRules.hpas.KubeHpaReplicasMismatch.labels | object | `{}` |  |
 | containerRules.hpas.KubeHpaReplicasMismatch.severity | string | `"warning"` |  |
 | containerRules.hpas.enabled | bool | `true` | Enables the HorizontalPodAutoscaler resource rules |
-| containerRules.jobs.JobSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| containerRules.jobs.JobSelectorValidity | object | `{"for":"1h","labels":{},"severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.jobs.KubeJobCompletion.for | string | `"12h"` |  |
+| containerRules.jobs.KubeJobCompletion.labels | object | `{}` |  |
 | containerRules.jobs.KubeJobCompletion.severity | string | `"warning"` |  |
 | containerRules.jobs.KubeJobFailed.for | string | `"15m"` |  |
+| containerRules.jobs.KubeJobFailed.labels | object | `{}` |  |
 | containerRules.jobs.KubeJobFailed.severity | string | `"warning"` |  |
 | containerRules.jobs.enabled | bool | `true` | Enables the Job resource rules |
-| containerRules.pods.CPUThrottlingHigh | object | `{"for":"15m","severity":"warning","threshold":5}` | Container is being throttled by the CGroup - needs more resources. This value is appropriate for applications that are highly sensitive to request latency. Insensitive workloads might need to raise this percentage to avoid alert noise. |
+| containerRules.pods.CPUThrottlingHigh | object | `{"for":"15m","labels":{},"severity":"warning","threshold":5}` | Container is being throttled by the CGroup - needs more resources. This value is appropriate for applications that are highly sensitive to request latency. Insensitive workloads might need to raise this percentage to avoid alert noise. |
 | containerRules.pods.ContainerWaiting.for | string | `"1h"` |  |
+| containerRules.pods.ContainerWaiting.labels | object | `{}` |  |
 | containerRules.pods.ContainerWaiting.severity | string | `"warning"` |  |
-| containerRules.pods.PodContainerOOMKilled | object | `{"for":"1m","over":"60m","severity":"warning","threshold":0}` | Sums up all of the OOMKilled events per pod over the $over time (60m). If that number breaches the $threshold (0) for $for (1m), then it will alert. |
-| containerRules.pods.PodContainerTerminated | object | `{"for":"1m","over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
-| containerRules.pods.PodCrashLoopBackOff | object | `{"for":"10m","severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
-| containerRules.pods.PodNotReady | object | `{"for":"15m","severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
-| containerRules.pods.PodSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| containerRules.pods.PodContainerOOMKilled | object | `{"for":"1m","labels":{},"over":"60m","severity":"warning","threshold":0}` | Sums up all of the OOMKilled events per pod over the $over time (60m). If that number breaches the $threshold (0) for $for (1m), then it will alert. |
+| containerRules.pods.PodContainerTerminated | object | `{"for":"1m","labels":{},"over":"10m","reasons":["ContainerCannotRun","DeadlineExceeded"],"severity":"warning","threshold":0}` | Monitors Pods for Containers that are terminated either for unexpected reasons like ContainerCannotRun. If that number breaches the $threshold (1) for $for (1m), then it will alert. |
+| containerRules.pods.PodCrashLoopBackOff | object | `{"for":"10m","labels":{},"severity":"warning"}` | Pod is in a CrashLoopBackOff state and is not becoming healthy. |
+| containerRules.pods.PodNotReady | object | `{"for":"15m","labels":{},"severity":"warning"}` | Pod has been in a non-ready state for more than a specific threshold |
+| containerRules.pods.PodSelectorValidity | object | `{"for":"1h","labels":{},"severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.pods.enabled | bool | `true` | Enables the Pod resource rules |
 | containerRules.statefulsets.KubeStatefulSetGenerationMismatch.for | string | `"15m"` |  |
+| containerRules.statefulsets.KubeStatefulSetGenerationMismatch.labels | object | `{}` |  |
 | containerRules.statefulsets.KubeStatefulSetGenerationMismatch.severity | string | `"warning"` |  |
 | containerRules.statefulsets.KubeStatefulSetReplicasMismatch.for | string | `"15m"` |  |
+| containerRules.statefulsets.KubeStatefulSetReplicasMismatch.labels | object | `{}` |  |
 | containerRules.statefulsets.KubeStatefulSetReplicasMismatch.severity | string | `"warning"` |  |
 | containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut.for | string | `"15m"` |  |
+| containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut.labels | object | `{}` |  |
 | containerRules.statefulsets.KubeStatefulSetUpdateNotRolledOut.severity | string | `"warning"` |  |
-| containerRules.statefulsets.StatefulsetSelectorValidity | object | `{"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
+| containerRules.statefulsets.StatefulsetSelectorValidity | object | `{"for":"1h","labels":{},"severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | containerRules.statefulsets.enabled | bool | `true` | Enables the StatefulSet resource rules |
 | defaults.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.daemonsetNameSelector | `string` | `".*"` | Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -45,8 +45,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -72,8 +75,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -93,8 +99,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -119,8 +128,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -161,8 +173,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -195,8 +210,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -224,8 +242,11 @@ spec:
       labels:
         severity: {{ .severity }}
         namespace: {{ $.Release.Namespace }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -252,8 +273,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -280,8 +304,11 @@ spec:
       labels:
         severity: {{ .severity }}
         namespace: {{ $.Release.Namespace }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -313,8 +340,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -335,8 +365,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -369,8 +402,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -397,8 +433,11 @@ spec:
       labels:
         severity: {{ .severity }}
         namespace: {{ $.Release.Namespace }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -444,8 +483,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -465,8 +507,11 @@ spec:
       for: 10m
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -483,8 +528,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -511,8 +559,11 @@ spec:
       labels:
         severity: {{ .severity }}
         namespace: {{ $.Release.Namespace }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -538,8 +589,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -556,8 +610,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -584,8 +641,11 @@ spec:
       labels:
         severity: {{ .severity }}
         namespace: {{ $.Release.Namespace }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -625,8 +685,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -645,8 +708,11 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 
@@ -673,8 +739,11 @@ spec:
       labels:
         severity: {{ .severity }}
         namespace: {{ $.Release.Namespace }}
-        {{- if $.Values.defaults.additionalRuleLabels }}
-        {{ toYaml $.Values.defaults.additionalRuleLabels | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.defaults.additionalRuleLabels }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
 

--- a/charts/prometheus-alerts/values.local.yaml
+++ b/charts/prometheus-alerts/values.local.yaml
@@ -3,3 +3,36 @@ alertManager:
   enabled: true
   pagerduty:
     routing_key: abcdefg
+containerRules:
+  pods:
+    PodSelectorValidity: &testLabels
+      labels:
+        foo: bar
+        baz: bat
+    PodContainerTerminated: *testLabels
+    PodContainerOOMKilled: *testLabels
+    PodCrashLoopBackOff: *testLabels
+    PodNotReady: *testLabels
+    ContainerWaiting: *testLabels
+    CPUThrottlingHigh: *testLabels
+  deployments:
+    DeploymentSelectorValidity: *testLabels
+    KubeDeploymentGenerationMismatch: *testLabels
+  statefulsets:
+    StatefulsetSelectorValidity: *testLabels
+    KubeStatefulSetReplicasMismatch: *testLabels
+    KubeStatefulSetGenerationMismatch: *testLabels
+    KubeStatefulSetUpdateNotRolledOut: *testLabels
+  daemonsets:
+    DaemonsetSelectorValidity: *testLabels
+    KubeDaemonSetRolloutStuck: *testLabels
+    KubeDaemonSetNotScheduled: *testLabels
+    KubeDaemonSetMisScheduled: *testLabels
+  jobs:
+    JobSelectorValidity: *testLabels
+    KubeJobCompletion: *testLabels
+    KubeJobFailed: *testLabels
+  hpas:
+    HpaSelectorValidity: *testLabels
+    KubeHpaReplicasMismatch: *testLabels
+    KubeHpaMaxedOut: *testLabels

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -140,6 +140,7 @@ containerRules:
     PodSelectorValidity:
       severity: warning
       for: 1h
+      labels: {}
 
     # -- Monitors Pods for Containers that are terminated either for unexpected
     # reasons like ContainerCannotRun. If that number breaches the $threshold (1)
@@ -153,6 +154,7 @@ containerRules:
         # - Error  < when a container is evicted gracefully, the "error" state is used.
         - ContainerCannotRun
         - DeadlineExceeded
+      labels: {}
 
     # -- Sums up all of the OOMKilled events per pod over the $over time (60m). If
     # that number breaches the $threshold (0) for $for (1m), then it will alert.
@@ -161,21 +163,25 @@ containerRules:
       threshold: 0
       over: 60m
       for: 1m
+      labels: {}
 
     # -- Pod is in a CrashLoopBackOff state and is not becoming healthy.
     PodCrashLoopBackOff:
       severity: warning
       for: 10m
+      labels: {}
 
     # -- Pod has been in a non-ready state for more than a specific threshold
     PodNotReady:
       severity: warning
       for: 15m
+      labels: {}
 
     # Pod container waiting longer than threshold
     ContainerWaiting:
       severity: warning
       for: 1h
+      labels: {}
 
     # -- Container is being throttled by the CGroup - needs more resources.
     # This value is appropriate for applications that are highly sensitive to
@@ -185,6 +191,7 @@ containerRules:
       severity: warning
       threshold: 5
       for: 15m
+      labels: {}
 
   deployments:
     # -- Enables the Deployment resource rules
@@ -197,11 +204,13 @@ containerRules:
     DeploymentSelectorValidity:
       severity: warning
       for: 1h
+      labels: {}
 
     # -- Deployment generation mismatch due to possible roll-back
     KubeDeploymentGenerationMismatch:
       severity: warning
       for: 15m
+      labels: {}
 
   statefulsets:
     # -- Enables the StatefulSet resource rules
@@ -214,21 +223,25 @@ containerRules:
     StatefulsetSelectorValidity:
       severity: warning
       for: 1h
+      labels: {}
 
     # Deployment has not matched the expected number of replicas
     KubeStatefulSetReplicasMismatch:
       severity: warning
       for: 15m
+      labels: {}
 
     # StatefulSet generation mismatch due to possible roll-back
     KubeStatefulSetGenerationMismatch:
       severity: warning
       for: 15m
+      labels: {}
 
     # StatefulSet update has not been rolled out
     KubeStatefulSetUpdateNotRolledOut:
       severity: warning
       for: 15m
+      labels: {}
 
   daemonsets:
     # -- Enables the DaemonSet resource rules
@@ -241,21 +254,25 @@ containerRules:
     DaemonsetSelectorValidity:
       severity: warning
       for: 1h
+      labels: {}
 
     # DaemonSet rollout is stuck
     KubeDaemonSetRolloutStuck:
       severity: warning
       for: 15m
+      labels: {}
 
     # DaemonSet pods are not scheduled
     KubeDaemonSetNotScheduled:
       severity: warning
       for: 10m
+      labels: {}
 
     # DaemonSet pods are misscheduled
     KubeDaemonSetMisScheduled:
       severity: warning
       for: 15m
+      labels: {}
 
   jobs:
     # -- Enables the Job resource rules
@@ -268,16 +285,19 @@ containerRules:
     JobSelectorValidity:
       severity: warning
       for: 1h
+      labels: {}
 
     # Job did not complete in time
     KubeJobCompletion:
       severity: warning
       for: 12h
+      labels: {}
 
     # Job failed to complete
     KubeJobFailed:
       severity: warning
       for: 15m
+      labels: {}
 
   hpas:
     # -- Enables the HorizontalPodAutoscaler resource rules
@@ -290,13 +310,16 @@ containerRules:
     HpaSelectorValidity:
       severity: warning
       for: 1h
+      labels: {}
 
     # HPA has not matched descired number of replicas
     KubeHpaReplicasMismatch:
       severity: warning
       for: 15m
+      labels: {}
 
     # HPA is running at max replicas
     KubeHpaMaxedOut:
       severity: warning
       for: 15m
+      labels: {}


### PR DESCRIPTION
This is technically a feature - but it's so minor, I am considering it a patch. I'm just adding in an additional mechanism for setting individual labels on individual prometheus rules, which can be used to help route people to specific dashboards, or pass information to help routing the alerts in pagerduty.

Eg: Diff on `values.local.yaml`:

```diff
diranged@Matts-Macbook-Air prometheus-alerts % make template > new && diff -b -u orig new
install.go:218: [debug] Original chart version: ""
install.go:235: [debug] CHART PATH: /Users/diranged/git/nextdoor/k8s-charts/charts/prometheus-alerts

--- orig	2024-05-20 14:21:36
+++ new	2024-05-20 14:29:07
...
 Update Complete. ⎈Happy Helming!⎈
@@ -116,6 +116,8 @@
       for: 1m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: PodContainerOOMKilled
       annotations:
         summary: Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status
@@ -137,6 +139,8 @@
       for: 1m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: ContainerWaiting
       annotations:
         summary: Pod container waiting longer than 1h
@@ -152,6 +156,8 @@
       for: 1h
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: CPUThrottlingHigh
       annotations:
         summary: Processes experience elevated CPU throttling.
@@ -172,6 +178,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
   - name: prometheus-alerts.observability.kubernetesAppsRules
     rules:
     - alert: PodCrashLoopBackOff
@@ -194,6 +202,8 @@
       for: 10m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: PodNotReady
       annotations:
         summary: Pod has been in a non-ready state for more than 15m
@@ -222,6 +232,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
 
     - alert: PodSelectorValidity
       annotations:
@@ -246,6 +258,8 @@
       labels:
         severity: warning
         namespace: observability
+        baz: bat
+        foo: bar
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         summary: Deployment generation mismatch due to possible roll-back
@@ -262,6 +276,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
 
     - alert: DeploymentSelectorValidity
       annotations:
@@ -285,6 +301,8 @@
       labels:
         severity: warning
         namespace: observability
+        baz: bat
+        foo: bar
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         summary: StatefulSet has not matched the expected number of replicas.
@@ -306,6 +324,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         summary: StatefulSet generation mismatch due to possible roll-back
@@ -322,6 +342,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
         summary: StatefulSet update has not been rolled out.
@@ -350,6 +372,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
 
     - alert: StatefulsetSelectorValidity
       annotations:
@@ -373,6 +397,8 @@
       labels:
         severity: warning
         namespace: observability
+        baz: bat
+        foo: bar
     - alert: KubeDaemonSetRolloutStuck
       annotations:
         summary: DaemonSet rollout is stuck.
@@ -408,6 +434,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: KubeDaemonSetNotScheduled
       annotations:
         summary: DaemonSet pods are not scheduled.
@@ -423,6 +451,8 @@
       for: 10m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: KubeDaemonSetMisScheduled
       annotations:
         summary: DaemonSet pods are misscheduled.
@@ -435,6 +465,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
 
     - alert: DaemonsetSelectorValidity
       annotations:
@@ -458,6 +490,8 @@
       labels:
         severity: warning
         namespace: observability
+        baz: bat
+        foo: bar
     - alert: KubeJobCompletion
       annotations:
         summary: Job did not complete in time
@@ -473,6 +507,8 @@
       for: 12h
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: KubeJobFailed
       annotations:
         summary: Job failed to complete.
@@ -485,6 +521,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
 
     - alert: JobSelectorValidity
       annotations:
@@ -508,6 +546,8 @@
       labels:
         severity: warning
         namespace: observability
+        baz: bat
+        foo: bar
     - alert: KubeHpaReplicasMismatch
       annotations:
         summary: HPA has not matched descired number of replicas.
@@ -537,6 +577,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
     - alert: KubeHpaMaxedOut
       annotations:
         summary: HPA is running at max replicas
@@ -551,6 +593,8 @@
       for: 15m
       labels:
         severity: warning
+        baz: bat
+        foo: bar
 
     - alert: HpaSelectorValidity
       annotations:
@@ -574,3 +618,5 @@
       labels:
         severity: warning
         namespace: observability
+        baz: bat
+        foo: bar
```