### PR TITLE
fix(nd-common): mutating webhook not working for single pod istio proxy sidecar injection

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.3.1
+version: 0.3.2
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_istio.tpl
+++ b/charts/nd-common/templates/_istio.tpl
@@ -161,6 +161,7 @@ mesh.
 
 {{- /* https://istio.io/latest/docs/ops/configuration/mesh/injection-concepts/ */ -}}
 sidecar.istio.io/inject: {{ eq true .Values.istio.enabled | quote }}
+istio.io/rev: {{ .Values.istio.rev | default "stable" | quote }}
 
 {{- /*
 Explicitly disable or enable Metrics Merging - we want to keep our Envoy


### PR DESCRIPTION
The istio mutating webhook config can look something like this:

```
  Object Selector:
    Match Expressions:
      Key:       sidecar.istio.io/inject
      Operator:  NotIn
      Values:
        false
      Key:       istio.io/rev
      Operator:  In
      Values:
        stable
```

... for namespaces that are configured to be off the mesh, we'd need this change to allow single pods within that namespace to be a part of the mesh.