### PR TITLE
chore: auto-add istio ingress gateway namespace to AuthorizationPolicy

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.3.4
+version: 0.3.5
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_authorizationpolicy.tpl
+++ b/charts/nd-common/templates/_authorizationpolicy.tpl
@@ -16,7 +16,6 @@ Via https://istio.io/latest/docs/concepts/security/#allow-nothing-deny-all-and-a
 policy with the ALLOW action.
 
 - */}}
-
 {{- define "nd-common.authorizationPolicy" }}
 {{- if and .Values.istio.enabled (.Capabilities.APIVersions.Has "security.istio.io/v1beta1") }}
 ---
@@ -45,6 +44,7 @@ spec:
         {{- range $port := .Values.ports }}
         - {{ $port.containerPort | quote }}
         {{- end }}
+  {{- end }}
   {{- if and .Values.virtualService.enabled (gt (len .Values.virtualService.gateways) 0) }}
   - from:
     - source:
@@ -59,7 +59,6 @@ spec:
         {{- range $port := .Values.ports }}
         - {{ $port.containerPort | quote }}
         {{- end }}
-  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.4
+    version: 0.3.5
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -218,7 +218,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.4 |
+| file://../nd-common | nd-common | 0.3.5 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.12.1
+version: 1.12.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.4
+    version: 0.3.5
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.12.1](https://img.shields.io/badge/Version-1.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.12.2](https://img.shields.io/badge/Version-1.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -368,7 +368,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.4 |
+| file://../nd-common | nd-common | 0.3.5 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -51,3 +51,8 @@ datadog:
 network:
   allowedNamespaces: [foo, bar]
   allowAll: false
+
+virtualService:
+  enabled: false
+  gateways:
+    - istio-gateways/foo-gateway

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.4
+    version: 0.3.5
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -309,7 +309,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.4 |
+| file://../nd-common | nd-common | 0.3.5 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values


### PR DESCRIPTION
Ref: https://github.com/Nextdoor/k8s-charts/pull/342

## Motivation

We have an `AuthorizationPolicy` where users can set allowedNamespaces. However, it's easy to miss the namespace of the ingress gateway that users may want their VirtualService tied to.

## What This Does

This parses the namespace of the istio gateways that users provide and ~creates a new list by appending it to the allowedNamespaces-provided list~ adds a separate rule for it

This is a safe assumption due to our checks of its format: https://github.com/Nextdoor/k8s-charts/blob/ca85ca6dedd25eb979e4f3f8240bd53cc424fa45/charts/simple-app/templates/istio/virtualservice.yaml#L19

## Test

Updated set `network.allowAll` and `virtualService.enabled` in values.local.yaml to `true...

Resulting relevant diff of `make template`:

### First Commit

```diff
--- /tmp/simple-app-orig.yaml	2024-10-29 19:55:03
+++ /tmp/simple-app-new.yaml	2024-10-29 19:57:33
...
@@ -424,7 +424,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.1
+    helm.sh/chart: simple-app-1.12.2
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -466,6 +466,7 @@
         namespaces:
         - foo
         - bar
+        - istio-gateways
     to:
     - operation:
         ports:
...
```

### Updated Commit

```diff
...
@@ -471,6 +471,15 @@
         ports:
         - "80"
         - "8443"
+  - from:
+    - source:
+        namespaces:
+        - "istio-gateways"
+    to:
+    - operation:
+        ports:
+        - "80"
+        - "8443"
 ---
...
```