### PR TITLE
feat(simple-app): added rollouts (argo-rollouts) to simple-app

### DIFF
--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.13.3
+version: 1.14.0
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -13,6 +13,15 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
+### 1.13.x -> 1.14.x
+
+**NEW: Added capabilities to enable rollout deployments for new and current services**
+
+### 1.12.x -> 1.13.x
+
+# TODO add what was added to minor version bump here
+**NEW:**
+
 ### 1.11.x -> 1.12.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**


### PR DESCRIPTION
## Context
Currently, the `simple-app` and `rollout-app` have _very_ similar capabilities and even code structure at the moment, so with this PR, this merges the two to be within just the `simple-app`. By default, the services using `simple-app` will not be using a rollout deployment schema, however, if the user has the variable `rollout.enabled` set to `true`, then the user will be able to configure their deployment schema to be a rollout deployment (handled by [Argo Rollouts](https://argoproj.github.io/rollouts/)).

> [!IMPORTANT]
> For now, we will be leaving the `rollout-app` within the repository. This PR will mark the `rollout-app` as deprecated. However, due to the charts being similar, for future reference, the chart will be deleted within a following release of `k8s-charts.git`. This is due to the previously mentioned similarity between the two, and also to force developers to _actively be aware_ that their services may _benefit greatly_ in using rollout deployments! It will also be very confusing for developers to have `simple-app` have rollouts, whilst there is also a `rollout-app`
>
> Tier 0 and usually even tier 1 services should use rollouts deployments. All other services are at their own disgression to use rollouts or not, depending on the complexity of their services, the severity of safety revolving around the users the service is for, etc.

