### PR TITLE
fix(rollout-app): allowed VirtualService's when AZ's are configured

### DIFF
--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -173,20 +173,10 @@ spec:
       During a migration, since we reference a previous Deployments service, we do not want to supply VirtualService values here,
       otherwise we will run into selector misalignments.
       */}}
-      {{- if not $.Values.migrate.inProgress }}
+      {{- if not $.Values.migrate.inProgress }}  # TODO: remove this if we find that this field is not even needed within the migration doc logic here: https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor
       {{- if or $.Values.virtualService.enabled $.Values.ingress.enabled }}
-        {{/*
-        If you have multiple rollouts, then it does not make sense to have *multiple* virtual services as well.
-        In addition to that, Argo Rollouts will not let multiple rollouts reference the same virtual service,
-        meaning that you cannot share a virtual service between multiple rollouts. Thus, this is why failing here
-        is necessary. For context on where Argo Rollouts fails, see:
-        https://github.com/argoproj/argo-rollouts/blob/76cfc0e58892ed9759c1a732e243f75aed2fc6bd/utils/conditions/conditions.go#L158
-        */}}
-        {{- if and (gt (len $.Values.rolloutZones) 0) ($.Values.virtualService.enabled) -}}
-        {{- fail (printf "Invalid spec, multiple zones cannot be configured with virtual services enabled") }}
-        {{- end }}
-      stableService: {{ $fullName }}
-      canaryService: {{ $fullName }}-canary
+      stableService: {{ include "nd-common.serviceName" $ }}
+      canaryService: {{ include "nd-common.serviceName" $ }}-canary
       {{ end }}
 
       {{- if or $.Values.virtualService.enabled $.Values.ingress.enabled }}
@@ -194,11 +184,11 @@ spec:
         {{- if $.Values.virtualService.enabled }}
         istio:
           virtualService:
-            name: {{ $fullName }}
+            name: {{ include "nd-common.fullname" $ }}
         {{- end }}
         {{- if $.Values.ingress.enabled }}
         alb:
-          ingress: {{ $fullName }}
+          ingress: {{ include "nd-common.fullname" $ }}
           servicePort: {{ default (first $.Values.ports).containerPort $.Values.ingress.port }}
         {{- end }}
       {{- end }}

--- a/charts/rollout-app/templates/services.yaml
+++ b/charts/rollout-app/templates/services.yaml
@@ -1,45 +1,4 @@
-{{/*
-This is an umbrella service that is used to route web traffic to potential
-different AZ's for your rollout, load balancing across them. This is the 
-always-created and always-on service that will round-robin traffic
-to the different stable and canary services in across AZs.
-
-This is only used for multiple rollout deployments.
-*/}}
-{{- $usingZones := false -}}
-{{- if gt (len .Values.rolloutZones) 0 -}}
-  {{- $usingZones = true -}}
-{{- end -}}
-{{ if $usingZones }}
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "nd-common.serviceName" . }}
-  labels:
-    {{- include "rollout-app.labels" . | nindent 4 }}
-  annotations:
-    {{/*
-    This is only used for type=LoadBalancer Services which run in AWS.
-    */}}
-    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: kubernetes_namespace={{ .Release.Namespace }}
-spec:
-  type: {{ .Values.service.type }}
-  ports:
-    {{- include "rollout-app.servicePorts" . | nindent 4 }}
-  selector:
-    {{- include "nd-common.selectorLabels" . | nindent 4 }}
-
-{{- else -}} {{/*  if you are using a single rollout deployment*/}}
----
-{{/*
-This optional "Stable" service is created only when the .Values.strategy is set
-to "canary". Rollouts will then use this service to run the "production" pods.
-When using Istio VirtualServices (if .Values.virtualService.enabled=true), the
-VirtualService will be configured to use this Service as the stable service,
-and it will automatically adjust the weights to move traffic between the stable
-and canary service.
-*/}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -114,4 +73,3 @@ spec:
     {{- include "nd-common.selectorLabels" . | nindent 4 }}
 {{- end }}
 ---
-{{- end -}}


### PR DESCRIPTION
## Context
I was under the presumption that VirtualServices cannot be shared across multiple Rollout objects. However, after some testing, I was able to configure multiple rollout objects to use _one_ virtualservice object. 

I also realized that the `service.yaml` file does not make the necessary `...-canary` service that is needed when also using VirtualServices. Previously, it just made only one service, but now it creates a stable and canary service.

## Testing Proof: Multiple Argo Rollouts Can Share the Same VirtualService
Setup:
Created 2 rollouts: cg-rollout-app-us-east-2a and cg-rollout-app-us-east-2b by adding the appropriate `rolloutZones` list
Created 1 VirtualService: cg-rollout-app

Both rollouts reference the same VirtualService in their traffic routing field during creation, and I was able to spin up both rollouts and their ReplicaSets without ArgoRollouts throwing an error.

Results:
```bash
k get rollouts
NAME                        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
cg-rollout-app-us-east-2a   2         2         2                        42m
cg-rollout-app-us-east-2b   2         2         2                        29m

k get vs      
NAME             GATEWAYS   HOSTS                                                                                                                                  AGE
cg-rollout-app              ["blah.myhost.com", "nah.test.com"]                                                                                       32m
```