### PR TITLE
chore: add version labels for all internal charts

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.16.0
+version: 0.16.1
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.3.1
+    version: 0.3.6
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -264,7 +264,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.3.1 |
+| file://../nd-common | nd-common | 0.3.6 |
 
 ## Values
 

--- a/charts/daemonset-app/templates/_helpers.tpl
+++ b/charts/daemonset-app/templates/_helpers.tpl
@@ -9,8 +9,8 @@ The additional labels include:
 {{- define "daemonset-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.chart/name" "daemonset-app"
-    "helm.chart/version" .Chart.Version
+    "helm.sh/chartName" "daemonset-app"
+    "helm.sh/chartVersion" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/daemonset-app/templates/_helpers.tpl
+++ b/charts/daemonset-app/templates/_helpers.tpl
@@ -1,24 +1,15 @@
-{{- define "stateful-app.proxyImageFqdn" -}}
-{{- $tag := .Values.proxySidecar.image.tag }}
-{{- if hasPrefix "sha256:" $tag }}
-{{- .Values.proxySidecar.image.repository }}@{{ $tag }}
-{{- else }}
-{{- .Values.proxySidecar.image.repository }}:{{ $tag }}
-{{- end }}
-{{- end }}
-
 {{/*
 This function generates an extended set of labels by combining the base labels 
 from the "nd-common.labels" template with additional custom labels. 
 
 The additional labels include:
-  - helm.chart/name: Specifies the name of the chart (hardcoded as "stateful-app").
+  - helm.chart/name: Specifies the name of the chart (hardcoded as "daemonset-app").
   - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
 */}}
 {{- define "nd-common.extendedLabels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.chart/name" "stateful-app"
+    "helm.chart/name" "daemonset-app"
     "helm.chart/version" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}

--- a/charts/daemonset-app/templates/_helpers.tpl
+++ b/charts/daemonset-app/templates/_helpers.tpl
@@ -6,7 +6,7 @@ The additional labels include:
   - helm.chart/name: Specifies the name of the chart (hardcoded as "daemonset-app").
   - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
 */}}
-{{- define "nd-common.extendedLabels" -}}
+{{- define "daemonset-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
     "helm.chart/name" "daemonset-app"

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "daemonset-app.labels" . | nindent 4 }}
 spec:
   {{- with .Values.minReadySeconds }}
   minReadySeconds: {{ . }}
@@ -30,7 +30,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.extendedLabels" . | nindent 8 }}
+        {{- include "daemonset-app.labels" . | nindent 8 }}
         {{- include "nd-common.istioLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   {{- with .Values.minReadySeconds }}
   minReadySeconds: {{ . }}
@@ -30,7 +30,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.labels" . | nindent 8 }}
+        {{- include "nd-common.extendedLabels" . | nindent 8 }}
         {{- include "nd-common.istioLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/daemonset-app/templates/prometheusrules.yaml
+++ b/charts/daemonset-app/templates/prometheusrules.yaml
@@ -8,7 +8,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/daemonset-app/templates/prometheusrules.yaml
+++ b/charts/daemonset-app/templates/prometheusrules.yaml
@@ -8,7 +8,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "daemonset-app.labels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/daemonset-app/templates/serviceaccount.yaml
+++ b/charts/daemonset-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/daemonset-app/templates/serviceaccount.yaml
+++ b/charts/daemonset-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "daemonset-app.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/

--- a/charts/rollout-app/templates/_helpers.tpl
+++ b/charts/rollout-app/templates/_helpers.tpl
@@ -41,3 +41,20 @@ Again, we do not use all of the values, we only use the values that make sense.
   name: {{ $port.name }}
 {{- end }}
 {{- end -}}
+
+{{/*
+This function generates an extended set of labels by combining the base labels 
+from the "nd-common.labels" template with additional custom labels. 
+
+The additional labels include:
+  - helm.chart/name: Specifies the name of the chart (hardcoded as "rollout-app").
+  - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
+*/}}
+{{- define "nd-common.extendedLabels" -}}
+{{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
+{{- $extendedLabels := merge $baseLabels (dict
+    "helm.chart/name" "rollout-app"
+    "helm.chart/version" .Chart.Version
+) -}}
+{{- $extendedLabels | toYaml -}}
+{{- end -}}

--- a/charts/rollout-app/templates/_helpers.tpl
+++ b/charts/rollout-app/templates/_helpers.tpl
@@ -53,8 +53,8 @@ The additional labels include:
 {{- define "rollout-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.chart/name" "rollout-app"
-    "helm.chart/version" .Chart.Version
+    "helm.sh/chartName" "rollout-app"
+    "helm.sh/chartVersion" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/rollout-app/templates/_helpers.tpl
+++ b/charts/rollout-app/templates/_helpers.tpl
@@ -50,7 +50,7 @@ The additional labels include:
   - helm.chart/name: Specifies the name of the chart (hardcoded as "rollout-app").
   - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
 */}}
-{{- define "nd-common.extendedLabels" -}}
+{{- define "rollout-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
     "helm.chart/name" "rollout-app"

--- a/charts/rollout-app/templates/hpa.yaml
+++ b/charts/rollout-app/templates/hpa.yaml
@@ -5,7 +5,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: argoproj.io/v1alpha1

--- a/charts/rollout-app/templates/hpa.yaml
+++ b/charts/rollout-app/templates/hpa.yaml
@@ -5,7 +5,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: argoproj.io/v1alpha1

--- a/charts/rollout-app/templates/ingress/ingress.yaml
+++ b/charts/rollout-app/templates/ingress/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   annotations:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/rollout-app/templates/ingress/ingress.yaml
+++ b/charts/rollout-app/templates/ingress/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/rollout-app/templates/ingress/networkpolicy.yaml
+++ b/charts/rollout-app/templates/ingress/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingress-access
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/rollout-app/templates/ingress/networkpolicy.yaml
+++ b/charts/rollout-app/templates/ingress/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingress-access
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/rollout-app/templates/istio/networkpolicy.yaml
+++ b/charts/rollout-app/templates/istio/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingressgateway-access
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/rollout-app/templates/istio/networkpolicy.yaml
+++ b/charts/rollout-app/templates/istio/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingressgateway-access
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/rollout-app/templates/istio/virtualservice.yaml
+++ b/charts/rollout-app/templates/istio/virtualservice.yaml
@@ -6,7 +6,7 @@ kind: VirtualService
 metadata:
   name: {{ include "nd-common.fullname" $ }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/rollout-app/templates/istio/virtualservice.yaml
+++ b/charts/rollout-app/templates/istio/virtualservice.yaml
@@ -6,7 +6,7 @@ kind: VirtualService
 metadata:
   name: {{ include "nd-common.fullname" $ }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/rollout-app/templates/poddisruptionbudget.yaml
+++ b/charts/rollout-app/templates/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/rollout-app/templates/poddisruptionbudget.yaml
+++ b/charts/rollout-app/templates/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/rollout-app/templates/prometheusrules.yaml
+++ b/charts/rollout-app/templates/prometheusrules.yaml
@@ -8,7 +8,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/rollout-app/templates/prometheusrules.yaml
+++ b/charts/rollout-app/templates/prometheusrules.yaml
@@ -8,7 +8,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -3,7 +3,7 @@ kind: Rollout
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   {{- with .Values.minReadySeconds }}
   minReadySeconds: {{ . }}
@@ -140,7 +140,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.labels" . | nindent 8 }}
+        {{- include "nd-common.extendedLabels" . | nindent 8 }}
         {{- include "nd-common.istioLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -3,7 +3,7 @@ kind: Rollout
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
 spec:
   {{- with .Values.minReadySeconds }}
   minReadySeconds: {{ . }}
@@ -140,7 +140,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.extendedLabels" . | nindent 8 }}
+        {{- include "rollout-app.labels" . | nindent 8 }}
         {{- include "nd-common.istioLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/rollout-app/templates/serviceaccount.yaml
+++ b/charts/rollout-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/rollout-app/templates/serviceaccount.yaml
+++ b/charts/rollout-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/rollout-app/templates/services.yaml
+++ b/charts/rollout-app/templates/services.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   annotations:
     {{/*
     This is only used for type=LoadBalancer Services which run in AWS.
@@ -40,7 +40,7 @@ kind: Service
 metadata:
   name: {{ include "nd-common.fullname" . }}-preview
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   annotations:
     {{/*
     This is only used for type=LoadBalancer Services which run in AWS.
@@ -73,7 +73,7 @@ kind: Service
 metadata:
   name: {{ include "nd-common.fullname" . }}-canary
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   annotations:
     {{/*
     This is only used for type=LoadBalancer Services which run in AWS.

--- a/charts/rollout-app/templates/services.yaml
+++ b/charts/rollout-app/templates/services.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
   annotations:
     {{/*
     This is only used for type=LoadBalancer Services which run in AWS.
@@ -40,7 +40,7 @@ kind: Service
 metadata:
   name: {{ include "nd-common.fullname" . }}-preview
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
   annotations:
     {{/*
     This is only used for type=LoadBalancer Services which run in AWS.
@@ -73,7 +73,7 @@ kind: Service
 metadata:
   name: {{ include "nd-common.fullname" . }}-canary
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "rollout-app.labels" . | nindent 4 }}
   annotations:
     {{/*
     This is only used for type=LoadBalancer Services which run in AWS.

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.12.3
+version: 1.12.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.12.3](https://img.shields.io/badge/Version-1.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.12.4](https://img.shields.io/badge/Version-1.12.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -11,3 +11,15 @@ setting.
 {{- .Values.proxySidecar.image.repository }}:{{ $tag }}
 {{- end }}
 {{- end }}
+
+{{- define "nd-common.extendedLabels" -}}
+{{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
+{{- $extendedLabels := merge $baseLabels (dict
+    "helm.chart.simple-app/version" .Chart.Version
+) -}}
+{{- $extendedLabels | toYaml -}}
+{{- end -}}
+
+
+
+

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -23,8 +23,8 @@ The additional labels include:
 {{- define "simple-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.chart/name" "simple-app"
-    "helm.chart/version" .Chart.Version
+    "helm.sh/chartName" "simple-app"
+    "helm.sh/chartVersion" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -19,7 +19,3 @@ setting.
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}
-
-
-
-

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -12,10 +12,19 @@ setting.
 {{- end }}
 {{- end }}
 
+{{/*
+This function generates an extended set of labels by combining the base labels 
+from the "nd-common.labels" template with additional custom labels. 
+
+The additional labels include:
+  - helm.chart/name: Specifies the name of the chart (hardcoded as "simple-app").
+  - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
+*/}}
 {{- define "nd-common.extendedLabels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.chart.simple-app/version" .Chart.Version
+    "helm.chart/name" "simple-app"
+    "helm.chart/version" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -20,7 +20,7 @@ The additional labels include:
   - helm.chart/name: Specifies the name of the chart (hardcoded as "simple-app").
   - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
 */}}
-{{- define "nd-common.extendedLabels" -}}
+{{- define "simple-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
     "helm.chart/name" "simple-app"

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -68,7 +68,7 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.extendedLabels" $ | nindent 4 }}
+    {{- include "simple-app.labels" $ | nindent 4 }}
     {{- with $deploymentZoneLabel }}
     {{ . }}
     {{- end }}
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.extendedLabels" $ | nindent 8 }}
+        {{- include "simple-app.labels" $ | nindent 8 }}
         {{- include "nd-common.istioLabels" $ | nindent 8 }}
         {{- with $.Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
@@ -315,7 +315,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.extendedLabels" $ | nindent 4 }}
+    {{- include "simple-app.labels" $ | nindent 4 }}
     {{- with $deploymentZoneLabel }}
     {{ . }}
     {{- end }}
@@ -369,7 +369,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.extendedLabels" $ | nindent 4 }}
+    {{- include "simple-app.labels" $ | nindent 4 }}
     {{- with $deploymentZoneLabel }}
     {{ . }}
     {{- end }}

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -68,7 +68,7 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.labels" $ | nindent 4 }}
+    {{- include "nd-common.extendedLabels" $ | nindent 4 }}
     {{- with $deploymentZoneLabel }}
     {{ . }}
     {{- end }}
@@ -105,7 +105,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.labels" $ | nindent 8 }}
+        {{- include "nd-common.extendedLabels" $ | nindent 8 }}
         {{- include "nd-common.istioLabels" $ | nindent 8 }}
         {{- with $.Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
@@ -315,7 +315,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.labels" $ | nindent 4 }}
+    {{- include "nd-common.extendedLabels" $ | nindent 4 }}
     {{- with $deploymentZoneLabel }}
     {{ . }}
     {{- end }}
@@ -369,7 +369,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.labels" $ | nindent 4 }}
+    {{- include "nd-common.extendedLabels" $ | nindent 4 }}
     {{- with $deploymentZoneLabel }}
     {{ . }}
     {{- end }}

--- a/charts/simple-app/templates/ingress/ingress.yaml
+++ b/charts/simple-app/templates/ingress/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   annotations:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/simple-app/templates/ingress/ingress.yaml
+++ b/charts/simple-app/templates/ingress/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "simple-app.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/simple-app/templates/ingress/networkpolicy.yaml
+++ b/charts/simple-app/templates/ingress/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingress-access
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/simple-app/templates/ingress/networkpolicy.yaml
+++ b/charts/simple-app/templates/ingress/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingress-access
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "simple-app.labels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/simple-app/templates/istio/networkpolicy.yaml
+++ b/charts/simple-app/templates/istio/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingressgateway-access
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/simple-app/templates/istio/networkpolicy.yaml
+++ b/charts/simple-app/templates/istio/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingressgateway-access
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "simple-app.labels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/simple-app/templates/istio/virtualservice.yaml
+++ b/charts/simple-app/templates/istio/virtualservice.yaml
@@ -6,7 +6,7 @@ kind: VirtualService
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "simple-app.labels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/simple-app/templates/istio/virtualservice.yaml
+++ b/charts/simple-app/templates/istio/virtualservice.yaml
@@ -6,7 +6,7 @@ kind: VirtualService
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/simple-app/templates/prometheusrules.yaml
+++ b/charts/simple-app/templates/prometheusrules.yaml
@@ -8,7 +8,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/simple-app/templates/prometheusrules.yaml
+++ b/charts/simple-app/templates/prometheusrules.yaml
@@ -8,7 +8,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "simple-app.labels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/simple-app/templates/serviceaccount.yaml
+++ b/charts/simple-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/simple-app/templates/serviceaccount.yaml
+++ b/charts/simple-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "simple-app.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/stateful-app/templates/_helpers.tpl
+++ b/charts/stateful-app/templates/_helpers.tpl
@@ -18,8 +18,8 @@ The additional labels include:
 {{- define "stateful-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.chart/name" "stateful-app"
-    "helm.chart/version" .Chart.Version
+    "helm.sh/chartName" "stateful-app"
+    "helm.sh/chartVersion" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/stateful-app/templates/_helpers.tpl
+++ b/charts/stateful-app/templates/_helpers.tpl
@@ -15,7 +15,7 @@ The additional labels include:
   - helm.chart/name: Specifies the name of the chart (hardcoded as "stateful-app").
   - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
 */}}
-{{- define "nd-common.extendedLabels" -}}
+{{- define "stateful-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
     "helm.chart/name" "stateful-app"

--- a/charts/stateful-app/templates/ingress/ingress.yaml
+++ b/charts/stateful-app/templates/ingress/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   annotations:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/stateful-app/templates/ingress/ingress.yaml
+++ b/charts/stateful-app/templates/ingress/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/stateful-app/templates/ingress/networkpolicy.yaml
+++ b/charts/stateful-app/templates/ingress/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingress-access
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/stateful-app/templates/ingress/networkpolicy.yaml
+++ b/charts/stateful-app/templates/ingress/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingress-access
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/stateful-app/templates/istio/networkpolicy.yaml
+++ b/charts/stateful-app/templates/istio/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingressgateway-access
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/stateful-app/templates/istio/networkpolicy.yaml
+++ b/charts/stateful-app/templates/istio/networkpolicy.yaml
@@ -5,7 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "nd-common.fullname" . }}-ingressgateway-access
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   policyTypes: [Ingress]
   podSelector:

--- a/charts/stateful-app/templates/istio/virtualservice.yaml
+++ b/charts/stateful-app/templates/istio/virtualservice.yaml
@@ -6,7 +6,7 @@ kind: VirtualService
 metadata:
   name: {{ include "nd-common.fullname" $ }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/stateful-app/templates/istio/virtualservice.yaml
+++ b/charts/stateful-app/templates/istio/virtualservice.yaml
@@ -6,7 +6,7 @@ kind: VirtualService
 metadata:
   name: {{ include "nd-common.fullname" $ }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   {{- with .Values.virtualService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/stateful-app/templates/poddisruptionbudget.yaml
+++ b/charts/stateful-app/templates/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/stateful-app/templates/poddisruptionbudget.yaml
+++ b/charts/stateful-app/templates/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/stateful-app/templates/prometheusrules.yaml
+++ b/charts/stateful-app/templates/prometheusrules.yaml
@@ -9,7 +9,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/stateful-app/templates/prometheusrules.yaml
+++ b/charts/stateful-app/templates/prometheusrules.yaml
@@ -9,7 +9,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-rules
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.PodRules

--- a/charts/stateful-app/templates/serviceaccount.yaml
+++ b/charts/stateful-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/stateful-app/templates/serviceaccount.yaml
+++ b/charts/stateful-app/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "nd-common.serviceAccountName" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -8,7 +8,7 @@ kind: StatefulSet
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.labels" . | nindent 4 }}
+    {{- include "nd-common.extendedLabels" . | nindent 4 }}
 spec:
   {{- with .Values.podManagementPolicy }}
   podManagementPolicy: {{ . }}
@@ -47,7 +47,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.labels" . | nindent 8 }}
+        {{- include "nd-common.extendedLabels" . | nindent 8 }}
         {{- include "nd-common.istioLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/stateful-app/templates/statefulset.yaml
+++ b/charts/stateful-app/templates/statefulset.yaml
@@ -8,7 +8,7 @@ kind: StatefulSet
 metadata:
   name: {{ include "nd-common.fullname" . }}
   labels:
-    {{- include "nd-common.extendedLabels" . | nindent 4 }}
+    {{- include "stateful-app.labels" . | nindent 4 }}
 spec:
   {{- with .Values.podManagementPolicy }}
   podManagementPolicy: {{ . }}
@@ -47,7 +47,7 @@ spec:
         {{- end }}
         {{- end }}
       labels:
-        {{- include "nd-common.extendedLabels" . | nindent 8 }}
+        {{- include "stateful-app.labels" . | nindent 8 }}
         {{- include "nd-common.istioLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}


### PR DESCRIPTION
### **Description:**

This PR introduces a new custom label function to all internal Helm charts. The purpose of this function is to enhance the visibility of Helm chart versioning for the applications using these charts.  

The new labels added by the function are:  
- `helm.chart/name`: Specifies the chart name (e.g., `simple-app`).  
- `helm.chart/version`: Reflects the chart version (`.Chart.Version`).  

### **Why is this change needed?**
1. **Improved Visibility:**  
   - These labels will allow us to track the Helm chart version deployed for each application easily.
   - It provides better observability into versioning at a glance.

2. **Grafana Dashboard Integration:**  
   - We will use this labeling information to create a Grafana dashboard that displays applications along with their corresponding Helm chart versions.

### **Example Usage:**
Here’s how the labels will look after applying this change:
```yaml
labels:
  helm.sh/chartName: "simple-app"
  helm.sh/chartVersion: "1.12.4"
  app.kubernetes.io/name: "simple-app"
  app.kubernetes.io/instance: "simple-app-instance"
```

### **Testing:**
- Verified that the generated manifests include the expected labels.
- Ensured no breaking changes to existing functionality.

### Simple-app diff
```diff
$ diff -u -b orig new
--- orig	2024-12-02 16:13:24
+++ new	2024-12-02 17:00:38
@@ -4,8 +4,8 @@
 ...Successfully got an update from the "flink-operator" chart repository
 ...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "strimzi" chart repository
-...Successfully got an update from the "jetstack" chart repository
 ...Successfully got an update from the "k8s-charts" chart repository
+...Successfully got an update from the "jetstack" chart repository
 ...Successfully got an update from the "argo" chart repository
 ...Successfully got an update from the "fairwinds-stable" chart repository
 Update Complete. ⎈Happy Helming!⎈
@@ -20,13 +20,15 @@
 metadata:
   name: simple-app-ingress-access
   labels:
-    helm.sh/chart: simple-app-1.12.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: simple-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "simple-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: simple-app
-    app.kubernetes.io/instance: simple-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chartName: simple-app
+    helm.sh/chartVersion: 1.12.4
+    tags.datadoghq.com/service: simple-app
+    tags.datadoghq.com/version: latest
 spec:
   policyTypes: [Ingress]
   podSelector:
@@ -46,7 +48,7 @@
 metadata:
   name: simple-app-ingress
   labels:
-    helm.sh/chart: simple-app-1.12.3
+    helm.sh/chart: simple-app-1.12.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -79,13 +81,15 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: simple-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "simple-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: simple-app
-    app.kubernetes.io/instance: simple-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chartName: simple-app
+    helm.sh/chartVersion: 1.12.4
+    tags.datadoghq.com/service: simple-app
+    tags.datadoghq.com/version: latest
 spec:
   selector:
     matchLabels:
@@ -100,13 +104,15 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: simple-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "simple-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: simple-app
-    app.kubernetes.io/instance: simple-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chartName: simple-app
+    helm.sh/chartVersion: 1.12.4
+    tags.datadoghq.com/service: simple-app
+    tags.datadoghq.com/version: latest
 ---
 # Source: simple-app/templates/secret.yaml
 apiVersion: v1
@@ -122,7 +128,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.3
+    helm.sh/chart: simple-app-1.12.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -155,7 +161,7 @@
 metadata:
   name: simple-app-metrics
   labels:
-    helm.sh/chart: simple-app-1.12.3
+    helm.sh/chart: simple-app-1.12.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -180,13 +186,15 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: simple-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "simple-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: simple-app
-    app.kubernetes.io/instance: simple-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chartName: simple-app
+    helm.sh/chartVersion: 1.12.4
+    tags.datadoghq.com/service: simple-app
+    tags.datadoghq.com/version: latest
 spec:
   revisionHistoryLimit: 3
   selector:
@@ -238,13 +246,15 @@
             }
           ]
       labels:
-        helm.sh/chart: simple-app-1.12.3
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/instance: simple-app
         app.kubernetes.io/managed-by: Helm
-        tags.datadoghq.com/service: "simple-app"
-        tags.datadoghq.com/version: "latest"
         app.kubernetes.io/name: simple-app
-        app.kubernetes.io/instance: simple-app
+        app.kubernetes.io/version: latest
+        helm.sh/chart: simple-app-1.12.4
+        helm.sh/chartName: simple-app
+        helm.sh/chartVersion: 1.12.4
+        tags.datadoghq.com/service: simple-app
+        tags.datadoghq.com/version: latest
         sidecar.istio.io/inject: "true"
         istio.io/rev: "stable"
         prometheus.istio.io/merge-metrics: "false"
@@ -334,13 +344,15 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: simple-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "simple-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: simple-app
-    app.kubernetes.io/instance: simple-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chartName: simple-app
+    helm.sh/chartVersion: 1.12.4
+    tags.datadoghq.com/service: simple-app
+    tags.datadoghq.com/version: latest
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -383,13 +395,15 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: simple-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "simple-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: simple-app
-    app.kubernetes.io/instance: simple-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chartName: simple-app
+    helm.sh/chartVersion: 1.12.4
+    tags.datadoghq.com/service: simple-app
+    tags.datadoghq.com/version: latest
   annotations:
     alb.ingress.kubernetes.io/tags: kubernetes_namespace=simple-app
 spec:
@@ -493,13 +507,15 @@
 metadata:
   name: simple-app-simple-app-rules
   labels:
-    helm.sh/chart: simple-app-1.12.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: simple-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "simple-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: simple-app
-    app.kubernetes.io/instance: simple-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chartName: simple-app
+    helm.sh/chartVersion: 1.12.4
+    tags.datadoghq.com/service: simple-app
+    tags.datadoghq.com/version: latest
 spec:
   groups:
   - name: simple-app.simple-app.simple-app.PodRules
@@ -693,7 +709,7 @@
 metadata:
   name: simple-app-monitor-rules
   labels:
-    helm.sh/chart: simple-app-1.12.3
+    helm.sh/chart: simple-app-1.12.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -717,7 +733,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.3
+    helm.sh/chart: simple-app-1.12.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -761,7 +777,7 @@
 metadata:
   name: "simple-app-test-connection"
   labels:
-    helm.sh/chart: simple-app-1.12.3
+    helm.sh/chart: simple-app-1.12.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
```

#### Stateful-app diff
```diff
$ diff -u -b orig new
--- orig	2024-12-02 16:13:34
+++ new	2024-12-02 17:00:47
@@ -20,13 +20,15 @@
 metadata:
   name: stateful-app-ingress-access
   labels:
-    helm.sh/chart: stateful-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: stateful-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "stateful-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: stateful-app
-    app.kubernetes.io/instance: stateful-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chartName: stateful-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: stateful-app
+    tags.datadoghq.com/version: latest
 spec:
   policyTypes: [Ingress]
   podSelector:
@@ -46,13 +48,15 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: stateful-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "stateful-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: stateful-app
-    app.kubernetes.io/instance: stateful-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chartName: stateful-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: stateful-app
+    tags.datadoghq.com/version: latest
 spec:
   selector:
     matchLabels:
@@ -67,13 +71,15 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: stateful-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "stateful-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: stateful-app
-    app.kubernetes.io/instance: stateful-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chartName: stateful-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: stateful-app
+    tags.datadoghq.com/version: latest
 ---
 # Source: stateful-app/templates/service.yaml
 apiVersion: v1
@@ -81,7 +87,7 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.3
+    helm.sh/chart: stateful-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -114,7 +120,7 @@
 metadata:
   name: stateful-app-metrics
   labels:
-    helm.sh/chart: stateful-app-1.4.3
+    helm.sh/chart: stateful-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -139,13 +145,15 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: stateful-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "stateful-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: stateful-app
-    app.kubernetes.io/instance: stateful-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chartName: stateful-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: stateful-app
+    tags.datadoghq.com/version: latest
 spec:
   replicas: 2
   revisionHistoryLimit: 3
@@ -198,13 +206,15 @@
             }
           ]
       labels:
-        helm.sh/chart: stateful-app-1.4.3
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/instance: stateful-app
         app.kubernetes.io/managed-by: Helm
-        tags.datadoghq.com/service: "stateful-app"
-        tags.datadoghq.com/version: "latest"
         app.kubernetes.io/name: stateful-app
-        app.kubernetes.io/instance: stateful-app
+        app.kubernetes.io/version: latest
+        helm.sh/chart: stateful-app-1.4.4
+        helm.sh/chartName: stateful-app
+        helm.sh/chartVersion: 1.4.4
+        tags.datadoghq.com/service: stateful-app
+        tags.datadoghq.com/version: latest
         sidecar.istio.io/inject: "true"
         istio.io/rev: "stable"
         prometheus.istio.io/merge-metrics: "false"
@@ -287,13 +297,15 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: stateful-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "stateful-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: stateful-app
-    app.kubernetes.io/instance: stateful-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chartName: stateful-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: stateful-app
+    tags.datadoghq.com/version: latest
   annotations:
     alb.ingress.kubernetes.io/tags: kubernetes_namespace=stateful-app
 spec:
@@ -397,13 +409,15 @@
 metadata:
   name: stateful-app-stateful-app-rules
   labels:
-    helm.sh/chart: stateful-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: stateful-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "stateful-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: stateful-app
-    app.kubernetes.io/instance: stateful-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chartName: stateful-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: stateful-app
+    tags.datadoghq.com/version: latest
 spec:
   groups:
   - name: stateful-app.stateful-app.stateful-app.PodRules
@@ -600,7 +614,7 @@
 metadata:
   name: stateful-app-monitor-rules
   labels:
-    helm.sh/chart: stateful-app-1.4.3
+    helm.sh/chart: stateful-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -624,7 +638,7 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.3
+    helm.sh/chart: stateful-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -668,7 +682,7 @@
 metadata:
   name: "stateful-app-test-connection"
   labels:
-    helm.sh/chart: stateful-app-1.4.3
+    helm.sh/chart: stateful-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
```

#### rollout-app diff
```diff
$ diff -u -b orig new
--- orig	2024-12-02 16:13:46
+++ new	2024-12-02 17:00:32
@@ -1,8 +1,8 @@
 Pulling dependencies in...
 helm dependency update .
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "flink-operator" chart repository
+...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "strimzi" chart repository
 ...Successfully got an update from the "k8s-charts" chart repository
 ...Successfully got an update from the "jetstack" chart repository
@@ -20,13 +20,15 @@
 metadata:
   name: rollout-app-ingress-access
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
 spec:
   policyTypes: [Ingress]
   podSelector:
@@ -46,7 +48,7 @@
 metadata:
   name: rollout-app-ingress
   labels:
-    helm.sh/chart: rollout-app-1.4.3
+    helm.sh/chart: rollout-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
@@ -79,13 +81,15 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
 spec:
   selector:
     matchLabels:
@@ -100,13 +104,15 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
 ---
 # Source: rollout-app/templates/secret.yaml
 apiVersion: v1
@@ -122,13 +128,15 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
   annotations:

     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: kubernetes_namespace=rollout-app
@@ -154,13 +162,15 @@
 metadata:
   name: rollout-app-preview
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
   annotations:

     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: kubernetes_namespace=rollout-app
@@ -186,13 +196,15 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
 spec:
   scaleTargetRef:
     apiVersion: argoproj.io/v1alpha1
@@ -235,13 +247,15 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
   annotations:
     alb.ingress.kubernetes.io/tags: kubernetes_namespace=rollout-app
 spec:
@@ -263,7 +277,7 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.3
+    helm.sh/chart: rollout-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
@@ -384,7 +398,7 @@
 metadata:
   name: rollout-app-monitor-rules
   labels:
-    helm.sh/chart: rollout-app-1.4.3
+    helm.sh/chart: rollout-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
@@ -408,13 +422,15 @@
 metadata:
   name: rollout-app-rollout-app-rules
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
 spec:
   groups:
   - name: rollout-app.rollout-app.rollout-app.PodRules
@@ -590,13 +606,15 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.3
-    app.kubernetes.io/version: "latest"
+    app.kubernetes.io/instance: rollout-app
     app.kubernetes.io/managed-by: Helm
-    tags.datadoghq.com/service: "rollout-app"
-    tags.datadoghq.com/version: "latest"
     app.kubernetes.io/name: rollout-app
-    app.kubernetes.io/instance: rollout-app
+    app.kubernetes.io/version: latest
+    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chartName: rollout-app
+    helm.sh/chartVersion: 1.4.4
+    tags.datadoghq.com/service: rollout-app
+    tags.datadoghq.com/version: latest
 spec:
   revisionHistoryLimit: 3
   selector:
@@ -653,13 +671,15 @@
             }
           ]
       labels:
-        helm.sh/chart: rollout-app-1.4.3
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/instance: rollout-app
         app.kubernetes.io/managed-by: Helm
-        tags.datadoghq.com/service: "rollout-app"
-        tags.datadoghq.com/version: "latest"
         app.kubernetes.io/name: rollout-app
-        app.kubernetes.io/instance: rollout-app
+        app.kubernetes.io/version: latest
+        helm.sh/chart: rollout-app-1.4.4
+        helm.sh/chartName: rollout-app
+        helm.sh/chartVersion: 1.4.4
+        tags.datadoghq.com/service: rollout-app
+        tags.datadoghq.com/version: latest
         sidecar.istio.io/inject: "true"
         istio.io/rev: "stable"
         prometheus.istio.io/merge-metrics: "false"
@@ -740,7 +760,7 @@
 metadata:
   name: "rollout-app-test-connection"
   labels:
-    helm.sh/chart: rollout-app-1.4.3
+    helm.sh/chart: rollout-app-1.4.4
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
```