### PR TITLE
chore(charts/nd-common): support newer trafficDistribution field in Service

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.17.5
+version: 0.17.6
 appVersion: latest
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.5.2
+    version: 0.5.3
     repository: file://../nd-common

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.17.5](https://img.shields.io/badge/Version-0.17.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.17.6](https://img.shields.io/badge/Version-0.17.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,13 @@ in Kubernetes][statefulsets]. The chart provides all of the common pieces like
 ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
+
+### 1.16.x -> 1.17.x
+
+**NEW: Goldilocks support, k8s-native sidecars support, allow setting Service TrafficDistribution**
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 ### 1.15.x -> 1.16.x
 
@@ -264,7 +271,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.5.2 |
+| file://../nd-common | nd-common | 0.5.3 |
 
 ## Values
 
@@ -354,6 +361,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | `string` | `"ClusterIP"` | `ClusterIP`, `NodePort`, `LoadBalancer` or `ExternalName`. |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -20,6 +20,8 @@ ServiceAccounts, Services, etc.
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.15.x -> 1.16.x
 
 **NEW: Templated Termination Grace Period**

--- a/charts/daemonset-app/README.md.gotmpl
+++ b/charts/daemonset-app/README.md.gotmpl
@@ -19,6 +19,8 @@ ServiceAccounts, Services, etc.
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.15.x -> 1.16.x
 
 **NEW: Templated Termination Grace Period**

--- a/charts/daemonset-app/README.md.gotmpl
+++ b/charts/daemonset-app/README.md.gotmpl
@@ -12,6 +12,13 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
+### 1.16.x -> 1.17.x
+
+**NEW: Goldilocks support, k8s-native sidecars support, allow setting Service TrafficDistribution**
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
+
 ### 1.15.x -> 1.16.x
 
 **NEW: Templated Termination Grace Period**

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -219,6 +219,18 @@ service:
   # application name.
   name:
 
+  # -- (`string`) Allows you to set preferences for how traffic should be routed
+  # to Service endpoints.
+  #
+  # In absense, default routing strategy for kube-proxy is to distribute traffic
+  # to any endpoint in the cluster
+  #
+  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # discretion of user as it's a simple heuristic: if there are endpoints in the
+  # zone, they will receive all traffic for that zone, if there are no endpoints
+  # in a zone, the traffic will be distributed to other zones
+  trafficDistribution:
+
 # Configuration for creating a dedicated ALB for your service. This is
 # acceptable - but not the preferred method (see the IngressGateway setup
 # below).

--- a/charts/nd-common/Chart.yaml
+++ b/charts/nd-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nd-common
 description: A helper chart used by most of our other charts
 type: library
-version: 0.5.2
+version: 0.5.3
 appVersion: latest

--- a/charts/nd-common/README.md
+++ b/charts/nd-common/README.md
@@ -2,7 +2,7 @@
 
 A helper chart used by most of our other charts
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **This chart is a [Library Chart](https://helm.sh/docs/topics/library_charts/)** -
 this means that the chart itself deploys no resources, and has no `.yaml`

--- a/charts/nd-common/templates/_service.tpl
+++ b/charts/nd-common/templates/_service.tpl
@@ -26,6 +26,9 @@ metadata:
     This is only used for type=LoadBalancer Services which run in AWS.
     */}}
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: kubernetes_namespace={{ .Release.Namespace }}
+    {{- with .Values.service.annotations }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/nd-common/templates/_service.tpl
+++ b/charts/nd-common/templates/_service.tpl
@@ -32,6 +32,24 @@ spec:
     {{- include "nd-common.servicePorts" $ | nindent 4 }}
   selector:
     {{- include "nd-common.selectorLabels" $ | nindent 4 }}
+  {{/* https://github.com/helm/helm/issues/12053#issuecomment-1535044379 */}}
+  {{- if semverCompare ">=1.31.0-0" .Capabilities.KubeVersion.Version }}
+  {{/*
+  As of Kubernetes v1.31, Service spec supports the trafficDistribution field, which is beta 'on',
+  and moved to GA in v1.33.
+
+  For now, to ensure no side-effects, we only will set the field if the user explicitly sets it.
+
+  In the future, we may default set to 'PreferClose' (for kube-proxy, this means prioritizing sending
+  traffic to endpoints within the same zone as the client)
+
+  In its absense, the default routing strategy for kube-proxy is to distribute traffic to any endpoint
+  in the cluster
+  */}}
+  {{- with .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .}}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 ---

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.5.2
+    version: 0.5.3
     repository: file://../nd-common

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -20,7 +20,7 @@ how these work, and the various custom resource definitions.
 
 ### 1.5.x -> 1.6.x
 
-**NEW: Enabled migration capabilities from `simple-app` to `rollout-app`**
+**NEW: Enabled migration capabilities from `simple-app` to `rollout-app`, allow setting Service TrafficDistribution**
 
 Beginning with this version, you can now migrate from `simple-app` to `rollout-app` with no downtime between your services.
 To enable this, you will need to set the `migrate.inProgress` value to `true` in your values file.
@@ -29,6 +29,9 @@ Check the `migrate.workloadRef.scaleDown` field for strategies available for sca
 The default value is `onsuccess`, meaning that the Deployment be scaled down only after the Rollout becomes healthy (extremely safe!).
 For more information on steps to migrate, check out the documentation here:
 # https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 ### 1.4.x -> 1.5.x
 
@@ -241,7 +244,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.5.2 |
+| file://../nd-common | nd-common | 0.5.3 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.3 |
 
 ## Values
@@ -384,6 +387,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -33,6 +33,8 @@ For more information on steps to migrate, check out the documentation here:
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.4.x -> 1.5.x
 
 **NEW: Allow rollouts per availability-zone and added support for canary `dynamicStableScale` field**

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -19,7 +19,7 @@ how these work, and the various custom resource definitions.
 
 ### 1.5.x -> 1.6.x
 
-**NEW: Enabled migration capabilities from `simple-app` to `rollout-app`**
+**NEW: Enabled migration capabilities from `simple-app` to `rollout-app`, allow setting Service TrafficDistribution**
 
 Beginning with this version, you can now migrate from `simple-app` to `rollout-app` with no downtime between your services.
 To enable this, you will need to set the `migrate.inProgress` value to `true` in your values file.
@@ -28,6 +28,9 @@ Check the `migrate.workloadRef.scaleDown` field for strategies available for sca
 The default value is `onsuccess`, meaning that the Deployment be scaled down only after the Rollout becomes healthy (extremely safe!).
 For more information on steps to migrate, check out the documentation here:
 # https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 ### 1.4.x -> 1.5.x
 

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -32,6 +32,8 @@ For more information on steps to migrate, check out the documentation here:
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.4.x -> 1.5.x
 
 **NEW: Allow rollouts per availability-zone and added support for canary `dynamicStableScale` field**

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -453,6 +453,18 @@ service:
   # application name.
   name:
 
+  # -- (`string`) Allows you to set preferences for how traffic should be routed
+  # to Service endpoints.
+  #
+  # In absense, default routing strategy for kube-proxy is to distribute traffic
+  # to any endpoint in the cluster
+  #
+  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # discretion of user as it's a simple heuristic: if there are endpoints in the
+  # zone, they will receive all traffic for that zone, if there are no endpoints
+  # in a zone, the traffic will be distributed to other zones
+  trafficDistribution:
+
 # Configuration for creating a dedicated ALB for your service. This is
 # acceptable - but not the preferred method (see the IngressGateway setup
 # below).

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.13.10
+version: 1.13.11
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.5.2
+    version: 0.5.3
     repository: file://../nd-common

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -20,6 +20,8 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.11.x -> 1.12.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.13.10](https://img.shields.io/badge/Version-1.13.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.13.11](https://img.shields.io/badge/Version-1.13.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,13 @@ in a [Deployment][deployments]. The chart automatically configures various
 defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
+
+### 1.12.x -> 1.13.x
+
+**NEW: Support label overrides, istio-proxy to run as k8s-native sidecars, and setting Service TrafficDistribution**
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 ### 1.11.x -> 1.12.x
 
@@ -368,7 +375,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.5.2 |
+| file://../nd-common | nd-common | 0.5.3 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.3 |
 
 ## Values
@@ -493,6 +500,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -19,6 +19,8 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.11.x -> 1.12.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -12,6 +12,13 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 ## Upgrade Notes
 
+### 1.12.x -> 1.13.x
+
+**NEW: Support label overrides, istio-proxy to run as k8s-native sidecars, and setting Service TrafficDistribution**
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
+
 ### 1.11.x -> 1.12.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -59,10 +59,6 @@ to be zone-specific.
 {{- $disableTopoSpreadFunction = true }}
 {{- else }}
 {{- $fullName            = include "nd-common.fullname" $ }}
-{{- if $.Values.deploymentZonesTransition }}
-{{- /* We need a separate label for transitions to make sure the node selectors for the transition deployment and per az deployments don't overlap */}}
-{{- $deploymentZoneLabel       = printf "%s: %s" "deployment-zone-status" "transition" }} 
-{{- end }}
 {{- end }}
 
 ---

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -251,6 +251,18 @@ service:
   # application name.
   name:
 
+  # -- (`string`) Allows you to set preferences for how traffic should be routed
+  # to Service endpoints.
+  #
+  # In absense, default routing strategy for kube-proxy is to distribute traffic
+  # to any endpoint in the cluster
+  #
+  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # discretion of user as it's a simple heuristic: if there are endpoints in the
+  # zone, they will receive all traffic for that zone, if there are no endpoints
+  # in a zone, the traffic will be distributed to other zones
+  trafficDistribution:
+
 # Configuration for creating a dedicated ALB for your service. This is
 # acceptable - but not the preferred method (see the IngressGateway setup
 # below).

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.5.6
+version: 1.5.7
 appVersion: latest
 maintainers:
   - name: diranged
@@ -13,5 +13,5 @@ dependencies:
     repository: https://k8s-charts.nextdoor.com
     condition: istio-alerts.enabled
   - name: nd-common
-    version: 0.5.2
+    version: 0.5.3
     repository: file://../nd-common

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -20,6 +20,8 @@ ServiceAccounts, Services, etc.
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.3.x -> 1.4.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.5.6](https://img.shields.io/badge/Version-1.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.5.7](https://img.shields.io/badge/Version-1.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -12,6 +12,13 @@ in Kubernetes][statefulsets]. The chart provides all of the common pieces like
 ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
+
+### 1.4.x -> 1.5.x
+
+**NEW: Allow simpler common label overrides and Service to set PreferClose trafficDistribution**
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 ### 1.3.x -> 1.4.x
 
@@ -309,7 +316,7 @@ secretsEngine: sealed
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.5.2 |
+| file://../nd-common | nd-common | 0.5.3 |
 | https://k8s-charts.nextdoor.com | istio-alerts | 0.5.3 |
 
 ## Values
@@ -415,6 +422,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -12,6 +12,13 @@ ServiceAccounts, Services, etc.
 
 ## Upgrade Notes
 
+### 1.4.x -> 1.5.x
+
+**NEW: Allow simpler common label overrides and Service to set PreferClose trafficDistribution**
+
+`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
+
 ### 1.3.x -> 1.4.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -19,6 +19,8 @@ ServiceAccounts, Services, etc.
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
+Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
+
 ### 1.3.x -> 1.4.x
 
 **NEW: Allow access from cross-cluster, in-mesh services**

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -258,6 +258,18 @@ service:
   # application name.
   name:
 
+  # -- (`string`) Allows you to set preferences for how traffic should be routed
+  # to Service endpoints.
+  #
+  # In absense, default routing strategy for kube-proxy is to distribute traffic
+  # to any endpoint in the cluster
+  #
+  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # discretion of user as it's a simple heuristic: if there are endpoints in the
+  # zone, they will receive all traffic for that zone, if there are no endpoints
+  # in a zone, the traffic will be distributed to other zones
+  trafficDistribution:
+
 # Configuration for creating a dedicated ALB for your service. This is
 # acceptable - but not the preferred method (see the IngressGateway setup
 # below).


### PR DESCRIPTION
# What

As of Kubernetes v1.31, `Service` spec [supports the trafficDistribution field](https://v1-31.docs.kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution) (which is beta on v1.31.x an GA in v1.33).

For now, to ensure no side-effects, we only will set the field **_if the user explicitly sets it_**.

```
service:
  trafficDistribution: PreferClose
```

This is a simple heuristic: for kube-proxy, this means prioritizing sending traffic to endpoints within the same zone as the client if an endpoint in the zone exists.

In its absence, the default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster

Because of its straight-forward heuristic, this can possibly lead to overload, in which case setting the annotation of `service.kubernetes.io/topology-mode: Auto` may be a better approach if we want to default to something (see tests below)

# Test Results

## Setup

### Client (`debug-pod`) and Server (with trafficDistribution not set):

```
POD_NAME                   ZONE          POD_IP
debug-pod                  us-west-2b    100.80.89.20
httpbin-5f6bdcd9f-5p7t8    us-west-2c    100.80.184.152
httpbin-5f6bdcd9f-lrgbj    us-west-2a    100.80.58.64
httpbin-5f6bdcd9f-qwwqw    us-west-2b    100.80.88.238

$ kubectl get svc httpbin -o yaml | yq '.spec.trafficDistribution'
null

$ stern httpbin > /tmp/requests.log
```

#### Expected Result

All requests from `debug-pod` should be round-robined between the 3 pods

```
~ $ for attempt in $(seq 1 20); do curl -I http://httpbin ; sleep 1 ; done
```

#### Actual Result

```
$ grep '"x_forwarded_for":"100.80.89.20' /tmp/requests.log | cut -d' ' -f1 | sort | uniq -c
   8 httpbin-5f6bdcd9f-5p7t8
   5 httpbin-5f6bdcd9f-lrgbj
   7 httpbin-5f6bdcd9f-qwwqw
```

### Client (`debug-pod`) and Server (with trafficDistribution set to `PreferClose`):

```
POD_NAME                   ZONE          POD_IP
debug-pod                  us-west-2b    100.80.89.20
httpbin-5f6bdcd9f-4wxtc    us-west-2c    100.80.184.152
httpbin-5f6bdcd9f-5dp9l    us-west-2a    100.80.56.159
httpbin-5f6bdcd9f-bkr5z    us-west-2b    100.80.88.238

$ kubectl get svc httpbin -o yaml | yq '.spec.trafficDistribution'
PreferClose

$ stern httpbin > /tmp/requests.log
```

#### Expected Result

All requests from `debug-pod` should go to `httpbin-5f6bdcd9f-bkr5z` (same zone).

```
~ $ for attempt in $(seq 1 20); do curl -I http://httpbin ; sleep 1 ; done
```

#### Actual Result

```
$ grep '"x_forwarded_for":"100.80.89.20' /tmp/requests.log | cut -d' ' -f1 | sort | uniq -c
  20 httpbin-5f6bdcd9f-bkr5z
```

### Client (`debug-pod`) with Service annotation service.kubernetes.io/topology-mode: Auto

```
POD_NAME                   ZONE          POD_IP
debug-pod                  us-west-2b    100.80.89.24
httpbin-5f6bdcd9f-dj94t    us-west-2a    100.80.56.151
httpbin-5f6bdcd9f-wfzl7    us-west-2c    100.80.184.118
httpbin-5f6bdcd9f-xkxkc    us-west-2b    100.80.89.20

$ kubectl get svc httpbin -o yaml | yq '.spec.trafficDistribution'
null

$ kubectl get svc httpbin -o yaml | yq '.metadata.annotations
[...]
service.kubernetes.io/topology-mode: Auto

$ stern httpbin > /tmp/requests.log
```

#### Expected results

Most of the requests going to `httpbin-5f6bdcd9f-xkxkc`

#### Actual Result

```
$ grep '"x_forwarded_for":"100.80.89.24' /tmp/requests.log | cut -d' ' -f1 | sort | uniq -c
   3 httpbin-5f6bdcd9f-dj94t
   7 httpbin-5f6bdcd9f-wfzl7
  10 httpbin-5f6bdcd9f-xkxkc
```

### Client (`debug-pod`) with Service annotation service.kubernetes.io/topology-mode: Auto

Caveat: More replicas per-zone, to increase same zone routing as this heuristic looks at that

```
POD_NAME                   ZONE          POD_IP
debug-pod                  us-west-2b    100.80.89.24
httpbin-79558ccdc6-64d2j   us-west-2a    100.80.58.133
httpbin-79558ccdc6-67j7f   us-west-2b    100.80.82.21
httpbin-79558ccdc6-74hhv   us-west-2a    100.80.58.132
httpbin-79558ccdc6-cvthr   us-west-2b    100.80.89.25
httpbin-79558ccdc6-g29qf   us-west-2a    100.80.58.130
httpbin-79558ccdc6-sw8q6   us-west-2c    100.80.186.84
httpbin-79558ccdc6-x6l4j   us-west-2c    100.80.184.121
httpbin-79558ccdc6-x9hxh   us-west-2c    100.80.184.119
httpbin-79558ccdc6-ztxw2   us-west-2b    100.80.82.23


$ kubectl get svc httpbin -o yaml | yq '.spec.trafficDistribution'
null

$ kubectl get svc httpbin -o yaml | yq '.metadata.annotations
[...]
service.kubernetes.io/topology-mode: Auto

$ stern httpbin > /tmp/requests.log
```

#### Expected results

Majoirty of the requests going to server pods in same zone as client (`httpbin-79558ccdc6-67j7f`, `httpbin-79558ccdc6-cvthr`, `httpbin-79558ccdc6-ztxw2`)

#### Actual Result

```
$ grep '"x_forwarded_for":"100.80.89.24' /tmp/requests.log | cut -d' ' -f1 | sort | uniq -c
   4 httpbin-79558ccdc6-64d2j
  10 httpbin-79558ccdc6-67j7f // <--
   9 httpbin-79558ccdc6-74hhv
  10 httpbin-79558ccdc6-cvthr // <--
   5 httpbin-79558ccdc6-g29qf
   8 httpbin-79558ccdc6-sw8q6
   9 httpbin-79558ccdc6-x6l4j
   5 httpbin-79558ccdc6-x9hxh
   8 httpbin-79558ccdc6-ztxw2 // <--
```