### PR TITLE
fix: migrate to bitnamilegacy images for deprecated packages

### DIFF
--- a/charts/local-kafka/Chart.yaml
+++ b/charts/local-kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: local-kafka
 description: Local Development spinup of Strimzi-managed Kafka
 type: application
-version: 0.43.0
+version: 0.43.1
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/local-kafka/README.md
+++ b/charts/local-kafka/README.md
@@ -2,7 +2,7 @@
 
 Local Development spinup of Strimzi-managed Kafka
 
-![Version: 0.43.0](https://img.shields.io/badge/Version-0.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.43.1](https://img.shields.io/badge/Version-0.43.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [strimzi_op]: https://github.com/strimzi/strimzi-kafka-operator
 

--- a/charts/local-kafka/templates/tests/list_topics.yaml
+++ b/charts/local-kafka/templates/tests/list_topics.yaml
@@ -11,7 +11,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: list-topics-test
-      image: bitnami/kafka:3.6
+      image: bitnamilegacy/kafka:3.6
       command: [sh, -x, /scripts/run_test.sh]
       volumeMounts:
         - mountPath: /scripts

--- a/charts/simple-workflow/Chart.yaml
+++ b/charts/simple-workflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-workflow
 description: Default Argo Workflow Helm Chart
 type: application
-version: 0.0.15
+version: 0.0.16
 appVersion: latest
 maintainers:
   - name: masterginger

--- a/charts/simple-workflow/README.md
+++ b/charts/simple-workflow/README.md
@@ -2,7 +2,7 @@
 
 Default Argo Workflow Helm Chart
 
-![Version: 0.0.15](https://img.shields.io/badge/Version-0.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.16](https://img.shields.io/badge/Version-0.0.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Values
 

--- a/charts/simple-workflow/templates/workflow-janitor.yaml
+++ b/charts/simple-workflow/templates/workflow-janitor.yaml
@@ -22,7 +22,7 @@ spec:
       activeDeadlineSeconds: 120
       containers:
         - name: workflow-janitor
-          image: bitnami/kubectl:1.28.4
+          image: bitnamilegacy/kubectl:1.28.4
           command: ["/bin/bash"]
           args:
             - -c


### PR DESCRIPTION
## Summary
- Updated `local-kafka` chart (v0.43.1) to use `bitnamilegacy/kafka:3.6` instead of `bitnami/kafka:3.6`
- Updated `simple-workflow` chart (v0.0.16) to use `bitnamilegacy/kubectl:1.28.4` instead of `bitnami/kubectl:1.28.4`

These images have been deprecated from the main bitnami registry and are now only available in the bitnamilegacy registry.

## Test plan
- [ ] Verify local-kafka test pod uses correct image
- [ ] Verify simple-workflow janitor uses correct image
- [ ] Confirm charts install successfully in test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)