### PR TITLE
fix(nd-common): Use fullname for consistencey

### DIFF
--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.4.2
+version: 0.4.3
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/README.md.gotmpl
+++ b/charts/nd-common/README.md.gotmpl
@@ -214,7 +214,7 @@ functions file looks for particularly named values keys. In particular:
 * `.Values.datadog.env`: Optionally this value will override the ["env" concept in Datadog][unified_service_tagging]
 * `.Values.datadog.service`: This string maps to the ["service" concept in Datadog][unified_service_tagging]
 * `.Values.datadog.scrapeMetrics`
-* `.Values.datadog.metricsToScrape` 
+* `.Values.datadog.metricsToScrape`
 * `.Values.istio.enabled`
 
 ### `nd-common.datadogAnnotations`

--- a/charts/nd-common/templates/_common.tpl
+++ b/charts/nd-common/templates/_common.tpl
@@ -69,13 +69,13 @@ Selector labels - two functions here:
   * one for "matchExpressions"
 */}}
 {{- define "nd-common.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "nd-common.name" . }}
+app.kubernetes.io/name: {{ include "nd-common.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- define "nd-common.selectorLabelsExpression" -}}
 - key: app.kubernetes.io/name
   operator: In
-  values: [{{ include "nd-common.name" . }}]
+  values: [{{ include "nd-common.fullname" . }}]
 - key: app.kubernetes.io/instance
   operator: In
   values: [{{ .Release.Name }}]

--- a/charts/nd-common/templates/_monitors.tpl
+++ b/charts/nd-common/templates/_monitors.tpl
@@ -196,7 +196,7 @@ spec:
         expr: {{ (include "nd-common.monitorSampleLimit" .) | quote }}
         labels:
           namespace: {{ .Release.Namespace }}
-          name: {{ include "nd-common.name" . }}
+          name: {{ include "nd-common.fullname" . }}
           instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
So we have some weird inconsistencies when you try to set both `nameOverride` and `fullNameOverride`. It seems like we should just standardize on `fullName`. But we may need to do a bunch of test rendering to ensure we don't break any downstreams.

https://github.com/search?q=org%3ANextdoor+nd-common.name++NOT+is%3Aarchived+NOT+repo%3ANextdoor%2Fk8s-charts&type=code