### PR TITLE
chore(ci): Revert Update chart releaser and bump for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,10 @@ jobs:
           version: v3.4.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: charts
-          skip_existing: true
+          charts_repo_url: https://k8s-charts.nextdoor.com/
         env:
+          CR_SKIP_EXISTING: "true"
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/simple-app/values.local.yaml
+++ b/charts/simple-app/values.local.yaml
@@ -1,9 +1,11 @@
-# For local development, we turn on the Ingress controller and set up a simple local ingress.
+# For local development, we turn on the Ingress controller and set up a simple
+# local ingress.
 ingress:
-  # Enable local ingress for local development.
+  # -- Enable local ingress for local development.
   enabled: true
 
-  # Disable the SSL-Redirect explicitly because it only applies to ALB-ingress controllers.
+  # -- Disable the SSL-Redirect explicitly because it only applies to
+  # ALB-ingress controllers.
   sslRedirect: false
 
 livenessProbe:


### PR DESCRIPTION
Reverts Nextdoor/k8s-charts#377

@LaikaN57 I see the release job failed with https://github.com/Nextdoor/k8s-charts/actions/runs/15605804582/job/43954897382.

Reverting to previous version for index.yaml to re-gen?