### PR TITLE
feat: enable maintenance mode (or custom HTTP fault injections)

### DIFF
--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.2.2
+version: 1.3.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -343,8 +343,11 @@ secretsEngine: sealed
 | virtualService.annotations | object | `{}` | Any annotations you wish to add to the `VirtualService` resource. See https://istio.io/latest/docs/reference/config/annotations/ for more details. |
 | virtualService.corsPolicy | `map` | `{}` | If set, this will populate the corsPolicy setting for the VirtualService. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy for more details. |
 | virtualService.enabled | Boolean | `false` | Maps the Service to an Istio IngressGateway, exposing the service outside of the Kubernetes cluster. |
+| virtualService.fault | `map` | `{}` | Pass in an optional [`HTTPFaultInjection`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection) configuration here to specify faults such as delaying or aborting the proxying of requests to the service.  If a configuration here is set, maintenanceMode.enabled MUST be set to 'false' (as that creates a very specific fault injection).  Otherwise, we fail to render the chart. |
 | virtualService.gateways | list | `[]` | The name of the Istio `Gateway` resource that this `VirtualService` will register with. You can get a list of the avaialable `Gateways` by running `kubectl -n istio-system get gateways`. Not specifying a Gateway means that you are creating a VirtualService routing definition only inside of the Kubernetes cluster, which is totally reasonable if you want to do that.  Must be in the form of $namespace/$gateway. Eg, "istio-system/default-gateway". |
 | virtualService.hosts | list | `["{{ include \"nd-common.fullname\" . }}"]` | A list of destination hostnames that this VirtualService will accept traffic for. Multiple names can be listed here. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService for more details. |
+| virtualService.maintenanceMode.enabled | `bool` | `false` | Set to true if you want to create a specialized HTTP fault injection that aborts the proxying of requests to your service. You can also set the HTTP response that is returned when this mode is set. |
+| virtualService.maintenanceMode.httpStatus | `int` | `503` | The HTTP response code that is returned when maintenanceMode is enabled. |
 | virtualService.matches | `map[]` | `{}` | A list of Istio `HTTPMatchRequest` objects that will be applied to the VirtualService. This is the more advanced and customizable way of controlling which paths get sent to your backend. These are added _in addition_ to the `paths` or `path` settings. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest for examples. |
 | virtualService.path | string | `"/"` | The default path prefix that the `VirtualService` will match requests against to pass to the default `Service` object in this deployment. |
 | virtualService.paths | `string[]` | `[]` | List of optional path prefixes that the `VirtualService` will use to match requests against and will pass to the `Service` object in this deployment. This list replaces the `path` prefix above - use one or the other, do not use both. |

--- a/charts/rollout-app/templates/hpa.yaml
+++ b/charts/rollout-app/templates/hpa.yaml
@@ -8,12 +8,17 @@ metadata:
     {{- include "nd-common.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
-    apiVersion: argoproj.io/v1alpha1{{ if $deactivateHpaForMaintenance }}-disabled{{ end }}
+    apiVersion: argoproj.io/v1alpha1
     kind: Rollout
     name: {{ include "nd-common.fullname" . }}
   {{- with .Values.autoscaling.behavior }}
   behavior:
+    {{- if $deactivateHpaForMaintenance }}
+    scaleDown:
+      selectPolicy: Disabled
+    {{- else }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/rollout-app/templates/hpa.yaml
+++ b/charts/rollout-app/templates/hpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
+{{ $deactivateHpaForMaintenance := (and .Values.autoscaling.enabled .Values.virtualService.enabled .Values.virtualService.maintenanceMode.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -7,7 +8,7 @@ metadata:
     {{- include "nd-common.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
-    apiVersion: argoproj.io/v1alpha1
+    apiVersion: argoproj.io/v1alpha1{{ if $deactivateHpaForMaintenance }}-disabled{{ end }}
     kind: Rollout
     name: {{ include "nd-common.fullname" . }}
   {{- with .Values.autoscaling.behavior }}

--- a/charts/rollout-app/templates/istio/virtualservice.yaml
+++ b/charts/rollout-app/templates/istio/virtualservice.yaml
@@ -81,6 +81,22 @@ spec:
               number: {{ .Values.virtualService.port }}
           weight: 0
         {{- end }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection */}}
+      {{- if and .Values.virtualService.maintenanceMode.enabled .Values.virtualService.fault }}
+      {{ fail "Both virtualService.maintenanceMode.enabled and virtualService.fault are set. Either set enabled to false or fault to {}" }}
+      {{- end }}
+      {{- if .Values.virtualService.maintenanceMode.enabled }}
+      fault:
+        abort:
+          httpStatus: {{ .Values.virtualService.maintenanceMode.httpStatus }}
+          percentage:
+            value: 100
+      {{- else }}
+      {{- with .Values.virtualService.fault }}
+      fault:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
 
   {{- with .Values.virtualService.tls }}
   tls:

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -13,9 +13,6 @@ spec:
   {{- end }}
   {{- if and .Values.replicaCount (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicaCount }}
-  {{- else if (and .Values.autoscaling.enabled .Values.virtualService.enabled .Values.virtualService.maintenanceMode.enabled) }}
-  {{- /* https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation */}}
-  replicas: 0
   {{- end }}
   {{- with .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ . }}

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -13,6 +13,9 @@ spec:
   {{- end }}
   {{- if and .Values.replicaCount (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicaCount }}
+  {{- else if (and .Values.autoscaling.enabled .Values.virtualService.enabled .Values.virtualService.maintenanceMode.enabled) }}
+  {{- /* https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation */}}
+  replicas: 0
   {{- end }}
   {{- with .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ . }}

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -471,6 +471,22 @@ virtualService:
   # "istio-system/default-gateway".
   gateways: []
 
+  # Maintenance mode creates a specific fault injection within your VirtualService
+  #
+  # If enabled, the generic `faults` option below MUST be empty "{}" (as this creates a very
+  # specified fault injection).
+  #
+  # Otherwise, we fail to render the chart.
+  maintenanceMode:
+
+    # -- (`bool`) Set to true if you want to create a specialized HTTP fault injection
+    # that aborts the proxying of requests to your service. You can also set the HTTP response that
+    # is returned when this mode is set.
+    enabled: false
+
+    # -- (`int`) The HTTP response code that is returned when maintenanceMode is enabled.
+    httpStatus: 503
+
   # -- The default path prefix that the `VirtualService` will match requests
   # against to pass to the default `Service` object in this deployment.
   path: '/'
@@ -492,6 +508,16 @@ virtualService:
   # configuration here to control how services retry their failed requests to
   # the backend service. The default behavior is to retry 2 times if a 503 is returned.
   retries: {}
+
+  # -- (`map`) Pass in an optional
+  # [`HTTPFaultInjection`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection)
+  # configuration here to specify faults such as delaying or aborting the proxying of requests to the service.
+  #
+  # If a configuration here is set, maintenanceMode.enabled MUST be set to 'false' (as that creates a very
+  # specific fault injection).
+  #
+  # Otherwise, we fail to render the chart.
+  fault: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.10.2
+version: 1.11.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.10.2](https://img.shields.io/badge/Version-1.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -481,8 +481,11 @@ secretsEngine: sealed
 | virtualService.annotations | object | `{}` | Any annotations you wish to add to the `VirtualService` resource. See https://istio.io/latest/docs/reference/config/annotations/ for more details. |
 | virtualService.corsPolicy | `map` | `{}` | If set, this will populate the corsPolicy setting for the VirtualService. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy for more details. |
 | virtualService.enabled | Boolean | `false` | Maps the Service to an Istio IngressGateway, exposing the service outside of the Kubernetes cluster. |
+| virtualService.fault | `map` | `{}` | Pass in an optional [`HTTPFaultInjection`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection) configuration here to specify faults such as delaying or aborting the proxying of requests to the service.  If a configuration here is set, maintenanceMode.enabled MUST be set to 'false' (as that creates a very specific fault injection).  Otherwise, we fail to render the chart. |
 | virtualService.gateways | list | `[]` | The name of the Istio `Gateway` resource that this `VirtualService` will register with. You can get a list of the avaialable `Gateways` by running `kubectl -n istio-system get gateways`. Not specifying a Gateway means that you are creating a VirtualService routing definition only inside of the Kubernetes cluster, which is totally reasonable if you want to do that.  Must be in the form of $namespace/$gateway. Eg, "istio-system/default-gateway". |
 | virtualService.hosts | list | `["{{ include \"nd-common.fullname\" . }}"]` | A list of destination hostnames that this VirtualService will accept traffic for. Multiple names can be listed here. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService for more details. |
+| virtualService.maintenanceMode.enabled | `bool` | `false` | Set to true if you want to create a specialized HTTP fault injection that aborts the proxying of requests to your service. You can also set the HTTP response that is returned when this mode is set. |
+| virtualService.maintenanceMode.httpStatus | `int` | `503` | The HTTP response code that is returned when maintenanceMode is enabled. |
 | virtualService.matches | `map[]` | `{}` | A list of Istio `HTTPMatchRequest` objects that will be applied to the VirtualService. This is the more advanced and customizable way of controlling which paths get sent to your backend. These are added _in addition_ to the `paths` or `path` settings. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest for examples. |
 | virtualService.path | string | `"/"` | The default path prefix that the `VirtualService` will match requests against to pass to the default `Service` object in this deployment. |
 | virtualService.paths | `string[]` | `[]` | List of optional path prefixes that the `VirtualService` will use to match requests against and will pass to the `Service` object in this deployment. This list replaces the `path` prefix above - use one or the other, do not use both. |

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -7,6 +7,7 @@ make sure that each Deployment is scaled up separately from the next one.
 */}}
 {{- $deploymentZones := default (list "default") .Values.deploymentZones }}
 
+{{- $deactivateHpaForMaintenance := false }}
 
 {{- /*
 ...
@@ -27,6 +28,7 @@ Verify that some required inputs are supplied
 
 {{- if .Values.virtualService.enabled }}
 {{- $readinessProbe := required "readinessProbe is required" .Values.readinessProbe }}
+{{- $deactivateHpaForMaintenance = (and .Values.virtualService.maintenanceMode.enabled .Values.autoscaling.enabled) }}
 {{- end }}
 
 {{- /*
@@ -79,6 +81,9 @@ spec:
   {{- end }}
   {{- if and $.Values.replicaCount (not $.Values.autoscaling.enabled) }}
   replicas: {{ $.Values.replicaCount }}
+  {{- else if $deactivateHpaForMaintenance }}
+  {{- /* https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation */}}
+  replicas: 0
   {{- end }}
   {{- with $.Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ . }}

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -81,9 +81,6 @@ spec:
   {{- end }}
   {{- if and $.Values.replicaCount (not $.Values.autoscaling.enabled) }}
   replicas: {{ $.Values.replicaCount }}
-  {{- else if $deactivateHpaForMaintenance }}
-  {{- /* https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation */}}
-  replicas: 0
   {{- end }}
   {{- with $.Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ . }}
@@ -324,7 +321,7 @@ metadata:
     {{- end }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: apps/v1{{ if $deactivateHpaForMaintenance }}-disabled{{ end }}
     kind: Deployment
     name: {{ $fullName }}
   {{- with $.Values.autoscaling.behavior }}

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -321,12 +321,17 @@ metadata:
     {{- end }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1{{ if $deactivateHpaForMaintenance }}-disabled{{ end }}
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ $fullName }}
   {{- with $.Values.autoscaling.behavior }}
   behavior:
+    {{- if $deactivateHpaForMaintenance }}
+    scaleDown:
+      selectPolicy: Disabled
+    {{- else }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   minReplicas: {{ $.Values.autoscaling.minReplicas }}
   maxReplicas: {{ $.Values.autoscaling.maxReplicas }}

--- a/charts/simple-app/templates/istio/virtualservice.yaml
+++ b/charts/simple-app/templates/istio/virtualservice.yaml
@@ -62,6 +62,22 @@ spec:
             host: {{ include "nd-common.serviceName" $ }}
             port:
               number: {{ .Values.virtualService.port }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection */}}
+      {{- if and .Values.virtualService.maintenanceMode.enabled .Values.virtualService.fault }}
+      {{ fail "Both virtualService.maintenanceMode.enabled and virtualService.fault are set. Either set enabled to false or fault to {}" }}
+      {{- end }}
+      {{- if .Values.virtualService.maintenanceMode.enabled }}
+      fault:
+        abort:
+          httpStatus: {{ .Values.virtualService.maintenanceMode.httpStatus }}
+          percentage:
+            value: 100
+      {{- else }}
+      {{- with .Values.virtualService.fault }}
+      fault:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
   {{- with .Values.virtualService.tls }}
   tls:
     {{- tpl . $global | nindent 4 }}

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -335,6 +335,23 @@ virtualService:
   # "istio-system/default-gateway".
   gateways: []
 
+  # Maintenance mode creates a specific fault injection within your VirtualService
+  #
+  # If enabled, the generic `faults` option below MUST be empty "{}" (as this creates a very
+  # specified fault injection).
+  #
+  # Otherwise, we fail to render the chart.
+  maintenanceMode:
+
+    # -- (`bool`) Set to true if you want to create a specialized HTTP fault injection
+    # that aborts the proxying of requests to your service. You can also set the HTTP response that
+    # is returned when this mode is set.
+    enabled: false
+
+    # -- (`int`) The HTTP response code that is returned when maintenanceMode is enabled.
+    httpStatus: 503
+
+
   # -- The default path prefix that the `VirtualService` will match requests
   # against to pass to the default `Service` object in this deployment.
   path: '/'
@@ -356,6 +373,16 @@ virtualService:
   # configuration here to control how services retry their failed requests to
   # the backend service. The default behavior is to retry 2 times if a 503 is returned.
   retries: {}
+
+  # -- (`map`) Pass in an optional
+  # [`HTTPFaultInjection`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection)
+  # configuration here to specify faults such as delaying or aborting the proxying of requests to the service.
+  #
+  # If a configuration here is set, maintenanceMode.enabled MUST be set to 'false' (as that creates a very
+  # specific fault injection).
+  #
+  # Otherwise, we fail to render the chart.
+  fault: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -405,8 +405,11 @@ secretsEngine: sealed
 | virtualService.annotations | object | `{}` | Any annotations you wish to add to the `VirtualService` resource. See https://istio.io/latest/docs/reference/config/annotations/ for more details. |
 | virtualService.corsPolicy | `map` | `{}` | If set, this will populate the corsPolicy setting for the VirtualService. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#CorsPolicy for more details. |
 | virtualService.enabled | Boolean | `false` | Maps the Service to an Istio IngressGateway, exposing the service outside of the Kubernetes cluster. |
+| virtualService.fault | `map` | `{}` | Pass in an optional [`HTTPFaultInjection`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection) configuration here to specify faults such as delaying or aborting the proxying of requests to the service.  If a configuration here is set, maintenanceMode.enabled MUST be set to 'false' (as that creates a very specific fault injection).  Otherwise, we fail to render the chart. |
 | virtualService.gateways | list | `[]` | The name of the Istio `Gateway` resource that this `VirtualService` will register with. You can get a list of the avaialable `Gateways` by running `kubectl -n istio-system get gateways`. Not specifying a Gateway means that you are creating a VirtualService routing definition only inside of the Kubernetes cluster, which is totally reasonable if you want to do that.  Must be in the form of $namespace/$gateway. Eg, "istio-system/default-gateway". |
 | virtualService.hosts | list | `["{{ include \"nd-common.fullname\" . }}"]` | A list of destination hostnames that this VirtualService will accept traffic for. Multiple names can be listed here. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService for more details. |
+| virtualService.maintenanceMode.enabled | `bool` | `false` | Set to true if you want to create a specialized HTTP fault injection that aborts the proxying of requests to your service. You can also set the HTTP response that is returned when this mode is set. |
+| virtualService.maintenanceMode.httpStatus | `int` | `503` | The HTTP response code that is returned when maintenanceMode is enabled. |
 | virtualService.matches | `map[]` | `{}` | A list of Istio `HTTPMatchRequest` objects that will be applied to the VirtualService. This is the more advanced and customizable way of controlling which paths get sent to your backend. These are added _in addition_ to the `paths` or `path` settings. See https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest for examples. |
 | virtualService.path | string | `"/"` | The default path prefix that the `VirtualService` will match requests against to pass to the default `Service` object in this deployment. |
 | virtualService.paths | `string[]` | `[]` | List of optional path prefixes that the `VirtualService` will use to match requests against and will pass to the `Service` object in this deployment. This list replaces the `path` prefix above - use one or the other, do not use both. |

--- a/charts/stateful-app/templates/istio/virtualservice.yaml
+++ b/charts/stateful-app/templates/istio/virtualservice.yaml
@@ -58,6 +58,22 @@ spec:
             host: {{ include "nd-common.serviceName" $ }}
             port:
               number: {{ .Values.virtualService.port }}
+      {{- /* https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection */}}
+      {{- if and .Values.virtualService.maintenanceMode.enabled .Values.virtualService.fault }}
+      {{ fail "Both virtualService.maintenanceMode.enabled and virtualService.fault are set. Either set enabled to false or fault to {}" }}
+      {{- end }}
+      {{- if .Values.virtualService.maintenanceMode.enabled }}
+      fault:
+        abort:
+          httpStatus: {{ .Values.virtualService.maintenanceMode.httpStatus }}
+          percentage:
+            value: 100
+      {{- else }}
+      {{- with .Values.virtualService.fault }}
+      fault:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
   {{- with .Values.virtualService.tls }}
   tls:
     {{- tpl . $global | nindent 4 }}

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -342,6 +342,22 @@ virtualService:
   # "istio-system/default-gateway".
   gateways: []
 
+  # Maintenance mode creates a specific fault injection within your VirtualService
+  #
+  # If enabled, the generic `faults` option below MUST be empty "{}" (as this creates a very
+  # specified fault injection).
+  #
+  # Otherwise, we fail to render the chart.
+  maintenanceMode:
+
+    # -- (`bool`) Set to true if you want to create a specialized HTTP fault injection
+    # that aborts the proxying of requests to your service. You can also set the HTTP response that
+    # is returned when this mode is set.
+    enabled: false
+
+    # -- (`int`) The HTTP response code that is returned when maintenanceMode is enabled.
+    httpStatus: 503
+
   # -- The default path prefix that the `VirtualService` will match requests
   # against to pass to the default `Service` object in this deployment.
   path: '/'
@@ -363,6 +379,16 @@ virtualService:
   # configuration here to control how services retry their failed requests to
   # the backend service. The default behavior is to retry 2 times if a 503 is returned.
   retries: {}
+
+  # -- (`map`) Pass in an optional
+  # [`HTTPFaultInjection`](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection)
+  # configuration here to specify faults such as delaying or aborting the proxying of requests to the service.
+  #
+  # If a configuration here is set, maintenanceMode.enabled MUST be set to 'false' (as that creates a very
+  # specific fault injection).
+  #
+  # Otherwise, we fail to render the chart.
+  fault: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Similar to `retries`, this PR allows users to inject custom `faults` too to their `VirtualService`: https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection

We also support an opinionated fault injection called `maintenanceMode`: this will create a 100% abort fault injection to abstract away the implementation from end users (it also [implicitly deactivates the HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation) while in maintenance mode)

The templates are smart enough to only render if either one of `maintenanceMode.enabled` or `faults` are set.