### PR TITLE
feat(daemonset-app): add automountServiceAccountToken support

### DIFF
--- a/charts/daemonset-app/Chart.yaml
+++ b/charts/daemonset-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: daemonset-app
 description: Default DaemonSet Helm Chart
 type: application
-version: 0.17.10
+version: 0.17.11
 appVersion: latest
 maintainers:
   - name: diranged

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -282,8 +282,8 @@ secretsEngine: sealed
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| automountServiceAccountToken | `bool` | `true` | Whether to automount the Kubernetes API credentials into the pod. Set to `false` if your application does not need access to the Kubernetes API. |
 | args | list | `[]` | The arguments passed to the command. If unspecified the container defaults are used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
+| automountServiceAccountToken | `bool` | `true` | Whether to automount the Kubernetes API credentials into the pod. Set to `false` if your application does not need access to the Kubernetes API. |
 | command | list | `[]` | The command run by the container. This overrides `ENTRYPOINT`. If not specified, the container's default entrypoint is used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
 | containerName | string | `""` |  |
 | datadog.enabled | `bool` | `true` | Whether or not the various datadog labels and options should be included or not. |

--- a/charts/daemonset-app/README.md
+++ b/charts/daemonset-app/README.md
@@ -2,7 +2,7 @@
 
 Default DaemonSet Helm Chart
 
-![Version: 0.17.10](https://img.shields.io/badge/Version-0.17.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.17.11](https://img.shields.io/badge/Version-0.17.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 [statefulsets]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -282,6 +282,7 @@ secretsEngine: sealed
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| automountServiceAccountToken | `bool` | `true` | Whether to automount the Kubernetes API credentials into the pod. Set to `false` if your application does not need access to the Kubernetes API. |
 | args | list | `[]` | The arguments passed to the command. If unspecified the container defaults are used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
 | command | list | `[]` | The command run by the container. This overrides `ENTRYPOINT`. If not specified, the container's default entrypoint is used. The exact rules of how commadn and args are interpreted can be # found at: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/ |
 | containerName | string | `""` |  |

--- a/charts/daemonset-app/templates/daemonset.yaml
+++ b/charts/daemonset-app/templates/daemonset.yaml
@@ -57,6 +57,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "nd-common.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ tpl (toString . ) $ }}
       {{- end }}

--- a/charts/daemonset-app/values.yaml
+++ b/charts/daemonset-app/values.yaml
@@ -136,6 +136,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- (`bool`) Whether to automount the Kubernetes API credentials into the pod.
+# Set to `false` if your application does not need access to the Kubernetes API.
+automountServiceAccountToken: true
+
 # -- https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
 terminationGracePeriodSeconds: null
 


### PR DESCRIPTION
## Summary
- Adds a new `automountServiceAccountToken` value to the `daemonset-app` chart (defaults to `true` for backwards compatibility)
- Renders the field in the DaemonSet pod spec alongside `serviceAccountName`
- Patch version bump: 0.17.10 -> 0.17.11

## Motivation
On fresh Karpenter-provisioned nodes, kubelet's exponential backoff on volume mount retries adds 20-40s of artificial delay to every DaemonSet pod that references a ConfigMap or Secret — including the auto-injected `kube-api-access` projected volume. Workloads that don't need Kubernetes API access can opt out of this volume by setting `automountServiceAccountToken: false`, eliminating one source of cold-start delay and improving node initialization time.

Refs: Nextdoor/cloudeng#336

## Test plan
- [ ] Verify `helm template` renders `automountServiceAccountToken: true` by default
- [ ] Verify setting `automountServiceAccountToken: false` renders correctly
- [ ] CI chart linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)