### PR TITLE
fix(nd-common): support istio-proxy native sidecar (initContainer) preStop override

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.17.0
+version: 0.17.1
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.4.0
+    version: 0.4.1
     repository: file://../nd-common

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -359,6 +359,11 @@ istio:
   # a DaemonSet to be part of the service mesh.
   enabled: false
 
+  # -- (`bool`) Set to "true" if your app is running the istio-proxy as a
+  # Kubernetes native sidecar - in which case PreStop commands should be updating
+  # initContainers of the Pod spec rather than containers.
+  nativeSidecarsEnabled: false
+
   # -- (`list <str>`) If supplied, this is the command that will be passed into
   # the `istio-proxy` sidecar container as a pre-stop function. This is used to
   # delay the shutdown of the istio-proxy sidecar in some way or another. Our
@@ -369,6 +374,17 @@ istio:
   # eg:
   # preStopCommand: [ /bin/sleep, "30" ]
   preStopCommand: null
+
+  # -- (`bool`) Set to "true" if you want our own default behavior for preStop
+  # command to be applied to istio-proxy.
+  #
+  # This used to be untogglable as it was almost always required, but with Kubernetes
+  # native sidecars, it's really not needed as an infinite drain can take over all
+  # the time.
+  #
+  # However, due to https://github.com/istio/istio/issues/51855, you may still
+  # want this even for a native sidecar
+  preStopDefaultEnabled: true
 
   # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
   # turned on and Envoy will attempt to scrape metrics from the application pod

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.4.0
+version: 0.4.1
 appVersion: latest

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.4.5
+version: 1.4.6
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.3.6
+    version: 0.4.1
     repository: file://../nd-common

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -785,6 +785,11 @@ istio:
   # The port values can either be integers or templatized strings.
   excludeOutboundPorts: []
 
+  # -- (`bool`) Set to "true" if your app is running the istio-proxy as a
+  # Kubernetes native sidecar - in which case PreStop commands should be updating
+  # initContainers of the Pod spec rather than containers.
+  nativeSidecarsEnabled: false
+
   # -- (`list <str>`) If supplied, this is the command that will be passed into
   # the `istio-proxy` sidecar container as a pre-stop function. This is used to
   # delay the shutdown of the istio-proxy sidecar in some way or another. Our
@@ -795,6 +800,17 @@ istio:
   # eg:
   # preStopCommand: [ /bin/sleep, "30" ]
   preStopCommand: null
+
+  # -- (`bool`) Set to "true" if you want our own default behavior for preStop
+  # command to be applied to istio-proxy.
+  #
+  # This used to be untogglable as it was almost always required, but with Kubernetes
+  # native sidecars, it's really not needed as an infinite drain can take over all
+  # the time.
+  #
+  # However, due to https://github.com/istio/istio/issues/51855, you may still
+  # want this even for a native sidecar
+  preStopDefaultEnabled: true
 
   # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
   # turned on and Envoy will attempt to scrape metrics from the application pod

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.13.0
+version: 1.13.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.4.0
+    version: 0.4.1
     repository: file://../nd-common

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -661,6 +661,11 @@ istio:
   # The port values can either be integers or templatized strings.
   excludeOutboundPorts: []
 
+  # -- (`bool`) Set to "true" if your app is running the istio-proxy as a
+  # Kubernetes native sidecar - in which case PreStop commands should be updating
+  # initContainers of the Pod spec rather than containers.
+  nativeSidecarsEnabled: false
+
   # -- (`list <str>`) If supplied, this is the command that will be passed into
   # the `istio-proxy` sidecar container as a pre-stop function. This is used to
   # delay the shutdown of the istio-proxy sidecar in some way or another. Our
@@ -671,6 +676,17 @@ istio:
   # eg:
   # preStopCommand: [ /bin/sleep, "30" ]
   preStopCommand: null
+
+  # -- (`bool`) Set to "true" if you want our own default behavior for preStop
+  # command to be applied to istio-proxy.
+  #
+  # This used to be untogglable as it was almost always required, but with Kubernetes
+  # native sidecars, it's really not needed as an infinite drain can take over all
+  # the time.
+  #
+  # However, due to https://github.com/istio/istio/issues/51855, you may still
+  # want this even for a native sidecar
+  preStopDefaultEnabled: true
 
   # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
   # turned on and Envoy will attempt to scrape metrics from the application pod

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.4.0
+    version: 0.4.1
     repository: file://../nd-common

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -523,6 +523,11 @@ istio:
   # The port values can either be integers or templatized strings.
   excludeOutboundPorts: []
 
+  # -- (`bool`) Set to "true" if your app is running the istio-proxy as a
+  # Kubernetes native sidecar - in which case PreStop commands should be updating
+  # initContainers of the Pod spec rather than containers.
+  nativeSidecarsEnabled: false
+
   # -- (`list <str>`) If supplied, this is the command that will be passed into
   # the `istio-proxy` sidecar container as a pre-stop function. This is used to
   # delay the shutdown of the istio-proxy sidecar in some way or another. Our
@@ -533,6 +538,17 @@ istio:
   # eg:
   # preStopCommand: [ /bin/sleep, "30" ]
   preStopCommand: null
+
+  # -- (`bool`) Set to "true" if you want our own default behavior for preStop
+  # command to be applied to istio-proxy.
+  #
+  # This used to be untogglable as it was almost always required, but with Kubernetes
+  # native sidecars, it's really not needed as an infinite drain can take over all
+  # the time.
+  #
+  # However, due to https://github.com/istio/istio/issues/51855, you may still
+  # want this even for a native sidecar
+  preStopDefaultEnabled: true
 
   # -- (`bool`) If set to "True", then the Istio Metrics Merging system will be
   # turned on and Envoy will attempt to scrape metrics from the application pod


### PR DESCRIPTION
## Why

### Context

[Kubernetes native sidecar containers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) run as `InitContainers`

Istio allows us to [run the proxy as a native sidecar](https://github.com/istio/istio/issues/48794).

### What This Change Does

Allows preStop commands to be set on initContainers as well.

### But Why Is This Change Needed?

Ideally, the [default /drain](https://github.com/istio/istio/blob/14c3ef57a77fd4995f84bac71b41a768564714a9/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml#L211-L220) on native sidecars should suffice.

However, an open bug (https://github.com/istio/istio/issues/51855) is forcing us to potentially bring our default preStop commands on the native sidecars as well.

## Diffs

### Diff between default values and setting `istio.nativeSidecarsEnabled: true`

**When to use**: This is the proposed ideal setting when we want a workaround to https://github.com/istio/istio/issues/51855

```diff
@@ -234,7 +234,7 @@
         traffic.sidecar.istio.io/excludeInboundPorts: "9090"
         proxy.istio.io/overrides: >-
           {
-            "containers": [
+            "initContainers": [
               {
                 "name": "istio-proxy",
                 "lifecycle": {
```

### Diff between default values and setting `istio.nativeSidecarsEnabled: true` and `preStopDefaultEnabled: false`

**When to use**: This is the proposed ideal setting when https://github.com/istio/istio/issues/51855 is fixed and we want to default to upstream/Istio's drain mechanism... i.e., no override

```diff
@@ -232,25 +232,6 @@
         checksum/secrets: c8fa9ff9cda8a0e2d93fdc712c82373c94a1a5f1a48fc6d8db9f978047d937b6
         proxy.istio.io/config: '<redacted>'
         traffic.sidecar.istio.io/excludeInboundPorts: "9090"
-        proxy.istio.io/overrides: >-
-          {
-            "containers": [
-              {
-                "name": "istio-proxy",
-                "lifecycle": {
-                  "preStop": {
-                    "exec": {
-                      "command": [
-                        "/bin/sh",
-                        "-c",
-                        "while [ $(netstat -plunt | grep tcp | egrep -v 'envoy|pilot-agent' | wc -l | xargs) -ne 0 ]; do sleep 1; done"
-                      ]
-                    }
-                  }
-                }
-              }
-            ]
-          }
         ad.datadoghq.com/simple-app.check_names: '["prometheus"]'
         ad.datadoghq.com/simple-app.init_configs: '[{}]'
         ad.datadoghq.com/simple-app.instances: |-
```
