### PR TITLE
chore(charts): updating prefer close to prefer same zone in docs

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.17.7
+version: 0.17.8
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.17.7](https://img.shields.io/badge/Version-0.17.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.17.8](https://img.shields.io/badge/Version-0.17.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -17,7 +17,7 @@ ServiceAccounts, Services, etc.
 
 **NEW: Goldilocks support, k8s-native sidecars support, allow setting Service TrafficDistribution**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
@@ -364,7 +364,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
-| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | `string` | `"ClusterIP"` | `ClusterIP`, `NodePort`, `LoadBalancer` or `ExternalName`. |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/daemonset-app/README.md.gotmpl
+++ b/charts/daemonset-app/README.md.gotmpl
@@ -16,7 +16,7 @@ ServiceAccounts, Services, etc.
 
 **NEW: Goldilocks support, k8s-native sidecars support, allow setting Service TrafficDistribution**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -225,7 +225,7 @@ service:
   # In absense, default routing strategy for kube-proxy is to distribute traffic
   # to any endpoint in the cluster
   #
-  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at
   # discretion of user as it's a simple heuristic: if there are endpoints in the
   # zone, they will receive all traffic for that zone, if there are no endpoints
   # in a zone, the traffic will be distributed to other zones

--- a/charts/nd-common/templates/_service.tpl
+++ b/charts/nd-common/templates/_service.tpl
@@ -43,7 +43,7 @@ spec:
 
   For now, to ensure no side-effects, we only will set the field if the user explicitly sets it.
 
-  In the future, we may default set to 'PreferClose' (for kube-proxy, this means prioritizing sending
+  In the future, we may default set to 'PreferSameZone' (for kube-proxy, this means prioritizing sending
   traffic to endpoints within the same zone as the client)
 
   In its absense, the default routing strategy for kube-proxy is to distribute traffic to any endpoint

--- a/charts/rollout-app/Chart.yaml
+++ b/charts/rollout-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rollout-app
 description: Argo Rollout-based Application Helm Chart
 type: application
-version: 1.6.6
+version: 1.6.7
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/rollout-app/README.md
+++ b/charts/rollout-app/README.md
@@ -2,7 +2,7 @@
 
 Argo Rollout-based Application Helm Chart
 
-![Version: 1.6.6](https://img.shields.io/badge/Version-1.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.7](https://img.shields.io/badge/Version-1.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [analysistemplate]: https://argoproj.github.io/argo-rollouts/features/analysis/?query=AnalysisTemplate#background-analysis
 [argo_rollouts]: https://argoproj.github.io/argo-rollouts/
@@ -22,7 +22,7 @@ how these work, and the various custom resource definitions.
 
 **NEW: Allow setting Service TrafficDistribution, support subset-level traffic splitting, single PDB spanning all AZs**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 - Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
@@ -381,7 +381,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
-| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/rollout-app/README.md.gotmpl
+++ b/charts/rollout-app/README.md.gotmpl
@@ -21,7 +21,7 @@ how these work, and the various custom resource definitions.
 
 **NEW: Allow setting Service TrafficDistribution, support subset-level traffic splitting, single PDB spanning all AZs**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 - Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).

--- a/charts/rollout-app/values.yaml
+++ b/charts/rollout-app/values.yaml
@@ -430,7 +430,7 @@ service:
   # In absense, default routing strategy for kube-proxy is to distribute traffic
   # to any endpoint in the cluster
   #
-  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at
   # discretion of user as it's a simple heuristic: if there are endpoints in the
   # zone, they will receive all traffic for that zone, if there are no endpoints
   # in a zone, the traffic will be distributed to other zones

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: simple-app
 description: Default Microservice Helm Chart
 type: application
-version: 1.13.13
+version: 1.13.14
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/simple-app/README.md
+++ b/charts/simple-app/README.md
@@ -2,7 +2,7 @@
 
 Default Microservice Helm Chart
 
-![Version: 1.13.13](https://img.shields.io/badge/Version-1.13.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.13.14](https://img.shields.io/badge/Version-1.13.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -17,7 +17,7 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 **NEW: Support label overrides, istio-proxy to run as k8s-native sidecars, setting Service TrafficDistribution, and single PDB spanning all AZs**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 - Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
@@ -507,7 +507,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
-| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/simple-app/README.md.gotmpl
+++ b/charts/simple-app/README.md.gotmpl
@@ -16,7 +16,7 @@ defaults for you like the Kubernetes [Horizontal Pod Autoscaler][hpa].
 
 **NEW: Support label overrides, istio-proxy to run as k8s-native sidecars, setting Service TrafficDistribution, and single PDB spanning all AZs**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 - Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -263,7 +263,7 @@ service:
   # In absense, default routing strategy for kube-proxy is to distribute traffic
   # to any endpoint in the cluster
   #
-  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at
   # discretion of user as it's a simple heuristic: if there are endpoints in the
   # zone, they will receive all traffic for that zone, if there are no endpoints
   # in a zone, the traffic will be distributed to other zones

--- a/charts/stateful-app/Chart.yaml
+++ b/charts/stateful-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stateful-app
 description: Default StatefulSet Helm Chart
 type: application
-version: 1.5.8
+version: 1.5.9
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/stateful-app/README.md
+++ b/charts/stateful-app/README.md
@@ -2,7 +2,7 @@
 
 Default StatefulSet Helm Chart
 
-![Version: 1.5.8](https://img.shields.io/badge/Version-1.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.5.9](https://img.shields.io/badge/Version-1.5.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -15,9 +15,9 @@ ServiceAccounts, Services, etc.
 
 ### 1.4.x -> 1.5.x
 
-**NEW: Allow simpler common label overrides and Service to set PreferClose trafficDistribution**
+**NEW: Allow simpler common label overrides and Service to set PreferSameZone trafficDistribution**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).
@@ -425,7 +425,7 @@ secretsEngine: sealed
 | secretsEngine | String | `"plaintext"` | Secrets Engine determines the type of Secret Resource that will be created (`KMSSecret`, `SealedSecret`, `Secret`). kms || sealed || plaintext are possible values. |
 | securityContext | object | `{}` |  |
 | service.name | `string` | `nil` | Optional override for the Service name. Can be used to create a simpler more friendly service name that is not specific to the application name. |
-| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferClose', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
+| service.trafficDistribution | `string` | `nil` | Allows you to set preferences for how traffic should be routed to Service endpoints.  In absense, default routing strategy for kube-proxy is to distribute traffic to any endpoint in the cluster  We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at discretion of user as it's a simple heuristic: if there are endpoints in the zone, they will receive all traffic for that zone, if there are no endpoints in a zone, the traffic will be distributed to other zones |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/stateful-app/README.md.gotmpl
+++ b/charts/stateful-app/README.md.gotmpl
@@ -14,9 +14,9 @@ ServiceAccounts, Services, etc.
 
 ### 1.4.x -> 1.5.x
 
-**NEW: Allow simpler common label overrides and Service to set PreferClose trafficDistribution**
+**NEW: Allow simpler common label overrides and Service to set PreferSameZone trafficDistribution**
 
-`service.trafficDistribution`, if set to `PreferClose` will have preference to route
+`service.trafficDistribution`, if set to `PreferSameZone` will have preference to route
 traffic to endpoints in the [same zone](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) as client.
 
 Its heuristic is simple: if an endpoint exists in the same zone as the client, route request to that endpoint. This has the downside of possibly overwhelming that endpoint. In that case, you can use the more nuanced `service.kubernetes.io/topology-mode: Auto` annotation on your `Service` which has some [fallback behavior](https://v1-31.docs.kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing).

--- a/charts/stateful-app/values.yaml
+++ b/charts/stateful-app/values.yaml
@@ -264,7 +264,7 @@ service:
   # In absense, default routing strategy for kube-proxy is to distribute traffic
   # to any endpoint in the cluster
   #
-  # We may, one day, wish to set to 'PreferClose', but for now we'll leave it at
+  # We may, one day, wish to set to 'PreferSameZone', but for now we'll leave it at
   # discretion of user as it's a simple heuristic: if there are endpoints in the
   # zone, they will receive all traffic for that zone, if there are no endpoints
   # in a zone, the traffic will be distributed to other zones


### PR DESCRIPTION
Ref: https://github.com/Nextdoor/cloudeng/issues/234

This PR updates the PreferClose comments to PreferSameZone to ensure that future changes follow the updated guidance for EKS v1.34+