### PR TITLE
chore(nd-common): cleanly install even if virtualService field not set

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.3.5
+version: 0.3.6
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_authorizationpolicy.tpl
+++ b/charts/nd-common/templates/_authorizationpolicy.tpl
@@ -45,20 +45,22 @@ spec:
         - {{ $port.containerPort | quote }}
         {{- end }}
   {{- end }}
-  {{- if and .Values.virtualService.enabled (gt (len .Values.virtualService.gateways) 0) }}
+  {{- with .Values.virtualService }}
+  {{- if and .enabled (gt (len .gateways) 0) }}
   - from:
     - source:
         namespaces:
-        {{- range .Values.virtualService.gateways }}
+        {{- range .gateways }}
         {{- $gwNamespace := first (splitList "/" .)  }}
         - {{ $gwNamespace | quote }}
         {{- end }}
     to:
     - operation:
         ports:
-        {{- range $port := .Values.ports }}
+        {{- range $port := $.Values.ports }}
         - {{ $port.containerPort | quote }}
         {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.5
+    version: 0.3.6
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -218,7 +218,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.5 |
+| file://../nd-common | nd-common | 0.3.6 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.12.2
+version: 1.12.3
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.5
+    version: 0.3.6
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.12.2](https://img.shields.io/badge/Version-1.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.12.3](https://img.shields.io/badge/Version-1.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -368,7 +368,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.5 |
+| file://../nd-common | nd-common | 0.3.6 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.5
+    version: 0.3.6
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -309,7 +309,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.5 |
+| file://../nd-common | nd-common | 0.3.6 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.2 |
 
 ## Values


### PR DESCRIPTION
## Why

There may be apps that pull in and sub-chart `nd-common` , but they don't have the `virtualService: *` key set in their values.

In those cases, helm install may fail when we added https://github.com/Nextdoor/k8s-charts/pull/344.

Slightly tweaking nd-common AuthPolicy template to render cleanly in those scenarios