### PR TITLE
feat(rollout-app): added Datadog tags for stable and canary rollout ReplicaSets

### DIFF
--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.5.3
+version: 1.5.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.5.3](https://img.shields.io/badge/Version-1.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -20,7 +20,7 @@ how these work, and the various custom resource definitions.
 
 ### 1.4.x -> 1.5.x
 
-**NEW: Allow rollouts per- availability-zone and support canary `dynamicStableScale` option**
+**NEW: Allow rollouts per availability-zone, added support for canary `dynamicStableScale` field, and updated Datadog annotations**
 
 Beginning with this version, if serves up high cross-zone traffic, you may wish to enable
 same-zone locality awareness by spinning up Rollouts in each AZ. You can do this with the
@@ -28,6 +28,10 @@ same-zone locality awareness by spinning up Rollouts in each AZ. You can do this
 
 Also, for cost-consciousness we added support for the [dynamicStableScale](https://argo-rollouts.readthedocs.io/en/stable/features/canary/#dynamic-stable-scale-with-traffic-routing)
 option.
+
+DataDog annotations have been updated in this update to enable the DataDog Agent to tag
+stable and canary ReplicaSets with either a 'stable' or 'canary' value. This happens automatically if you set the `Values.datadog.enabled` flag to true.
+E.g., under annotations, there will be: `ad.datadoghq.com/tags: '{"argo_rollouts_replicaset_type": "stable"}'` (or "canary" for canary ReplicaSets).
 
 ### 1.3.x -> 1.4.x
 

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -19,7 +19,7 @@ how these work, and the various custom resource definitions.
 
 ### 1.4.x -> 1.5.x
 
-**NEW: Allow rollouts per- availability-zone and support canary `dynamicStableScale` option**
+**NEW: Allow rollouts per availability-zone, added support for canary `dynamicStableScale` field, and updated Datadog annotations**
 
 Beginning with this version, if serves up high cross-zone traffic, you may wish to enable 
 same-zone locality awareness by spinning up Rollouts in each AZ. You can do this with the
@@ -27,6 +27,10 @@ same-zone locality awareness by spinning up Rollouts in each AZ. You can do this
 
 Also, for cost-consciousness we added support for the [dynamicStableScale](https://argo-rollouts.readthedocs.io/en/stable/features/canary/#dynamic-stable-scale-with-traffic-routing)
 option.
+
+DataDog annotations have been updated in this update to enable the DataDog Agent to tag 
+stable and canary ReplicaSets with either a 'stable' or 'canary' value. This happens automatically if you set the `Values.datadog.enabled` flag to true.
+E.g., under annotations, there will be: `ad.datadoghq.com/tags: '{"argo_rollouts_replicaset_type": "stable"}'` (or "canary" for canary ReplicaSets).
 
 ### 1.3.x -> 1.4.x
 

--- a/charts/rollout-app/templates/_helpers.tpl
+++ b/charts/rollout-app/templates/_helpers.tpl
@@ -58,3 +58,45 @@ The additional labels include:
 ) -}}
 {{- $extendedLabels | toYaml -}}
 {{- end -}}
+
+{{- /*
+The following functions will append datadog annotations to stable and canary ReplicaSets if
+datadog monitoring is enabled. This function also handles cases where
+.Values.canary.stableMetadata and .Values.canary.canaryMetadata is configured, merging
+the two values such that any annotation mappings requested by the user are kept.
+For more information on adding tags using annotations, see:
+https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator
+*/ -}}
+{{- define "rollout-app.stableMetadata" }}
+{{- $stableMetadata := ( default (dict) .Values.canary.stableMetadata ) }}
+{{- $ddStableAnnotations := dict "ad.datadoghq.com/tags" (printf "%s: %s" "argo_rollouts_replicaset_type" "stable") }}
+{{- /*
+If users are trying to add customer annotations to a stable or canary ReplicaSet alongside having
+DataDog enabled, we need to ensure that we merge the DataDog key:value fields in addition to their
+key:value fields under the annotations field.
+*/ -}}
+{{- if .Values.datadog.enabled }}
+{{- $stableMetadata = merge (dict 
+  "annotations" (merge ($stableMetadata.annotations | default dict) $ddStableAnnotations)
+) $stableMetadata }}
+{{- end }}
+{{- /* Convert the configured stable metadata to correct yaml */ -}}
+{{- toYaml $stableMetadata }}
+{{- end -}}
+
+{{- define "rollout-app.canaryMetadata" }}
+{{- $canaryMetadata := ( default (dict) .Values.canary.canaryMetadata ) }}
+{{- $ddCanaryAnnotations := dict "ad.datadoghq.com/tags" (printf "%s: %s" "argo_rollouts_replicaset_type" "canary") }}
+{{- /*
+If users are trying to add customer annotations to a stable or canary ReplicaSet alongside having
+DataDog enabled, we need to ensure that we merge the DataDog key:value fields in addition to their
+key:value fields under the annotations field.
+*/ -}}
+{{- if .Values.datadog.enabled }}
+{{- $canaryMetadata = merge (dict 
+  "annotations" (merge ($canaryMetadata.annotations | default dict) $ddCanaryAnnotations)
+) $canaryMetadata }}
+{{- end }}
+{{- /* Convert the configured canary metadata to correct yaml */ -}}
+{{- toYaml $canaryMetadata }}
+{{- end -}}

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -36,7 +36,6 @@ disable this.
 {{/* The default rolloutZoneLabel is left empty. We patch it as we loop through $rolloutZones */}}
 {{- $rolloutZoneLabel := "" }}
 
-
 {{/* Iterate through the rollout zones now */}}
 {{- range $rolloutZone := index $rolloutZones }}
 
@@ -167,14 +166,16 @@ spec:
         {{- end }}
       {{- end }}
 
-      {{- with $.Values.canary.canaryMetadata }}
+      {{- $canaryMetadata := include "rollout-app.canaryMetadata" $ | fromYaml }}
+      {{- if $canaryMetadata }}
       canaryMetadata:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $canaryMetadata | nindent 8 }}
       {{- end }}
 
-      {{- with $.Values.canary.stableMetadata }}
+      {{- $stableMetadata := include "rollout-app.stableMetadata" $ | fromYaml }}
+      {{- if $stableMetadata }}
       stableMetadata:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $stableMetadata | nindent 8 }}
       {{- end }}
 
       {{- with $.Values.canary.maxUnavailable }}


### PR DESCRIPTION
## Context
Currently, if you have a DataDog agent running on your k8s cluster and your Argo Rollouts controller is [configured correctly](https://docs.datadoghq.com/integrations/argo-rollouts/) to allow the agent to scrape the `/metrics` endpoint for rollout metrics, you can get 90% of the granularity that you might need for the creation of a dashboard.

However, [DataDog allows](https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator) annotations to be added onto specific _ReplicaSets_ themselves for the creation of tags. These tags can have `KEY:VALUE` pairings for increased granularity into observability dashboards. This change in specific allows you to toggle between stable and canary ReplicaSets on a dashboard.

## Testing
One of my applications is currently running on these changes, and has the correct annotations applied to them. On top of that, I also see that the DataDog agent is able to successfully send the tag `KEY:VALUE` pairings to my dashboard 🙌 !