### PR TITLE
feat: analogous AuthorizationPolicies to NetworkPolicies for (Istio) multi-cluster access

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.3.2
+version: 0.3.3
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_authorizationpolicy.tpl
+++ b/charts/nd-common/templates/_authorizationpolicy.tpl
@@ -1,0 +1,81 @@
+{{- /*
+
+This function creates the following two AuthorizationPolicy objects:
+
+  1. To allow same-namespace access (this can probably be migrated to a
+     Kyverno ClusterPolicy that applies this on all namespaces, but for
+     now adding here for smooth transition for "allow" AuthorizationPolicies
+     to be created too)
+
+  2. To allowNamespaces to have ingress access to the service (a drop-in
+     replacement of the NetworkPolicy we make defunct when a service is to
+     be accessed from a multi-cluster setup
+
+These objects are generally pretty simple, but we re-use them in a few places
+and it's nice to have one common way to make them.
+
+AuthorizationPolicies can be used in lieu of NetworkPolicies in a multi-
+cluster setup
+
+Via https://istio.io/latest/docs/concepts/security/#allow-nothing-deny-all-and-allow-all-policy:
+
+> Note the “deny by default” behavior applies only if the workload has at least one authorization
+policy with the ALLOW action.
+
+- */}}
+{{- define "nd-common.authorizationPolicy" }}
+{{- if .Values.istio.enabled }}
+{{- /*
+
+Create a default AuthorizationPolicy that allows local namespace ingress
+
+See note above: after a while, wWe can probably have this as part of a
+Kyverno ClusterPolicy that's added to all namespaces.
+
+- */}}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-local-namespace-ingress
+spec:
+  selector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" . | nindent 6 }}
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        namespaces: [{{ .Release.Namespace }}]
+
+{{- if .Values.ports }}
+{{- if gt (len .Values.ports) 0 }}
+{{- if gt (len .Values.network.allowedNamespaces) 0 }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-{{ include "nd-common.fullname" . }}-ingress
+spec:
+  selector:
+    matchLabels:
+      {{- include "nd-common.selectorLabels" . | nindent 6 }}
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        namespaces:
+        {{- range .Values.network.allowedNamespaces }}
+        - {{ . | quote }}
+        {{- end }}
+    to:
+    - operation:
+        ports:
+        {{- range $port := .Values.ports }}
+        - {{ $port.containerPort | quote }}
+        {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/nd-common/templates/_authorizationpolicy.tpl
+++ b/charts/nd-common/templates/_authorizationpolicy.tpl
@@ -32,9 +32,7 @@ spec:
   - from:
     - source:
         namespaces: [{{ .Release.Namespace }}]
-{{- if .Values.ports }}
-{{- if gt (len .Values.ports) 0 }}
-{{- if gt (len .Values.network.allowedNamespaces) 0 }}
+  {{- if and .Values.ports (gt (len .Values.ports) 0) (gt (len .Values.network.allowedNamespaces) 0) }}
   - from:
     - source:
         namespaces:
@@ -45,8 +43,6 @@ spec:
         {{- range $port := .Values.ports }}
         - {{ $port.containerPort | quote }}
         {{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/nd-common/templates/_authorizationpolicy.tpl
+++ b/charts/nd-common/templates/_authorizationpolicy.tpl
@@ -38,11 +38,6 @@ spec:
   - from:
     - source:
         namespaces:
-        {{- /*
-        {{- range .Values.network.allowedNamespaces }}
-        - {{ . | quote }}
-        {{- end }}
-        */}}
         {{- toYaml .Values.network.allowedNamespaces | nindent 8 }}
     to:
     - operation:

--- a/charts/nd-common/templates/_networkpolicy.tpl
+++ b/charts/nd-common/templates/_networkpolicy.tpl
@@ -8,28 +8,6 @@ Kubernetes network, as our default is to block all traffic.
 */}}
 
 {{- define "nd-common.networkPolicy" }}
-{{- if .Values.network.multiCluster.allowFromRemote }}
-{{- /*
-
-NetworkPolicies can't enforce Ingress from **outside** the Kubernetes
-cluster - i.e., it only knows about cluster-local namespaces. So, we
-allow all and instead restrict with Istio's AuthorizationPolicy
-
-- */}}
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-for-multi-cluster-all-ingress
-  labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
-spec:
-  policyTypes: [Ingress]
-  podSelector:
-    matchLabels:
-      {{- include "nd-common.selectorLabels" . | nindent 6 }}
-  ingress:
-    - {}
-{{- else }}
 {{- if .Values.ports }}
 {{- if gt (len .Values.ports) 0 }}
 {{- if gt (len .Values.network.allowedNamespaces) 0 }}
@@ -45,6 +23,14 @@ spec:
     matchLabels:
       {{- include "nd-common.selectorLabels" . | nindent 6 }}
   ingress:
+    {{- if .Values.network.multiCluster.allowFromRemote }}
+    {{- /*
+      NetworkPolicies can't enforce Ingress from **outside** the Kubernetes
+      cluster - i.e., it only knows about cluster-local namespaces. So, we
+      allow all and instead restrict with Istio's AuthorizationPolicy
+    */}}
+    - {}
+    {{- else }}
     - ports:
       {{- range $port := .Values.ports }}
       - port: {{ $port.containerPort }}
@@ -60,7 +46,7 @@ spec:
               kubernetes.io/metadata.name: {{ . }}
         {{- end }}
         {{- end }}
-{{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/nd-common/templates/_networkpolicy.tpl
+++ b/charts/nd-common/templates/_networkpolicy.tpl
@@ -23,7 +23,7 @@ spec:
     matchLabels:
       {{- include "nd-common.selectorLabels" . | nindent 6 }}
   ingress:
-    {{- if .Values.network.multiCluster.allowFromRemote }}
+    {{- if .Values.network.allowAll }}
     {{- /*
       NetworkPolicies can't enforce Ingress from **outside** the Kubernetes
       cluster - i.e., it only knows about cluster-local namespaces. So, we

--- a/charts/nd-common/templates/_networkpolicy.tpl
+++ b/charts/nd-common/templates/_networkpolicy.tpl
@@ -8,9 +8,7 @@ Kubernetes network, as our default is to block all traffic.
 */}}
 
 {{- define "nd-common.networkPolicy" }}
-{{- if .Values.ports }}
-{{- if gt (len .Values.ports) 0 }}
-{{- if gt (len .Values.network.allowedNamespaces) 0 }}
+{{- if and .Values.ports (gt (len .Values.ports) 0) (gt (len .Values.network.allowedNamespaces) 0) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -47,7 +45,5 @@ spec:
         {{- end }}
         {{- end }}
     {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.2
+    version: 0.3.3
     repository: file://../nd-common

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.3.2
+version: 1.4.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -19,6 +19,16 @@ how these work, and the various custom resource definitions.
 ## Upgrade Notes
 
 ### 1.2.x -> 1.3.x
+
+**NEW: Allow access from cross-cluster, in-mesh services**
+
+`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
+access from other services running in a different cluster in a multi-cluter,
+multi-primary Istio environment.
+
+Also, beginning with this version, if your app is on the mesh, we'll create
+analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
+as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
@@ -206,7 +216,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.2 |
+| file://../nd-common | nd-common | 0.3.3 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values
@@ -299,7 +309,8 @@ secretsEngine: sealed
 | monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
-| network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
+| network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
+| network.multiCluster.allowFromRemote | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | nodeSelector | `map` | `{}` | A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | `Map` | `{}` | List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -22,13 +22,13 @@ how these work, and the various custom resource definitions.
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
-`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
-access from other services running in a different cluster in a multi-cluter,
-multi-primary Istio environment.
-
-Also, beginning with this version, if your app is on the mesh, we'll create
+Beginning with this version, if your app is on the mesh, we'll create
 analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
-as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+as they act as drop-in replacements for a multi-clustered, multi-primary setup.
+
+`network.allowAll`, if set, will update your NetworkPolicies to allow
+access from anywhere, including  other services running in a different
+cluster in a multi-cluter, multi-primary Istio environment.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
@@ -309,8 +309,8 @@ secretsEngine: sealed
 | monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
+| network.allowAll | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
-| network.multiCluster.allowFromRemote | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | nodeSelector | `map` | `{}` | A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | `Map` | `{}` | List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -18,7 +18,7 @@ how these work, and the various custom resource definitions.
 
 ## Upgrade Notes
 
-### 1.2.x -> 1.3.x
+### 1.3.x -> 1.4.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
@@ -29,6 +29,8 @@ as they act as drop-in replacements for a multi-clustered, multi-primary setup.
 `network.allowAll`, if set, will update your NetworkPolicies to allow
 access from anywhere, including  other services running in a different
 cluster in a multi-cluter, multi-primary Istio environment.
+
+### 1.2.x -> 1.3.x
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -21,13 +21,13 @@ how these work, and the various custom resource definitions.
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
-`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
-access from other services running in a different cluster in a multi-cluter,
-multi-primary Istio environment.
-
-Also, beginning with this version, if your app is on the mesh, we'll create
+Beginning with this version, if your app is on the mesh, we'll create
 analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
-as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+as they act as drop-in replacements for a multi-clustered, multi-primary setup.
+
+`network.allowAll`, if set, will update your NetworkPolicies to allow
+access from anywhere, including  other services running in a different
+cluster in a multi-cluter, multi-primary Istio environment.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -19,6 +19,16 @@ how these work, and the various custom resource definitions.
 
 ### 1.2.x -> 1.3.x
 
+**NEW: Allow access from cross-cluster, in-mesh services**
+
+`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
+access from other services running in a different cluster in a multi-cluter,
+multi-primary Istio environment.
+
+Also, beginning with this version, if your app is on the mesh, we'll create
+analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
+as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
 `virtualService.fault` allows you to set custom [HTTP fault injections](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection)

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -17,7 +17,7 @@ how these work, and the various custom resource definitions.
 
 ## Upgrade Notes
 
-### 1.2.x -> 1.3.x
+### 1.3.x -> 1.4.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
@@ -28,6 +28,8 @@ as they act as drop-in replacements for a multi-clustered, multi-primary setup.
 `network.allowAll`, if set, will update your NetworkPolicies to allow
 access from anywhere, including  other services running in a different
 cluster in a multi-cluter, multi-primary Istio environment.
+
+### 1.2.x -> 1.3.x
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/rollout-app/templates/authorizationpolicy.yaml
+++ b/charts/rollout-app/templates/authorizationpolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "nd-common.authorizationPolicy" . }}

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -813,12 +813,11 @@ network:
   # service-to-service communication grants.
   allowedNamespaces: []
 
-  multiCluster:
-    # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
-    # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
-    #
-    # This assumes your app is part of the Istio service mesh
-    allowFromRemote: false
+  # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
+  # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
+  #
+  # This assumes your app is part of the Istio service mesh
+  allowAll: false
 
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -805,13 +805,20 @@ istio:
 
 # Network access controls for the Pods in this application
 network:
-  # -- (`strings[]`) A list of namespaces that are allowed to access the Pods
-  # in this application. If not supplied, then no `NetworkPolicy` is created,
-  # and your application may be isolated to itself. Note, enabling
-    # `VirtualService` or `Ingress` configurations will create their own
+  # -- (`strings[]`) A list of namespaces that are allowed to access the Pods in
+  # this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy`
+  # is created, and your application may be isolated to itself. Note, enabling
+  # `VirtualService` or `Ingress` configurations will create their own
   # dedicated `NetworkPolicy` resources, so this is only intended for internal
   # service-to-service communication grants.
   allowedNamespaces: []
+
+  multiCluster:
+    # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
+    # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
+    #
+    # This assumes your app is part of the Istio service mesh
+    allowFromRemote: false
 
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.11.1
+version: 1.11.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.2
+    version: 0.3.3
     repository: file://../nd-common

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.11.2
+version: 1.12.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.11.2](https://img.shields.io/badge/Version-1.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -13,7 +13,7 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
-### 1.10.x -> 1.11.x
+### 1.11.x -> 1.12.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
@@ -24,6 +24,8 @@ as they act as drop-in replacements for a multi-clustered, multi-primary setup.
 `network.allowAll`, if set, will update your NetworkPolicies to allow
 access from anywhere, including  other services running in a different
 cluster in a multi-cluter, multi-primary Istio environment.
+
+### 1.10.x -> 1.11.x
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.11.1](https://img.shields.io/badge/Version-1.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.11.2](https://img.shields.io/badge/Version-1.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -14,6 +14,16 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 ## Upgrade Notes
 
 ### 1.10.x -> 1.11.x
+
+**NEW: Allow access from cross-cluster, in-mesh services**
+
+`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
+access from other services running in a different cluster in a multi-cluter,
+multi-primary Istio environment.
+
+Also, beginning with this version, if your app is on the mesh, we'll create
+analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
+as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
@@ -356,7 +366,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.2 |
+| file://../nd-common | nd-common | 0.3.3 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values
@@ -434,7 +444,8 @@ secretsEngine: sealed
 | monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
-| network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
+| network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
+| network.multiCluster.allowFromRemote | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | nodeSelector | `map` | `{}` | A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | `Map` | `{}` | List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -17,13 +17,13 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
-`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
-access from other services running in a different cluster in a multi-cluter,
-multi-primary Istio environment.
-
-Also, beginning with this version, if your app is on the mesh, we'll create
+Beginning with this version, if your app is on the mesh, we'll create
 analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
-as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+as they act as drop-in replacements for a multi-clustered, multi-primary setup.
+
+`network.allowAll`, if set, will update your NetworkPolicies to allow
+access from anywhere, including  other services running in a different
+cluster in a multi-cluter, multi-primary Istio environment.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
@@ -444,8 +444,8 @@ secretsEngine: sealed
 | monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
+| network.allowAll | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
-| network.multiCluster.allowFromRemote | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | nodeSelector | `map` | `{}` | A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | `Map` | `{}` | List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -14,6 +14,16 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ### 1.10.x -> 1.11.x
 
+**NEW: Allow access from cross-cluster, in-mesh services**
+
+`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
+access from other services running in a different cluster in a multi-cluter,
+multi-primary Istio environment.
+
+Also, beginning with this version, if your app is on the mesh, we'll create
+analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
+as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
 `virtualService.fault` allows you to set custom [HTTP fault injections](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection)

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -16,13 +16,13 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
-`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
-access from other services running in a different cluster in a multi-cluter,
-multi-primary Istio environment.
-
-Also, beginning with this version, if your app is on the mesh, we'll create
+Beginning with this version, if your app is on the mesh, we'll create
 analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
-as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+as they act as drop-in replacements for a multi-clustered, multi-primary setup.
+
+`network.allowAll`, if set, will update your NetworkPolicies to allow
+access from anywhere, including  other services running in a different
+cluster in a multi-cluter, multi-primary Istio environment.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -12,7 +12,7 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
-### 1.10.x -> 1.11.x
+### 1.11.x -> 1.12.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
@@ -23,6 +23,8 @@ as they act as drop-in replacements for a multi-clustered, multi-primary setup.
 `network.allowAll`, if set, will update your NetworkPolicies to allow
 access from anywhere, including  other services running in a different
 cluster in a multi-cluter, multi-primary Istio environment.
+
+### 1.10.x -> 1.11.x
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/simple-app/templates/authorizationpolicy.yaml
+++ b/charts/simple-app/templates/authorizationpolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "nd-common.authorizationPolicy" . }}

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -50,3 +50,5 @@ datadog:
 
 network:
   allowedNamespaces: [foo, bar]
+  multiCluster:
+    allowFromRemote: false

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -50,5 +50,4 @@ datadog:
 
 network:
   allowedNamespaces: [foo, bar]
-  multiCluster:
-    allowFromRemote: false
+  allowAll: false

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -693,12 +693,11 @@ network:
   # service-to-service communication grants.
   allowedNamespaces: []
 
-  multiCluster:
-    # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
-    # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
-    #
-    # This assumes your app is part of the Istio service mesh
-    allowFromRemote: false
+  # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
+  # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
+  #
+  # This assumes your app is part of the Istio service mesh
+  allowAll: false
 
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -685,13 +685,20 @@ priorityClassName: null
 
 # Network access controls for the Pods in this application
 network:
-  # -- (`strings[]`) A list of namespaces that are allowed to access the Pods
-  # in this application. If not supplied, then no `NetworkPolicy` is created,
-  # and your application may be isolated to itself. Note, enabling
-    # `VirtualService` or `Ingress` configurations will create their own
+  # -- (`strings[]`) A list of namespaces that are allowed to access the Pods in
+  # this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy`
+  # is created, and your application may be isolated to itself. Note, enabling
+  # `VirtualService` or `Ingress` configurations will create their own
   # dedicated `NetworkPolicy` resources, so this is only intended for internal
   # service-to-service communication grants.
   allowedNamespaces: []
+
+  multiCluster:
+    # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
+    # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
+    #
+    # This assumes your app is part of the Istio service mesh
+    allowFromRemote: false
 
 # Configures labels and other parameters assuming that the Datadog Agent is
 # installed on the underlying hosts and is part of the Kubernetes cluster.

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.2
+    version: 0.3.3
     repository: file://../nd-common

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.3.2
+version: 1.4.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -14,6 +14,16 @@ ServiceAccounts, Services, etc.
 ## Upgrade Notes
 
 ### 1.2.x -> 1.3.x
+
+**NEW: Allow access from cross-cluster, in-mesh services**
+
+`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
+access from other services running in a different cluster in a multi-cluter,
+multi-primary Istio environment.
+
+Also, beginning with this version, if your app is on the mesh, we'll create
+analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
+as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
@@ -297,7 +307,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.2 |
+| file://../nd-common | nd-common | 0.3.3 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values
@@ -359,7 +369,8 @@ secretsEngine: sealed
 | monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
-| network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
+| network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
+| network.multiCluster.allowFromRemote | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | nodeSelector | `map` | `{}` | A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | `Map` | `{}` | List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -13,7 +13,7 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
-### 1.2.x -> 1.3.x
+### 1.3.x -> 1.4.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
@@ -24,6 +24,8 @@ as they act as drop-in replacements for a multi-clustered, multi-primary setup.
 `network.allowAll`, if set, will update your NetworkPolicies to allow
 access from anywhere, including  other services running in a different
 cluster in a multi-cluter, multi-primary Istio environment.
+
+### 1.2.x -> 1.3.x
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -17,13 +17,13 @@ ServiceAccounts, Services, etc.
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
-`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
-access from other services running in a different cluster in a multi-cluter,
-multi-primary Istio environment.
-
-Also, beginning with this version, if your app is on the mesh, we'll create
+Beginning with this version, if your app is on the mesh, we'll create
 analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
-as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+as they act as drop-in replacements for a multi-clustered, multi-primary setup.
+
+`network.allowAll`, if set, will update your NetworkPolicies to allow
+access from anywhere, including  other services running in a different
+cluster in a multi-cluter, multi-primary Istio environment.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
@@ -369,8 +369,8 @@ secretsEngine: sealed
 | monitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | monitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | nameOverride | string | `""` |  |
+| network.allowAll | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | network.allowedNamespaces | `strings[]` | `[]` | A list of namespaces that are allowed to access the Pods in this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy` is created, and your application may be isolated to itself. Note, enabling `VirtualService` or `Ingress` configurations will create their own dedicated `NetworkPolicy` resources, so this is only intended for internal service-to-service communication grants. |
-| network.multiCluster.allowFromRemote | `bool` | `false` | If set to "True", then the NetworkPolicies will be opened up and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.  This assumes your app is part of the Istio service mesh |
 | nodeSelector | `map` | `{}` | A list of key/value pairs that will be added in to the nodeSelector spec for the pods. |
 | podAnnotations | `Map` | `{}` | List of Annotations to be added to the PodSpec |
 | podDisruptionBudget | object | `{"maxUnavailable":1}` | Set up a PodDisruptionBudget for the Deployment. See https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more details. |

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -14,6 +14,16 @@ ServiceAccounts, Services, etc.
 
 ### 1.2.x -> 1.3.x
 
+**NEW: Allow access from cross-cluster, in-mesh services**
+
+`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
+access from other services running in a different cluster in a multi-cluter,
+multi-primary Istio environment.
+
+Also, beginning with this version, if your app is on the mesh, we'll create
+analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
+as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 
 `virtualService.fault` allows you to set custom [HTTP fault injections](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection)

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -16,13 +16,13 @@ ServiceAccounts, Services, etc.
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
-`network.multiCluster.allowFromRemote` will tweak your NetworkPolicies to allow
-access from other services running in a different cluster in a multi-cluter,
-multi-primary Istio environment.
-
-Also, beginning with this version, if your app is on the mesh, we'll create
+Beginning with this version, if your app is on the mesh, we'll create
 analogous [AuthorizationPolicies](https://istio.io/latest/docs/reference/config/security/authorization-policy/) to the already existing NetworkPolicies,
-as they work in lieu of NetPols for a multi-clustered, multi-primary setup.
+as they act as drop-in replacements for a multi-clustered, multi-primary setup.
+
+`network.allowAll`, if set, will update your NetworkPolicies to allow
+access from anywhere, including  other services running in a different
+cluster in a multi-cluter, multi-primary Istio environment.
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -12,7 +12,7 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
-### 1.2.x -> 1.3.x
+### 1.3.x -> 1.4.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**
 
@@ -23,6 +23,9 @@ as they act as drop-in replacements for a multi-clustered, multi-primary setup.
 `network.allowAll`, if set, will update your NetworkPolicies to allow
 access from anywhere, including  other services running in a different
 cluster in a multi-cluter, multi-primary Istio environment.
+
+
+### 1.2.x -> 1.3.x
 
 **NEW: Maintenance Mode and Custom HTTP Fault Injections**
 

--- a/charts/stateful-app/templates/authorizationpolicy.yaml
+++ b/charts/stateful-app/templates/authorizationpolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "nd-common.authorizationPolicy" . }}

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -543,13 +543,20 @@ istio:
 
 # Network access controls for the Pods in this application.
 network:
-  # -- (`strings[]`) A list of namespaces that are allowed to access the Pods
-  # in this application. If not supplied, then no `NetworkPolicy` is created,
-  # and your application may be isolated to itself. Note, enabling
+  # -- (`strings[]`) A list of namespaces that are allowed to access the Pods in
+  # this application. If not supplied, then no `NetworkPolicy` or `AuthorizationPolicy`
+  # is created, and your application may be isolated to itself. Note, enabling
   # `VirtualService` or `Ingress` configurations will create their own
   # dedicated `NetworkPolicy` resources, so this is only intended for internal
   # service-to-service communication grants.
   allowedNamespaces: []
+
+  multiCluster:
+    # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
+    # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
+    #
+    # This assumes your app is part of the Istio service mesh
+    allowFromRemote: false
 
 # -- (`string`) Set a different priority class to the pods, by default the default priority class is given to pods.
 # Priority class could be used to prioritize pods over others and allow them to evict other pods with lower priorities.

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -551,12 +551,11 @@ network:
   # service-to-service communication grants.
   allowedNamespaces: []
 
-  multiCluster:
-    # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
-    # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
-    #
-    # This assumes your app is part of the Istio service mesh
-    allowFromRemote: false
+  # -- (`bool`) If set to "True", then the NetworkPolicies will be opened up
+  # and traffic auth will be managed by Istio's `AuthorizationPolicy` instead.
+  #
+  # This assumes your app is part of the Istio service mesh
+  allowAll: false
 
 # -- (`string`) Set a different priority class to the pods, by default the default priority class is given to pods.
 # Priority class could be used to prioritize pods over others and allow them to evict other pods with lower priorities.


### PR DESCRIPTION
## What this change does

In essence:

- If service has Istio enabled, adds `AuthorizationPolicy` that is _**analogous**_ to the existing `NetworkPolicy` that we already create (**this should be a no-op**).
- If service also enables ~`.Values.network.multiCluster.allowFromRemote`~  `.Values.network.allowAll`, we open up the NetworkPolicy to allow the AuthorizationPolicies above to take over its enforcement wholly.

## Why

To enable services in a multi-primary (Istio mesh), mult-cluster setup to be accessed from services in a different cluster (because NetworkPolicies can't enforce Ingress from **outside** the Kubernetes cluster without getting to CIDR ranges - i.e., it only knows about cluster-local namespaces. So, we allow all and instead restrict with Istio's AuthorizationPolicy)