### PR TITLE
fix(nd-common): render cleanly on sub-charting edge-case where map does not exist

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.4.1
+version: 0.4.2
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_istio.tpl
+++ b/charts/nd-common/templates/_istio.tpl
@@ -49,8 +49,12 @@ fixed, we suggest setting .Values.istio.nativeSidecars.keepCustomPreStopOverride
 to false so that the native drain preStop command can take over.
 */ -}}
 
-{{- /* Original value could be bool, empty string "", nil, etc */ -}}
-{{- $nativeSidecars := .Values.istio.nativeSidecars.enabled | toString }}
+{{- /*
+Original value could be bool, empty string "", nil, etc or nativeSidecars
+may not even be defined
+*/ -}}
+{{- $nsMap := get .Values.istio "nativeSidecars" | default dict -}}
+{{- $nativeSidecars := get $nsMap "enabled" | toString -}}
 
 {{- $containerType := (eq $nativeSidecars "true") | ternary "initContainers" "containers" }}
 {{- if .Values.istio.preStopCommand }}
@@ -69,7 +73,7 @@ proxy.istio.io/overrides: >-
       }
     ]
   } 
-{{- else if and .Values.ports (gt (len .Values.ports) 0) .Values.istio.nativeSidecars.keepCustomPreStopOverride }}
+{{- else if and .Values.ports (gt (len .Values.ports) 0) (get $nsMap "keepCustomPreStopOverride") }}
 proxy.istio.io/overrides: >-
   { 
     "{{ $containerType }}": [


### PR DESCRIPTION
## Why

Fixes a slight backwards compatibility issue for charts that have this exact scenario (all cases must be `true`):

1. Uses  `nd-common` **_only_** as a subchart (not simple-app, et al)
2. Has `istio.enabled` set to `true`
3. Doesn't set `values.yaml` to have `istio.nativeSidecars.(...)` (which is set in simple-app et al)

In that scenario, rendering charts will give:

```
executing "nd-common.istioAnnotations" at <.Values.istio.nativeSidecars.enabled>: nil pointer evaluating interface {}.enabled
```

... this change will handle that gracefully.

## Testing

Rendered simple-app with all different values ([1] no sidecars map, [2] sidecars.enabled set to true|false|"") on this branch and `main` and confirmed equal templates