### PR TITLE
chore: update version labels for all internal charts

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/daemonset-app/templates/_helpers.tpl
+++ b/charts/daemonset-app/templates/_helpers.tpl
@@ -3,14 +3,14 @@ This function generates an extended set of labels by combining the base labels
 from the "nd-common.labels" template with additional custom labels. 
 
 The additional labels include:
-  - helm.chart/name: Specifies the name of the chart (hardcoded as "daemonset-app").
-  - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
+  - helm.sh/chart-name: Specifies the name of the chart (hardcoded as "daemonset-app").
+  - helm.sh/chart-version: Includes the chart version dynamically from .Chart.Version.
 */}}
 {{- define "daemonset-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.sh/chartName" "daemonset-app"
-    "helm.sh/chartVersion" .Chart.Version
+    "helm.sh/chart-name" "daemonset-app"
+    "helm.sh/chart-version" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.4.4
+version: 1.4.5
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/

--- a/charts/rollout-app/templates/_helpers.tpl
+++ b/charts/rollout-app/templates/_helpers.tpl
@@ -47,14 +47,14 @@ This function generates an extended set of labels by combining the base labels
 from the "nd-common.labels" template with additional custom labels. 
 
 The additional labels include:
-  - helm.chart/name: Specifies the name of the chart (hardcoded as "rollout-app").
-  - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
+  - helm.sh/chart-name: Specifies the name of the chart (hardcoded as "rollout-app").
+  - helm.sh/chart-version: Includes the chart version dynamically from .Chart.Version.
 */}}
 {{- define "rollout-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.sh/chartName" "rollout-app"
-    "helm.sh/chartVersion" .Chart.Version
+    "helm.sh/chart-name" "rollout-app"
+    "helm.sh/chart-version" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.12.4
+version: 1.12.5
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.12.4](https://img.shields.io/badge/Version-1.12.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.12.5](https://img.shields.io/badge/Version-1.12.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/simple-app/templates/_helpers.tpl
+++ b/charts/simple-app/templates/_helpers.tpl
@@ -17,14 +17,14 @@ This function generates an extended set of labels by combining the base labels
 from the "nd-common.labels" template with additional custom labels. 
 
 The additional labels include:
-  - helm.chart/name: Specifies the name of the chart (hardcoded as "simple-app").
-  - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
+  - helm.sh/chart-name: Specifies the name of the chart (hardcoded as "simple-app").
+  - helm.sh/chart-version: Includes the chart version dynamically from .Chart.Version.
 */}}
 {{- define "simple-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.sh/chartName" "simple-app"
-    "helm.sh/chartVersion" .Chart.Version
+    "helm.sh/chart-name" "simple-app"
+    "helm.sh/chart-version" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.4.4
+version: 1.4.5
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/charts/stateful-app/templates/_helpers.tpl
+++ b/charts/stateful-app/templates/_helpers.tpl
@@ -12,14 +12,14 @@ This function generates an extended set of labels by combining the base labels
 from the "nd-common.labels" template with additional custom labels. 
 
 The additional labels include:
-  - helm.chart/name: Specifies the name of the chart (hardcoded as "stateful-app").
-  - helm.chart/version: Includes the chart version dynamically from .Chart.Version.
+  - helm.sh/chart-name: Specifies the name of the chart (hardcoded as "stateful-app").
+  - helm.sh/chart-version: Includes the chart version dynamically from .Chart.Version.
 */}}
 {{- define "stateful-app.labels" -}}
 {{- $baseLabels := include "nd-common.labels" . | fromYaml -}}
 {{- $extendedLabels := merge $baseLabels (dict
-    "helm.sh/chartName" "stateful-app"
-    "helm.sh/chartVersion" .Chart.Version
+    "helm.sh/chart-name" "stateful-app"
+    "helm.sh/chart-version" .Chart.Version
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}


### PR DESCRIPTION
This is follow up PR to https://github.com/Nextdoor/k8s-charts/pull/350. This just updates the label names to match kubernetes standards. 

```diff
$ diff -u -b orig new
--- orig	2024-12-03 17:20:49
+++ new	2024-12-03 17:17:01
@@ -3,12 +3,12 @@
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "flink-operator" chart repository
 ...Successfully got an update from the "codimd" chart repository
-...Successfully got an update from the "kedacore" chart repository
 ...Successfully got an update from the "strimzi" chart repository
+...Successfully got an update from the "kedacore" chart repository
 ...Successfully got an update from the "k8s-charts" chart repository
 ...Successfully got an update from the "jetstack" chart repository
-...Successfully got an update from the "fairwinds-stable" chart repository
 ...Successfully got an update from the "argo" chart repository
+...Successfully got an update from the "fairwinds-stable" chart repository
 Update Complete. ⎈Happy Helming!⎈
 Saving 2 charts
 Downloading istio-alerts from repo https://k8s-charts.nextdoor.com
@@ -25,9 +25,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: simple-app-1.12.4
-    helm.sh/chartName: simple-app
-    helm.sh/chartVersion: 1.12.4
+    helm.sh/chart: simple-app-1.12.5
+    helm.sh/chart-name: simple-app
+    helm.sh/chart-version: 1.12.5
     tags.datadoghq.com/service: simple-app
     tags.datadoghq.com/version: latest
 spec:
@@ -49,7 +49,7 @@
 metadata:
   name: simple-app-ingress
   labels:
-    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chart: simple-app-1.12.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -86,9 +86,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: simple-app-1.12.4
-    helm.sh/chartName: simple-app
-    helm.sh/chartVersion: 1.12.4
+    helm.sh/chart: simple-app-1.12.5
+    helm.sh/chart-name: simple-app
+    helm.sh/chart-version: 1.12.5
     tags.datadoghq.com/service: simple-app
     tags.datadoghq.com/version: latest
 spec:
@@ -109,9 +109,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: simple-app-1.12.4
-    helm.sh/chartName: simple-app
-    helm.sh/chartVersion: 1.12.4
+    helm.sh/chart: simple-app-1.12.5
+    helm.sh/chart-name: simple-app
+    helm.sh/chart-version: 1.12.5
     tags.datadoghq.com/service: simple-app
     tags.datadoghq.com/version: latest
 ---
@@ -129,7 +129,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chart: simple-app-1.12.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -162,7 +162,7 @@
 metadata:
   name: simple-app-metrics
   labels:
-    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chart: simple-app-1.12.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -191,9 +191,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: simple-app-1.12.4
-    helm.sh/chartName: simple-app
-    helm.sh/chartVersion: 1.12.4
+    helm.sh/chart: simple-app-1.12.5
+    helm.sh/chart-name: simple-app
+    helm.sh/chart-version: 1.12.5
     tags.datadoghq.com/service: simple-app
     tags.datadoghq.com/version: latest
 spec:
@@ -251,9 +251,9 @@
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: simple-app
         app.kubernetes.io/version: latest
-        helm.sh/chart: simple-app-1.12.4
-        helm.sh/chartName: simple-app
-        helm.sh/chartVersion: 1.12.4
+        helm.sh/chart: simple-app-1.12.5
+        helm.sh/chart-name: simple-app
+        helm.sh/chart-version: 1.12.5
         tags.datadoghq.com/service: simple-app
         tags.datadoghq.com/version: latest
         sidecar.istio.io/inject: "true"
@@ -349,9 +349,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: simple-app-1.12.4
-    helm.sh/chartName: simple-app
-    helm.sh/chartVersion: 1.12.4
+    helm.sh/chart: simple-app-1.12.5
+    helm.sh/chart-name: simple-app
+    helm.sh/chart-version: 1.12.5
     tags.datadoghq.com/service: simple-app
     tags.datadoghq.com/version: latest
 spec:
@@ -400,9 +400,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: simple-app-1.12.4
-    helm.sh/chartName: simple-app
-    helm.sh/chartVersion: 1.12.4
+    helm.sh/chart: simple-app-1.12.5
+    helm.sh/chart-name: simple-app
+    helm.sh/chart-version: 1.12.5
     tags.datadoghq.com/service: simple-app
     tags.datadoghq.com/version: latest
   annotations:
@@ -512,9 +512,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: simple-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: simple-app-1.12.4
-    helm.sh/chartName: simple-app
-    helm.sh/chartVersion: 1.12.4
+    helm.sh/chart: simple-app-1.12.5
+    helm.sh/chart-name: simple-app
+    helm.sh/chart-version: 1.12.5
     tags.datadoghq.com/service: simple-app
     tags.datadoghq.com/version: latest
 spec:
@@ -710,7 +710,7 @@
 metadata:
   name: simple-app-monitor-rules
   labels:
-    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chart: simple-app-1.12.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -734,7 +734,7 @@
 metadata:
   name: simple-app
   labels:
-    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chart: simple-app-1.12.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
@@ -778,7 +778,7 @@
 metadata:
   name: "simple-app-test-connection"
   labels:
-    helm.sh/chart: simple-app-1.12.4
+    helm.sh/chart: simple-app-1.12.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "simple-app"
```

```diff
$ diff -u -b orig new
--- orig	2024-12-03 17:21:09
+++ new	2024-12-03 17:17:19
@@ -1,12 +1,12 @@
 Pulling dependencies in...
 helm dependency update .
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "flink-operator" chart repository
+...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "kedacore" chart repository
 ...Successfully got an update from the "strimzi" chart repository
-...Successfully got an update from the "jetstack" chart repository
 ...Successfully got an update from the "k8s-charts" chart repository
+...Successfully got an update from the "jetstack" chart repository
 ...Successfully got an update from the "argo" chart repository
 ...Successfully got an update from the "fairwinds-stable" chart repository
 Update Complete. ⎈Happy Helming!⎈
@@ -25,9 +25,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stateful-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: stateful-app-1.4.4
-    helm.sh/chartName: stateful-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: stateful-app-1.4.5
+    helm.sh/chart-name: stateful-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: stateful-app
     tags.datadoghq.com/version: latest
 spec:
@@ -53,9 +53,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stateful-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: stateful-app-1.4.4
-    helm.sh/chartName: stateful-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: stateful-app-1.4.5
+    helm.sh/chart-name: stateful-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: stateful-app
     tags.datadoghq.com/version: latest
 spec:
@@ -76,9 +76,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stateful-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: stateful-app-1.4.4
-    helm.sh/chartName: stateful-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: stateful-app-1.4.5
+    helm.sh/chart-name: stateful-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: stateful-app
     tags.datadoghq.com/version: latest
 ---
@@ -88,7 +88,7 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chart: stateful-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -121,7 +121,7 @@
 metadata:
   name: stateful-app-metrics
   labels:
-    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chart: stateful-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -150,9 +150,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stateful-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: stateful-app-1.4.4
-    helm.sh/chartName: stateful-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: stateful-app-1.4.5
+    helm.sh/chart-name: stateful-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: stateful-app
     tags.datadoghq.com/version: latest
 spec:
@@ -211,9 +211,9 @@
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: stateful-app
         app.kubernetes.io/version: latest
-        helm.sh/chart: stateful-app-1.4.4
-        helm.sh/chartName: stateful-app
-        helm.sh/chartVersion: 1.4.4
+        helm.sh/chart: stateful-app-1.4.5
+        helm.sh/chart-name: stateful-app
+        helm.sh/chart-version: 1.4.5
         tags.datadoghq.com/service: stateful-app
         tags.datadoghq.com/version: latest
         sidecar.istio.io/inject: "true"
@@ -302,9 +302,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stateful-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: stateful-app-1.4.4
-    helm.sh/chartName: stateful-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: stateful-app-1.4.5
+    helm.sh/chart-name: stateful-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: stateful-app
     tags.datadoghq.com/version: latest
   annotations:
@@ -414,9 +414,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: stateful-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: stateful-app-1.4.4
-    helm.sh/chartName: stateful-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: stateful-app-1.4.5
+    helm.sh/chart-name: stateful-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: stateful-app
     tags.datadoghq.com/version: latest
 spec:
@@ -615,7 +615,7 @@
 metadata:
   name: stateful-app-monitor-rules
   labels:
-    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chart: stateful-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -639,7 +639,7 @@
 metadata:
   name: stateful-app
   labels:
-    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chart: stateful-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
@@ -683,7 +683,7 @@
 metadata:
   name: "stateful-app-test-connection"
   labels:
-    helm.sh/chart: stateful-app-1.4.4
+    helm.sh/chart: stateful-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "stateful-app"
```

```diff
$ diff -u -b orig new
--- orig	2024-12-03 17:21:02
+++ new	2024-12-03 17:17:25
@@ -1,8 +1,8 @@
 Pulling dependencies in...
 helm dependency update .
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "flink-operator" chart repository
+...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "kedacore" chart repository
 ...Successfully got an update from the "strimzi" chart repository
 ...Successfully got an update from the "k8s-charts" chart repository
@@ -25,9 +25,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
 spec:
@@ -49,7 +49,7 @@
 metadata:
   name: rollout-app-ingress
   labels:
-    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chart: rollout-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
@@ -86,9 +86,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
 spec:
@@ -109,9 +109,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
 ---
@@ -133,9 +133,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
   annotations:
@@ -167,9 +167,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
   annotations:
@@ -201,9 +201,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
 spec:
@@ -252,9 +252,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
   annotations:
@@ -278,7 +278,7 @@
 metadata:
   name: rollout-app
   labels:
-    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chart: rollout-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
@@ -399,7 +399,7 @@
 metadata:
   name: rollout-app-monitor-rules
   labels:
-    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chart: rollout-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
@@ -427,9 +427,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
 spec:
@@ -611,9 +611,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rollout-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: rollout-app-1.4.4
-    helm.sh/chartName: rollout-app
-    helm.sh/chartVersion: 1.4.4
+    helm.sh/chart: rollout-app-1.4.5
+    helm.sh/chart-name: rollout-app
+    helm.sh/chart-version: 1.4.5
     tags.datadoghq.com/service: rollout-app
     tags.datadoghq.com/version: latest
 spec:
@@ -676,9 +676,9 @@
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rollout-app
         app.kubernetes.io/version: latest
-        helm.sh/chart: rollout-app-1.4.4
-        helm.sh/chartName: rollout-app
-        helm.sh/chartVersion: 1.4.4
+        helm.sh/chart: rollout-app-1.4.5
+        helm.sh/chart-name: rollout-app
+        helm.sh/chart-version: 1.4.5
         tags.datadoghq.com/service: rollout-app
         tags.datadoghq.com/version: latest
         sidecar.istio.io/inject: "true"
@@ -761,7 +761,7 @@
 metadata:
   name: "rollout-app-test-connection"
   labels:
-    helm.sh/chart: rollout-app-1.4.4
+    helm.sh/chart: rollout-app-1.4.5
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "rollout-app"
```

```diff
$ diff -u -b orig new
--- orig	2024-12-03 17:20:58
+++ new	2024-12-03 17:17:13
@@ -5,10 +5,10 @@
 ...Successfully got an update from the "codimd" chart repository
 ...Successfully got an update from the "kedacore" chart repository
 ...Successfully got an update from the "strimzi" chart repository
-...Successfully got an update from the "k8s-charts" chart repository
 ...Successfully got an update from the "jetstack" chart repository
-...Successfully got an update from the "argo" chart repository
+...Successfully got an update from the "k8s-charts" chart repository
 ...Successfully got an update from the "fairwinds-stable" chart repository
+...Successfully got an update from the "argo" chart repository
 Update Complete. ⎈Happy Helming!⎈
 Saving 1 charts
 Deleting outdated charts
@@ -20,7 +20,7 @@
 metadata:
   name: daemonset-app-ingress
   labels:
-    helm.sh/chart: daemonset-app-0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "daemonset-app"
@@ -50,9 +50,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: daemonset-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: daemonset-app-0.16.1
-    helm.sh/chartName: daemonset-app
-    helm.sh/chartVersion: 0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
+    helm.sh/chart-name: daemonset-app
+    helm.sh/chart-version: 0.16.2
     tags.datadoghq.com/service: daemonset-app
     tags.datadoghq.com/version: latest
 ---
@@ -62,7 +62,7 @@
 metadata:
   name: daemonset-app
   labels:
-    helm.sh/chart: daemonset-app-0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "daemonset-app"
@@ -91,7 +91,7 @@
 metadata:
   name: daemonset-app-metrics
   labels:
-    helm.sh/chart: daemonset-app-0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "daemonset-app"
@@ -120,9 +120,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: daemonset-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: daemonset-app-0.16.1
-    helm.sh/chartName: daemonset-app
-    helm.sh/chartVersion: 0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
+    helm.sh/chart-name: daemonset-app
+    helm.sh/chart-version: 0.16.2
     tags.datadoghq.com/service: daemonset-app
     tags.datadoghq.com/version: latest
 spec:
@@ -159,9 +159,9 @@
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: daemonset-app
         app.kubernetes.io/version: latest
-        helm.sh/chart: daemonset-app-0.16.1
-        helm.sh/chartName: daemonset-app
-        helm.sh/chartVersion: 0.16.1
+        helm.sh/chart: daemonset-app-0.16.2
+        helm.sh/chart-name: daemonset-app
+        helm.sh/chart-version: 0.16.2
         tags.datadoghq.com/service: daemonset-app
         tags.datadoghq.com/version: latest
         sidecar.istio.io/inject: "false"
@@ -236,9 +236,9 @@
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: daemonset-app
     app.kubernetes.io/version: latest
-    helm.sh/chart: daemonset-app-0.16.1
-    helm.sh/chartName: daemonset-app
-    helm.sh/chartVersion: 0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
+    helm.sh/chart-name: daemonset-app
+    helm.sh/chart-version: 0.16.2
     tags.datadoghq.com/service: daemonset-app
     tags.datadoghq.com/version: latest
 spec:
@@ -436,7 +436,7 @@
 metadata:
   name: daemonset-app-monitor-rules
   labels:
-    helm.sh/chart: daemonset-app-0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "daemonset-app"
@@ -460,7 +460,7 @@
 metadata:
   name: daemonset-app
   labels:
-    helm.sh/chart: daemonset-app-0.16.1
+    helm.sh/chart: daemonset-app-0.16.2
     app.kubernetes.io/version: "latest"
     app.kubernetes.io/managed-by: Helm
     tags.datadoghq.com/service: "daemonset-app"
```