### PR TITLE
chore(rollout-app): remove migrate key and simplify conditionals

### DIFF
--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.6.3
+version: 1.6.4
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.4](https://img.shields.io/badge/Version-1.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -20,15 +20,7 @@ how these work, and the various custom resource definitions.
 
 ### 1.5.x -> 1.6.x
 
-**NEW: Enabled migration capabilities from `simple-app` to `rollout-app`, allow setting Service TrafficDistribution, support subset-level traffic splitting**
-
-Beginning with this version, you can now migrate from `simple-app` to `rollout-app` with no downtime between your services.
-To enable this, you will need to set the `migrate.inProgress` value to `true` in your values file.
-Additionally, you may need to set the `migrate.workloadRef.name` value to the name of the dependency chart you are migrating from.
-Check the `migrate.workloadRef.scaleDown` field for strategies available for scaling down the Deployment.
-The default value is `onsuccess`, meaning that the Deployment be scaled down only after the Rollout becomes healthy (extremely safe!).
-For more information on steps to migrate, check out the documentation here:
-# https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor
+**NEW: Allow setting Service TrafficDistribution, support subset-level traffic splitting**
 
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
@@ -329,11 +321,6 @@ secretsEngine: sealed
 | istio.preStopCommand | `list <str>` | `nil` | If supplied, this is the command that will be passed into the `istio-proxy` sidecar container as a pre-stop function. This is used to delay the shutdown of the istio-proxy sidecar in some way or another. Our own default behavior is applied if this value is not set - which is that the sidecar will wait until it does not see the application container listening on any TCP ports, and then it will shut down.  eg: preStopCommand: [ /bin/sleep, "30" ] |
 | kmsSecretsRegion | String | `nil` | AWS region where the KMS key is located |
 | livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | A PodSpec container "livenessProbe" configuration object. Note that this livenessProbe will be applied to the proxySidecar container instead if that is enabled. |
-| migrate | object | `{"inProgress":false,"workloadRef":{"name":null,"scaleDown":"progressively"}}` | Migrating from `simple-app` (kind: Deployment) to `rollout-app` (kind: Rollout)? This section handles the migrations from Nextdoor's regular Deployment kind (found in `simple-app`) to the Rollout kind (found in `rollout-app`). Not necessary for new services. !IMPORTANT!: You should only toggle the `inProgress` field to `true` if your Rollout pods are already up and accepting traffic, aka their status is `Ready`. Not doing so will result in downtime for your application. If you wish to migrate (`inProgress` field is `true`), the Pods you deploy will use the template found currently within the Deployment's template. Upon migration completion (toggling `inProgress` to `false`), the Deployment will be deleted, and the Pod's will have labels that match a rollout deployment. For more information on steps to migrate, check out the documentation here: https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor |
-| migrate.inProgress | `bool` | `false` | If true, your service will start to migrate from a Deployment to a Rollout. Ensure that the other fields under migrate are also set. !IMPORTANT!: You should only toggle the `inProgress` field to `true` if your Rollout pods are already up and accepting traffic, aka their status is `Ready`. Not doing so will result in downtime for your application. |
-| migrate.workloadRef | `map` | `{"name":null,"scaleDown":"progressively"}` | The workloadRef field helps ensure that during the migration, traffic is still always being handled by *something*. The rollout CRD will divert traffic to the original Deployment, and depending on the scaleDownStrategy field, progressively starts scalng down traffic to the original Deployment as traffic towards the canary deployment ramps up. For more information on how this is used during migrations, see: https://argo-rollouts.readthedocs.io/en/stable/migrating/#reference-deployment-from-rollout |
-| migrate.workloadRef.name | `string` | `nil` | The of the chart that you are migrating from. If you are migrating from `simple-app`, the value can be found within your Chart.yaml file as in the dependencies list. Typically just `simple-app`, but it can also be the value of alias if that is set. NOTE: If you are migrating from a deployment that utilizes multiple availability zones, ensure that you apply the values found within `deploymentZones` to `rolloutZones` as well as the topology values. |
-| migrate.workloadRef.scaleDown | `string` | `"progressively"` | specifies how the Deployment should be scaled down. There are three options available: - `never`: the Deployment is not scaled down - `onsuccess`: the Deployment is scaled down after the Rollout becomes healthy - `progressively`: as the Rollout is scaled up the Deployment is scaled down, and the default choice for migrations For more information on the strategy, please visit: https://argo-rollouts.readthedocs.io/en/stable/migrating/#reference-deployment-from-rollout |
 | minReadySeconds | string | `nil` | https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds |
 | monitor.annotations | `map` | `{}` | ServiceMonitor annotations. |
 | monitor.enabled | `bool` | `true` | If enabled, ServiceMonitor resources for Prometheus Operator are created or if `Values.istio.enabled` is `True`, then the appropriate Pod Annotations will be added for the istio-proxy sidecar container to scrape the metrics. |

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -19,15 +19,7 @@ how these work, and the various custom resource definitions.
 
 ### 1.5.x -> 1.6.x
 
-**NEW: Enabled migration capabilities from `simple-app` to `rollout-app`, allow setting Service TrafficDistribution, support subset-level traffic splitting**
-
-Beginning with this version, you can now migrate from `simple-app` to `rollout-app` with no downtime between your services.
-To enable this, you will need to set the `migrate.inProgress` value to `true` in your values file.
-Additionally, you may need to set the `migrate.workloadRef.name` value to the name of the dependency chart you are migrating from.
-Check the `migrate.workloadRef.scaleDown` field for strategies available for scaling down the Deployment.
-The default value is `onsuccess`, meaning that the Deployment be scaled down only after the Rollout becomes healthy (extremely safe!).
-For more information on steps to migrate, check out the documentation here:
-# https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor
+**NEW: Allow setting Service TrafficDistribution, support subset-level traffic splitting**
 
 `service.trafficDistribution`, if set to `PreferClose` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -21,13 +21,6 @@ from multiple rollout deployments to a single rollout deployment.
 {{/* The default fullName field here... we override it and append to it as we loop through $rolloutZones */}}
 {{- $fullName := include "nd-common.fullname" . }}
 
-{{/*
-For users who are migrating from `simple-app` to `rollout-app`, they are able to specify their
-deployment name. This is a combination of the release name hyphenated with the chart name, or a user specified deployment reference name.
-Similar to $fullName, we override it and append to it as we loop through $rolloutZones.
-*/}}
-{{- $prevDeployment := default (default .Chart.Name .Values.nameOverride) (.Values.migrate.workloadRef.name) }}
-{{- $deploymentRefName := printf "%s-%s" (.Release.Name) ($prevDeployment) }}
 
 {{/* Verify that some required inputs are supplied */}}
 {{- if .Values.virtualService.enabled }}
@@ -54,7 +47,6 @@ In that case, we patch a few variables to be zone-specific.
 {{- if ne $rolloutZone "default" }}
 {{- $topologyKey               := required ".Values.rolloutZones requires that .Values.topologyKey is also set" $.Values.topologyKey }}
 {{- $fullName                  = printf "%s-%s" (include "nd-common.fullname" $) $rolloutZone }}
-{{- $deploymentRefName         = printf "%s-%s" $deploymentRefName $rolloutZone }}
 {{- $rolloutZoneLabel          = printf "%s: %s" $topologyKey $rolloutZone }}
 {{- $disableTopoSpreadFunction = true }}
 {{- else }}
@@ -92,40 +84,17 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- /* When migrating from a Deployment, the selector actually needs to match the original Deployment's labels. */}}
-      {{- if $.Values.migrate.inProgress }}
-      app.kubernetes.io/instance: {{ $.Release.Name }}
-      app.kubernetes.io/name: {{ $.Values.migrate.workloadRef.name }}
-      helm.sh/chart-name: simple-app
-      {{- else }}
       {{- include "nd-common.selectorLabels" $ | nindent 6 }}
       {{- with $rolloutZoneLabel }}
       {{ . }}
-      {{- end }}
       {{- end }}  
-  {{- if $.Values.migrate.inProgress }}
-  workloadRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{ $deploymentRefName }}
-    scaleDown: {{ $.Values.migrate.workloadRef.scaleDown }}
-  {{- end }}
   strategy:
     {{- if (eq $.Values.strategy "blueGreen") }}
     blueGreen:
       {{- $fullName = include "nd-common.fullname" $ }}
       {{- if or $.Values.virtualService.enabled $.Values.ingress.enabled }}
-      {{- /*
-      For users who are migrating from a Deployment to BlueGreen rollouts, we need to use the previous Deployment's service name as the activeService.
-      The service name is similar to $deploymentRefName, however, the rolloutZoneLabel is not included. The preview service should also not be included.
-      */}}
-      {{- if $.Values.migrate.inProgress }}
-      activeService: {{ printf "%s-%s" ($.Release.Name) ($prevDeployment) }}
-      previewService: null
-      {{- else }}
       activeService: {{ $fullName }}
       previewService: {{ $fullName }}-preview
-      {{- end }}
       {{- end }}
 
       {{- with $.Values.blueGreen.autoPromotionEnabled }}
@@ -170,25 +139,15 @@ spec:
     {{- else if (eq $.Values.strategy "canary") }}
     canary:
       {{- /*
-      During a migration, since we reference a previous Deployments service, we do not want to supply VirtualService values here,
-      otherwise we will run into selector misalignments.
-      */}}
-      {{- if not $.Values.migrate.inProgress }}  # TODO: remove this if we find that this field is not even needed within the migration doc logic here: https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor
-      {{- if or $.Values.virtualService.enabled $.Values.ingress.enabled }}
-      {{- /*
       Since multiple Rollout objects cannot referece the same stableService or canaryService, make sure we don't
       specify those fields for same-zone Rollout objects.
 
       In those cases, use approaches like Istio subset routing (based on pod labels) to direct traffic to appropriate
       version
       */}}
-      {{- if eq $rolloutZone "default" }}
+      {{- if and (eq $rolloutZone "default") (or $.Values.virtualService.enabled $.Values.ingress.enabled) }}
       stableService: {{ include "nd-common.serviceName" $ }}
       canaryService: {{ include "nd-common.serviceName" $ }}-canary
-      {{ end }}
-      {{ end }}
-
-      {{- if and (eq $rolloutZone "default") (or $.Values.virtualService.enabled $.Values.ingress.enabled) }}
       trafficRouting:
         {{- if $.Values.virtualService.enabled }}
         istio:
@@ -262,14 +221,6 @@ spec:
     {{- else }}
     {{- fail (printf "Must set $.Values.strategy to 'blueGreen' or 'canary', '%s' is invalid" $.Values.strategy) }}
     {{- end }}
-  {{- /*
-  When you are migrating from a regular Deployment, Argo Rollouts will use the previous Deployment's pods as the template.
-  Thus, we need to leave the template field as an empty object for Argo Rollouts to flesh out. Otherwise, you get the error:
-  The Rollout is invalid: spec.template: Internal error: template must be empty for workload reference rollout
-  */}}
-  {{- if $.Values.migrate.inProgress }}
-  template: {}
-  {{- else }}
   template:
     metadata:
       annotations:
@@ -497,6 +448,5 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-  {{- end }}
 ---
 {{- end }}

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -87,7 +87,7 @@ spec:
       {{- include "nd-common.selectorLabels" $ | nindent 6 }}
       {{- with $rolloutZoneLabel }}
       {{ . }}
-      {{- end }}  
+      {{- end }}
   strategy:
     {{- if (eq $.Values.strategy "blueGreen") }}
     blueGreen:

--- a/charts/rollout-app/templates/rollout.yaml
+++ b/charts/rollout-app/templates/rollout.yaml
@@ -167,8 +167,6 @@ spec:
         {{- end }}
       {{- end }}
 
-      {{- end }}
-
       {{- with $.Values.canary.canaryMetadata }}
       canaryMetadata:
         {{- toYaml . | nindent 8 }}

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -9,41 +9,6 @@ replicaCount: 2
 # just really noisy. Set our default to 3. https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
 revisionHistoryLimit: 3
 
-# -- Migrating from `simple-app` (kind: Deployment) to `rollout-app` (kind: Rollout)?
-# This section handles the migrations from Nextdoor's regular Deployment kind (found in `simple-app`)
-# to the Rollout kind (found in `rollout-app`). Not necessary for new services.
-# !IMPORTANT!: You should only toggle the `inProgress` field to `true` if your Rollout pods are already up and accepting traffic, aka
-# their status is `Ready`. Not doing so will result in downtime for your application.
-# If you wish to migrate (`inProgress` field is `true`), the Pods you deploy will use the template found currently within the
-# Deployment's template. Upon migration completion (toggling `inProgress` to `false`), the Deployment will be deleted,
-# and the Pod's will have labels that match a rollout deployment. For more information on steps to migrate, check out the documentation here:
-# https://nextdoor.atlassian.net/wiki/spaces/ENG/pages/4013359115/Canary+Deployments+At+Nextdoor
-migrate:
-  # -- (`bool`) If true, your service will start to migrate from a Deployment to a Rollout.
-  # Ensure that the other fields under migrate are also set.
-  # !IMPORTANT!: You should only toggle the `inProgress` field to `true` if your Rollout pods are already up and accepting traffic, aka
-  # their status is `Ready`. Not doing so will result in downtime for your application.
-  inProgress: false
-  # -- (`map`) The workloadRef field helps ensure that during the migration,
-  # traffic is still always being handled by *something*. The rollout CRD will divert traffic to the original Deployment,
-  # and depending on the scaleDownStrategy field, progressively starts scalng down traffic to the
-  # original Deployment as traffic towards the canary deployment ramps up.
-  # For more information on how this is used during migrations, see:
-  # https://argo-rollouts.readthedocs.io/en/stable/migrating/#reference-deployment-from-rollout
-  workloadRef:
-    # -- (`string`) The of the chart that you are migrating from. If you are migrating from `simple-app`,
-    # the value can be found within your Chart.yaml file as in the dependencies list.
-    # Typically just `simple-app`, but it can also be the value of alias if that is set.
-    # NOTE: If you are migrating from a deployment that utilizes multiple availability zones, ensure
-    # that you apply the values found within `deploymentZones` to `rolloutZones` as well as the topology values.
-    name: null
-    # -- (`string`) specifies how the Deployment should be scaled down. There are three options available:
-    # - `never`: the Deployment is not scaled down
-    # - `onsuccess`: the Deployment is scaled down after the Rollout becomes healthy
-    # - `progressively`: as the Rollout is scaled up the Deployment is scaled down, and the default choice for migrations
-    # For more information on the strategy, please visit:
-    # https://argo-rollouts.readthedocs.io/en/stable/migrating/#reference-deployment-from-rollout
-    scaleDown: progressively
 
 # -- Set up a PodDisruptionBudget for the Deployment. See
 # https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more


### PR DESCRIPTION
## Summary
Remove the migrate functionality that was originally added as an experiment for seamless migration from `simple-app` to `rollout-app`. After evaluation, we've determined that the safer approach for migration is to use parallel apps and then switch traffic, rather than the in-place migration approach.

## Changes
- ✅ Remove `migrate` configuration from `values.yaml`
- ✅ Remove all migration-related logic from `rollout.yaml` template  
- ✅ Update documentation to remove migration references
- ✅ Combine duplicate conditionals in canary strategy for cleaner code

## Background
The `migrate` key was originally added to experiment with in-place migration capabilities between simple-app (Deployment) and rollout-app (Rollout). However, we're removing this unused code because the safer approach for migration is to have parallel apps running and then perform traffic switching once the new app is fully scaled out.

## Test plan
- [x] Verify chart renders correctly without migrate references
- [x] Confirm no breaking changes for existing rollout-app users
- [x] Test canary and blue-green strategies work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)