### PR TITLE
fix(charts/simple-app): Disambiguate node selectors for transition deployments and per az

### DIFF
--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -59,6 +59,10 @@ to be zone-specific.
 {{- $disableTopoSpreadFunction = true }}
 {{- else }}
 {{- $fullName            = include "nd-common.fullname" $ }}
+{{- if .Values.deploymentZonesTransition }}
+{{- /* We need a separate label for transitions to make sure the node selectors for the transition deployment and per az deployments don't overlap */}}
+{{- $deploymentZoneLabel       = "transition: true"}} 
+{{- end }}
 {{- end }}
 
 ---


### PR DESCRIPTION
We currently see an error like "AmbiguousSelector  pods by selector _ are controlled by multiple HPAs" when setting per az transition to true. This error is because the selector for the transition deployment is a superset of the per az deployments. This pr adds an additional selector to the transition deployment to make it no longer a superset of the per az deployments