### PR TITLE
prometheus-alerts: pre-filled Loki logs link on Job alerts

### DIFF
--- a/charts/prometheus-alerts/Chart.yaml
+++ b/charts/prometheus-alerts/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: prometheus-alerts
 description: Helm Chart that provisions a series of common Prometheus Alerts
 type: application
-version: 1.8.8
+version: 1.9.0
 appVersion: 0.0.1
 maintainers:
   - name: diranged
     email: matt@nextdoor.com
 dependencies:
   - name: nd-common
-    version: 0.5.5
+    version: 0.5.6
     repository: file://../nd-common

--- a/charts/prometheus-alerts/README.md
+++ b/charts/prometheus-alerts/README.md
@@ -2,7 +2,7 @@
 
 Helm Chart that provisions a series of common Prometheus Alerts
 
-![Version: 1.8.8](https://img.shields.io/badge/Version-1.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 [deployments]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [hpa]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
@@ -87,7 +87,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../nd-common | nd-common | 0.5.5 |
+| file://../nd-common | nd-common | 0.5.6 |
 
 ## Values
 
@@ -150,6 +150,7 @@ This behavior can be tuned via the `defaults.podNameSelector`,
 | defaults.additionalRuleLabels | `map` | `{}` | Additional custom labels attached to every PrometheusRule |
 | defaults.daemonsetNameSelector | `string` | `".*"` | Pattern used to scope down the DaemonSet alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the DaemonSets in the namespace. This string is run through the `tpl` function. |
 | defaults.deploymentNameSelector | `string` | `".*"` | Pattern used to scope down the Deployment alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the Deployments in the namespace. This string is run through the `tpl` function. |
+| defaults.grafanaUrl | `string` | `"https://grafana.corp.nextdoor.com"` | Base URL (no trailing slash) of the Grafana used for the pre-filled Loki `logs_url` deep-link on the Job alerts (`KubeJobFailed`, `KubeJobCompletion`). Opens Explore scoped to the Job's `cluster`, `k8s_namespace_name`, and `k8s_job_name`. The central Grafana's Loki holds every cluster's logs, so one host serves all environments. Empty disables it. |
 | defaults.hpaNameSelector | `string` | `".*"` | Pattern used to scope down the HorizontalPodAutoscaler alerts to pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all the HorizontalPodAutoscalers in the namespace. This string is run through the `tpl` function. |
 | defaults.jobNameSelector | `string` | `".*"` | Pattern used to scope down the alerts to only Jobs that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all Jobs in the namespace. This string is run through the `tpl` function. |
 | defaults.podNameSelector | `string` | `".*"` | Pattern used to scope down the alerts to only Pods that are part of this general application. Set to `None` if you want to disable this selector and apply the rules to all Pods in the namespace. This string is run through the `tpl` function. |

--- a/charts/prometheus-alerts/runbook.md
+++ b/charts/prometheus-alerts/runbook.md
@@ -124,7 +124,10 @@ NAME                                      COMPLETIONS   DURATION   AGE
 foobar-weekly-28571172                    0/1           3d2h       3d2h
 foobar-incremental-daily-28575492         0/1           139m       139m
 ```
-2. Jobs in kubernetes cluster launch pods to run. Check your favorite logging tool 
-(e.g., DataDog) to look for pods that begin with name of your failing jobs
-(e.g. "foobar-incremental-daily" for this case) in the time period for any failure clues.
+2. Jobs in kubernetes cluster launch pods to run. Check the logs of the pods that
+begin with the name of your failing job (e.g. "foobar-incremental-daily" for this
+case) in the time period for any failure clues. The alert includes a pre-filled
+`logs_url` annotation that deep-links straight to those pod logs in Grafana Loki
+(Explore), so you can jump there directly from PagerDuty. You may also check your
+favorite logging tool (e.g., DataDog).
 3. Check the configuration of your job in the chart files of your repo.

--- a/charts/prometheus-alerts/templates/_helpers.tpl
+++ b/charts/prometheus-alerts/templates/_helpers.tpl
@@ -57,3 +57,13 @@ job="kube-state-metrics", daemonset=~"{{ tpl .Values.defaults.daemonsetNameSelec
 job="kube-state-metrics", daemonset!="", {{ include "prometheus-alerts.namespaceSelector" $ }}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+Grafana Explore (Loki) deep-link to the logs of the Pods owned by a Job.
+Call with the root context ($) from a `with .<JobAlert>` block so the
+Prometheus $labels.* actions render at alert time. Loki indexes Job logs by
+the k8s_job_name stream label, scoped to cluster + k8s_namespace_name.
+*/}}
+{{- define "prometheus-alerts.jobLogsUrl" -}}
+{{ .Values.defaults.grafanaUrl }}/explore?schemaVersion=1&orgId=1&panes=%7B%22logs%22%3A%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bcluster%3D%5C%22{{`{{`}} $labels.cluster {{`}}`}}%5C%22%2C%20k8s_namespace_name%3D%5C%22{{`{{`}} $labels.namespace {{`}}`}}%5C%22%2C%20k8s_job_name%3D%5C%22{{`{{`}} $labels.job_name {{`}}`}}%5C%22%7D%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22loki%22%7D%2C%22editorMode%22%3A%22code%22%2C%22direction%22%3A%22backward%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-6h%22%2C%22to%22%3A%22now%22%7D%7D%7D
+{{- end -}}

--- a/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
+++ b/charts/prometheus-alerts/templates/containers-prometheusrule.yaml
@@ -586,6 +586,9 @@ spec:
       annotations:
         summary: Job did not complete in time
         runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubejobcompletion
+        {{- if $.Values.defaults.grafanaUrl }}
+        logs_url: {{ include "prometheus-alerts.jobLogsUrl" $ }}
+        {{- end }}
         description: >-
           Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name
           {{`}}`}} is taking more than 12 hours to complete.
@@ -610,6 +613,9 @@ spec:
       annotations:
         summary: Job failed to complete.
         runbook_url: {{ $.Values.defaults.runbookUrl }}#alert-name-kubejobfailed
+        {{- if $.Values.defaults.grafanaUrl }}
+        logs_url: {{ include "prometheus-alerts.jobLogsUrl" $ }}
+        {{- end }}
         description: >-
           Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name
           {{`}}`}} failed to complete. Removing failed job after investigation

--- a/charts/prometheus-alerts/values.yaml
+++ b/charts/prometheus-alerts/values.yaml
@@ -20,6 +20,13 @@ defaults:
   # -- (`string`) The prefix URL to the runbook_urls that will be applied to each PrometheusRule
   runbookUrl: https://github.com/Nextdoor/k8s-charts/blob/main/charts/prometheus-alerts/runbook.md
 
+  # -- (`string`) Base URL (no trailing slash) of the Grafana used for the
+  # pre-filled Loki `logs_url` deep-link on the Job alerts (`KubeJobFailed`,
+  # `KubeJobCompletion`). Opens Explore scoped to the Job's `cluster`,
+  # `k8s_namespace_name`, and `k8s_job_name`. The central Grafana's Loki holds
+  # every cluster's logs, so one host serves all environments. Empty disables it.
+  grafanaUrl: https://grafana.corp.nextdoor.com
+
   # -- (`map`) Additional custom labels attached to every PrometheusRule
   additionalRuleLabels: {}
 


### PR DESCRIPTION
## What

Adds a `logs_url` annotation to the **KubeJobFailed** and **KubeJobCompletion** alerts in the `prometheus-alerts` chart. The annotation deep-links to **Grafana Explore (Loki)**, pre-filtered to the offending Job's logs:

```
{cluster="<cluster>", k8s_namespace_name="<namespace>", k8s_job_name="<job_name>"}
```

Since Alertmanager forwards alert annotations into the PagerDuty incident, an on-call engineer can now jump straight from the PagerDuty alert to the relevant pod logs instead of hand-building a Loki query.

## Why

[MONPLAT-241](https://linear.app/nextdoor/issue/MONPLAT-241/add-pre-filled-logs-link-to-pagerduty-kube-job-alerts). A `monolith/db-migration` `KubeJobFailed` alert paged on-call, and the ask was to make it directly investigable from PagerDuty by linking to logs. Follows the existing `logs_url` precedent in the `kyverno` and `cert-manager` PrometheusRules.

## Changes

* `templates/_helpers.tpl` — new `prometheus-alerts.jobLogsUrl` helper that builds the URL-encoded Explore link, emitting the Prometheus `$labels.cluster` / `$labels.namespace` / `$labels.job_name` actions verbatim so they render at alert time.
* `templates/containers-prometheusrule.yaml` — add `logs_url` to the two Job alerts (guarded by `defaults.grafanaUrl`).
* `values.yaml` — new configurable `defaults.grafanaUrl` (default `https://grafana.corp.nextdoor.com`). Set to `""` to omit the annotation.
* `Chart.yaml` — version `1.8.8` -> `1.9.0`.
* `README.md` — regenerated via `helm-docs`.
* `runbook.md` — note the new pre-filled link in the `KubeJobFailed` section.

## Loki labels (verified live)

Validated against the `grafana.corp.nextdoor.com` Loki datasource: Job logs are indexed under the `k8s_job_name` stream label (there is **no** `k8s_pod_name` label), alongside `cluster` and `k8s_namespace_name`. The alert's `cluster` label values (`staging-us1`, `us1`, …) match Loki's `cluster` values exactly, so the link is scoped to the right cluster — important because `monolith/db-migration` exists in several clusters.

## Example rendered link

For `cluster=staging-us1`, `namespace=monolith`, `job_name=db-migration` the annotation renders to:

[https://grafana.corp.nextdoor.com/explore?schemaVersion=1&orgId=1&panes=%7B%22logs%22%3A%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bcluster%3D%5C%22staging-us1%5C%22%2C%20k8s_namespace_name%3D%5C%22monolith%5C%22%2C%20k8s_job_name%3D%5C%22db-migration%5C%22%7D%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22loki%22%7D%2C%22editorMode%22%3A%22code%22%2C%22direction%22%3A%22backward%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-6h%22%2C%22to%22%3A%22now%22%7D%7D%7D](<https://grafana.corp.nextdoor.com/explore?schemaVersion=1&orgId=1&panes=%7B%22logs%22%3A%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bcluster%3D%5C%22staging-us1%5C%22%2C%20k8s_namespace_name%3D%5C%22monolith%5C%22%2C%20k8s_job_name%3D%5C%22db-migration%5C%22%7D%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22loki%22%7D%2C%22editorMode%22%3A%22code%22%2C%22direction%22%3A%22backward%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-6h%22%2C%22to%22%3A%22now%22%7D%7D%7D>)

## Testing

* `helm template` renders both alerts with the annotation; `$labels` placeholders are preserved for Prometheus to substitute.
* Parsed the rendered PrometheusRule as YAML and decoded the `panes` param — confirmed it produces the expected Loki query after substitution.
* Confirmed the corrected selector returns data in Loki (44 streams / 4673 entries for the staging-us1 db-migration job).
* `helm lint` passes; `helm-docs && git diff --exit-code` is clean.
* Verified `--set defaults.grafanaUrl=""` omits the annotation.

## Notes for reviewers

* Single source of truth — `simple-app` / `daemonset-app` / `stateful-app` and downstream app charts consume `prometheus-alerts` as a dependency, so they pick this up on their next dependency bump.
* Time window defaults to `now-6h` to allow for post-hoc investigation; easily widened in the Explore UI.
* Applied to both Job alerts since they share `$labels.job_name`. Happy to trim to `KubeJobFailed` only if preferred.

Generated by Ned for @rodrigo.