### PR TITLE
chore(ci): Upgrade chart-releaser to v1.7.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,10 +27,9 @@ jobs:
           version: v3.4.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
-          charts_repo_url: https://k8s-charts.nextdoor.com/
+          skip_existing: true
         env:
-          CR_SKIP_EXISTING: "true"
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Args changed a bit: https://github.com/helm/chart-releaser-action/tree/v1.7.0?tab=readme-ov-file#inputs