### PR TITLE
fix(istio-alerts): Fix istio alerts conflict issue

### DIFF
--- a/charts/istio-alerts/Chart.yaml
+++ b/charts/istio-alerts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: istio-alerts
 description: A Helm chart that provisions a series of alerts for istio VirtualServices
 type: application
-version: 0.5.3
+version: 0.5.4
 maintainers:
   - name: diranged
     email: matt@nextdoor.com

--- a/charts/istio-alerts/README.md
+++ b/charts/istio-alerts/README.md
@@ -1,6 +1,6 @@
 # istio-alerts
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart that provisions a series of alerts for istio VirtualServices
 
@@ -45,7 +45,7 @@ source workload using the `source_workload` label, and will alert if any
 | chart_source | string | `"https://github.com/Nextdoor/k8s-charts"` |  |
 | defaults.additionalRuleLabels | object | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.runbookUrl | string | `"https://github.com/Nextdoor/k8s-charts/blob/main/charts/istio-alerts/runbook.md"` | The prefix URL to the runbook_urls that will be applied to each PrometheusRule |
-| serviceRules.destinationServiceName | string | `".*"` | Narrow down the alerts to a particular Destination Service if there are multiple services that require different thresholds within the same namespace. |
+| serviceRules.destinationServiceName | string | `""` | Narrow down the alerts to a particular Destination Service if there are multiple services that require different thresholds within the same namespace. |
 | serviceRules.destinationServiceSelectorValidity | object | `{"enabled":true,"for":"1h","severity":"warning"}` | Does a basic lookup using the defined selectors to see if we can see any info for a given selector. This is the "watcher for the watcher". If we get alerted by this, we likely have a bad selector and our alerts are not going to ever fire. |
 | serviceRules.destinationServiceSelectorValidity.enabled | bool | `true` | Whether to enable the monitor on the selector for the VirtualService. |
 | serviceRules.destinationServiceSelectorValidity.for | string | `"1h"` | How long to evaluate. |

--- a/charts/istio-alerts/templates/_helpers.tpl
+++ b/charts/istio-alerts/templates/_helpers.tpl
@@ -1,3 +1,14 @@
+{{- define "istio-alerts.alias" -}}
+  {{- if eq .Chart.Name "istio-alerts" -}}
+    {{- $path := splitList "/" .Template.Name -}}
+    {{- if gt (len $path) 3 -}}
+    {{- (index $path 2) | lower -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .Chart.Name | lower -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "istio-alerts.namespaceSelectorIstioForMetrics" -}}
 destination_service_namespace="{{ .Release.Namespace }}"
 {{- end }}
@@ -5,6 +16,8 @@ destination_service_namespace="{{ .Release.Namespace }}"
 {{- define "istio-alerts.destinationServiceSelectorForIstioMetrics" -}}
 {{- if .Values.serviceRules.destinationServiceName -}}
 destination_service_name=~"{{ tpl .Values.serviceRules.destinationServiceName $ }}", {{ include "istio-alerts.namespaceSelectorIstioForMetrics" $ }}
+{{- else if (include "istio-alerts.alias" $) -}}
+destination_service_name="{{ include "istio-alerts.alias" $ }}", {{ include "istio-alerts.namespaceSelectorIstioForMetrics" $ }}
 {{- else -}}
 destination_service_name!="", {{ include "istio-alerts.namespaceSelectorIstioForMetrics" $ }}
 {{- end -}}

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -1,6 +1,10 @@
 {{ $destinationServiceSelectorForIstioMetrics     := include "istio-alerts.destinationServiceSelectorForIstioMetrics" . }}
 {{ $destinationServiceSelectorForKubeStateMetrics := include "istio-alerts.destinationServiceSelectorForKubeStateMetrics" . }}
-
+{{- $chartname := .Chart.Name -}}
+{{- $path := splitList "/" .Template.Name -}}
+{{- if gt (len $path) 3 -}}
+{{- $chartname = (printf "%s-%s" $name (index $path 2)) -}}
+{{- end -}}
 {{- if .Values.serviceRules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -11,7 +15,7 @@ metadata:
     nextdoor.com/source: {{ .Values.chart_source }}
 spec:
   groups:
-  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ .Chart.Name }}.IstioServiceRules
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ $chartname }}.IstioServiceRules
     rules:
     {{- with .Values.serviceRules.http5XXMonitor }}
     {{- if .enabled }}

--- a/charts/istio-alerts/templates/service-prometheusrule.yaml
+++ b/charts/istio-alerts/templates/service-prometheusrule.yaml
@@ -1,21 +1,16 @@
 {{ $destinationServiceSelectorForIstioMetrics     := include "istio-alerts.destinationServiceSelectorForIstioMetrics" . }}
 {{ $destinationServiceSelectorForKubeStateMetrics := include "istio-alerts.destinationServiceSelectorForKubeStateMetrics" . }}
-{{- $chartname := .Chart.Name -}}
-{{- $path := splitList "/" .Template.Name -}}
-{{- if gt (len $path) 3 -}}
-{{- $chartname = (printf "%s-%s" $name (index $path 2)) -}}
-{{- end -}}
 {{- if .Values.serviceRules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ .Release.Name }}-{{ lower .Chart.Name }}-service-rules
+  name: {{ .Release.Name }}-istio-{{ include "istio-alerts.alias" $ | default "alerts" }}-service-rules
   annotations:
     nextdoor.com/chart: {{ .Values.chart_name }}
     nextdoor.com/source: {{ .Values.chart_source }}
 spec:
   groups:
-  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ $chartname }}.IstioServiceRules
+  - name: {{ .Release.Namespace }}.{{ .Release.Name }}.{{ include "istio-alerts.alias" $ | default "alerts" }}.IstioServiceRules
     rules:
     {{- with .Values.serviceRules.http5XXMonitor }}
     {{- if .enabled }}

--- a/charts/istio-alerts/values.yaml
+++ b/charts/istio-alerts/values.yaml
@@ -23,7 +23,7 @@ serviceRules:
   # -- Narrow down the alerts to a particular Destination Service if there
   # are multiple services that require different thresholds within the same
   # namespace.
-  destinationServiceName: .*
+  destinationServiceName: ""
 
   # -- Configuration related to the 5xx monitor for the VirtualService.
   http5XXMonitor:


### PR DESCRIPTION
Our istio-alerts implementation is suffering from an issue with helm that does not pass the alias as the chart name to the sub sub chart, this leads to all the istio-alerts to have the .Chart.Name of "istio-alerts", while their parent chart gets the alias.
Example:
```
Parent chart:
  simple-app: alias child1
  statefulset-app: alias child2
```
both `child1` and `child2` passed on properly to `simple-app` and `statefulset-app`, but not to their subcharts - leaving their subcharts with the same name(hence: `istio-alerts`) - when that it used in a template it generates templates with the same name, when deployed to the same namespace they override one each other.
By default we had this issue and someone changed the default service name for the alerts to be `.*`, instead of empty as the existing logic implied - making it a namespace based rule and not allowing per app customization.

This change is attempting to use .Template.Name to extract the alias of the parent if the .Chart.Name is `istio-alerts` and use it in both the PrometheusRule name and in the destination_service to select the specific service (while allowing the users to set a more specific destinationService attribute in case it is different from the alias name).
